### PR TITLE
Add clarification that gzip compressed CSV files are supported

### DIFF
--- a/docs/data/csv.md
+++ b/docs/data/csv.md
@@ -6,7 +6,7 @@ CSV loading is a very common, and yet surprisingly tricky, task. While CSVs seem
 
 The DuckDB CSV reader can automatically infer which configuration flags to use by analyzing the CSV file. This will work correctly in most situations, and should be the first option attempted. In rare situations where the CSV reader cannot figure out the correct configuration it is possible to manually configure the CSV reader to correctly parse the CSV file.
 
-We use the following CSV file in our examples:
+We use the following CSV file in our examples (keep in mind that you can also use **compressed** CSV files in the following examples, e.g. a **gzipped** file such as `test.csv.gz` will work just fine):
 
 **test.csv**
 ```

--- a/docs/data/overview.md
+++ b/docs/data/overview.md
@@ -20,6 +20,12 @@ Data can be efficiently loaded from CSV files using the `read_csv_auto` function
 SELECT * FROM read_csv_auto('test.csv');
 ```
 
+You can also load data from **compressed** (e.g. compressed with [gzip](https://www.gzip.org/)) CSV files, for example:
+
+```sql
+SELECT * FROM read_csv_auto('test.csv.gz');
+```
+
 See [here](/docs/data/csv) for a detailed description of CSV loading.
 
 ### Parquet Loading


### PR DESCRIPTION
Add clarification that gzip compressed CSV files are supported. This is related to the following discussion: https://github.com/duckdb/duckdb/discussions/1645.