### PR TITLE
Restructure page on parquet files

### DIFF
--- a/docs/data/parquet.md
+++ b/docs/data/parquet.md
@@ -2,7 +2,11 @@
 layout: docu
 title: Parquet
 ---
-Parquet files are compressed columnar files that are efficient to load and process. They are typically produced from Spark, but can be produced in other manners as well. DuckDB includes an efficient Parquet reader in the form of the `parquet_scan` function.
+Parquet files are compressed columnar files that are efficient to load and process. They are typically produced from Spark, but can be produced in other manners as well. 
+
+### Single-File Reads
+
+DuckDB includes an efficient Parquet reader in the form of the `parquet_scan` function.
 
 ```sql
 SELECT * FROM parquet_scan('test.parquet');
@@ -16,7 +20,29 @@ SELECT * FROM 'test.parquet';
 
 Unlike CSV files, parquet files are structured and as such are unambiguous to read. No parameters need to be passed to this function. The `parquet_scan` function will figure out the column names and column types present in the file and emit them.
 
-### Querying Parquet Files
+### Multi-File Reads and Globs
+DuckDB can also read a series of Parquet files and treat them as if they were a single table. Note that this only works if the Parquet files have the same schema. You can specify which Parquet files you want to read using the glob syntax.
+
+|  Wildcard  |                        Description                        |
+|------------|-----------------------------------------------------------|
+| `*`        | matches any number of any characters (including none)     |
+| `?`        | matches any single character                              |
+| `[abc]`    | matches one character given in the bracket                |
+| `[a-z]`    | matches one character from the range given in the bracket |
+
+Here is an example that reads all the files that end with `.parquet` located in the `test` folder:
+
+```sql
+-- read all files that match the glob pattern
+SELECT * FROM parquet_scan('test/*.parquet');
+```
+
+### Partial Reading
+DuckDB supports projection pushdown into the Parquet file itself. That is to say, when querying a Parquet file, only the columns required for the query are read. This allows you to read only the part of the Parquet file that you are interested in. This will be done automatically by the system.
+
+DuckDB also supports filter pushdown into the Parquet reader. When you apply a filter to a column that is scanned from a Parquet file, the filter will be pushed down into the scan, and can even be used to skip parts of the file using the built-in zonemaps. Note that this will depend on whether or not your Parquet file contains zonemaps.
+
+### Inserts and Views
 You can also insert the data into a table or create a table from the parquet file directly. This will load the data from the parquet file and insert it into the database.
 
 ```sql
@@ -35,27 +61,6 @@ CREATE VIEW people AS SELECT * FROM parquet_scan('test.parquet');
 SELECT * FROM people;
 ```
 
-### Partial Reading
-DuckDB supports projection pushdown into the Parquet file itself. That is to say, when querying a Parquet file, only the columns required for the query are read. This allows you to read only the part of the Parquet file that you are interested in. This will be done automatically by the system.
-
-DuckDB also supports filter pushdown into the Parquet reader. When you apply a filter to a column that is scanned from a Parquet file, the filter will be pushed down into the scan, and can even be used to skip parts of the file using the built-in zonemaps. Note that this will depend on whether or not your Parquet file contains zonemaps.
-
-### Multi-File Reads and Globs
-DuckDB can also read a series of Parquet files and treat them as if they were a single table. Note that this only works if the Parquet files have the same schema. You can specify which Parquet files you want to read using the glob syntax.
-
-|  Wildcard  |                        Description                        |
-|------------|-----------------------------------------------------------|
-| `*`        | matches any number of any characters (including none)     |
-| `?`        | matches any single character                              |
-| `[abc]`    | matches one character given in the bracket                |
-| `[a-z]`    | matches one character from the range given in the bracket |
-
-Here is an example that reads all the files that end with `.parquet` located in the `test` folder:
-
-```sql
--- read all files that match the glob pattern
-SELECT * FROM parquet_scan('test/*.parquet');
-```
 
 ### Writing to Parquet Files
 DuckDB also has support for writing to Parquet files using the `COPY` statement syntax. You can specify which compression format should be used using the `CODEC` parameter (options: `UNCOMPRESSED`, `SNAPPY` (default), `ZSTD`, `GZIP`).


### PR DESCRIPTION
As per https://github.com/duckdb/duckdb/pull/936#issuecomment-841608805. I figured that multi-file reading is actually documented, but hard to find for me (because after reading single files, it goes on with non-reading topics). 

* `Reading` is now named `Single-File Reads` instead of no title (as a hint that there is multi-file reading to come further down the page), 
* `Querying Parquet Files` was renamed to `Inserts and Views`.
* Re-ordered the paragraphs such that all content regarding reading shows up first, then view and inserts, then all writes. 

I admit this re-shuffling is opinionated to some degree.