### PR TITLE
Document aliases of aggregate functions

### DIFF
--- a/docs/sql/aggregates.md
+++ b/docs/sql/aggregates.md
@@ -13,10 +13,10 @@ When the `DISTINCT` clause is provided, only distinct values are considered in t
 ## General Aggregate Functions
 The table below shows the available general aggregate functions.
 
-| Function | Description | Example | Alias |
+| Function | Description | Example | Alias(es) |
 |:---|:---|:---|:---|
-| `arg_max(arg,val)` |Calculates the arg value for a maximum val value. | `arg_max(A,B)` | `max_by(A,b)` |
-| `arg_min(arg,val)` |Calculates the arg value for a minimum val value. | `arg_min(A,B)` | `min_by(A,B)` |
+| `arg_max(arg,val)` |Calculates the arg value for a maximum val value. | `arg_max(A,B)` | `argMax(A,B)`, `max_by(A,b)` |
+| `arg_min(arg,val)` |Calculates the arg value for a minimum val value. | `arg_min(A,B)` | `argMin(A,B)`, `min_by(A,B)` |
 | `avg(arg)` |Calculates the average value for all tuples in arg. | `avg(A)` | - |
 | `bit_and(arg)` |Returns the bitwise AND of all bits in a given expression . | `bit_and(A)` | - |
 | `bit_or(arg)` |Returns the bitwise OR of all bits in a given expression.  | `bit_or(A)` | - |

--- a/docs/sql/aggregates.md
+++ b/docs/sql/aggregates.md
@@ -15,8 +15,8 @@ The table below shows the available general aggregate functions.
 
 | Function | Description | Example | Alias |
 |:---|:---|:---|:---|
-| `argMax(arg,val)` |Calculates the arg value for a maximum val value. | `argMax(A,B)` | - |
-| `argMin(arg,val)` |Calculates the arg value for a minimum val value. | `argMin(A,B)` | - |
+| `arg_max(arg,val)` |Calculates the arg value for a maximum val value. | `arg_max(A,B)` | `max_by(A,b)` |
+| `arg_min(arg,val)` |Calculates the arg value for a minimum val value. | `arg_min(A,B)` | `min_by(A,B)` |
 | `avg(arg)` |Calculates the average value for all tuples in arg. | `avg(A)` | - |
 | `bit_and(arg)` |Returns the bitwise AND of all bits in a given expression . | `bit_and(A)` | - |
 | `bit_or(arg)` |Returns the bitwise OR of all bits in a given expression.  | `bit_or(A)` | - |


### PR DESCRIPTION
@pdet I was looking into the `max_by` function. I wanted to extend the documentation as well but I'm uncertain about whether `max_by` is supposed to be an exact alias for `arg_max` or it is a statistical function that should always return floating-point values? (Currently, it returns floating-point values.)

```sql
create table args (a integer, b integer);
insert into args values (1,1), (2,2), (8,8), (10,10);
select arg_min(a,b), arg_max(a,b) from args;
select min_by(a,b), max_by(a,b) from args;
```

```console
D create table args (a integer, b integer);
D insert into args values (1,1), (2,2), (8,8), (10,10);
D select arg_min(a,b), arg_max(a,b) from args;
┌───────────────┬───────────────┐
│ arg_min(a, b) │ arg_max(a, b) │
├───────────────┼───────────────┤
│ 1             │ 10            │
└───────────────┴───────────────┘
D select min_by(a,b), max_by(a,b) from args;
┌──────────────┬──────────────┐
│ min_by(a, b) │ max_by(a, b) │
├──────────────┼──────────────┤
│ 1.0          │ 10.0         │
└──────────────┴──────────────┘
```
