### PR TITLE
String concat and create_fts_index

### DIFF
--- a/docs/sql/full_text_search.md
+++ b/docs/sql/full_text_search.md
@@ -11,7 +11,7 @@ The extension adds two `PRAGMA` statements to DuckDB: one to create, and one to 
 ### PRAGMA create_fts_index
 ```
 create_fts_index(input_table, input_id, *input_values, stemmer='porter', stopwords='english',
-                 ignore='(\\.|[^a-z])+', strip_accents=1, lower=1, overwrite=0)
+                 ignore='(\\.|[^a-z])+', strip_accents=TRUE, lower=TRUE, overwrite=FALSE)
 ```
 `PRAGMA` that creates a FTS index for the specified table.
 
@@ -22,7 +22,7 @@ create_fts_index(input_table, input_id, *input_values, stemmer='porter', stopwor
 |`\*input_values`|`VARCHAR`|Column names of the text fields to be indexed (vararg) e.g. `'text_field_1'`, `'text_field_2'`, ..., `'text_field_N'`, or `'\*'` for all columns in input_table of type `VARCHAR`|
 |`stemmer`|`VARCHAR`|The type of stemmer to be used. One of `'arabic'`, `'basque'`, `'catalan'`, `'danish'`, `'dutch'`, `'english'`, `'finnish'`, `'french'`, `'german'`, `'greek'`, `'hindi'`, `'hungarian'`, `'indonesian'`, `'irish'`, `'italian'`, `'lithuanian'`, `'nepali'`, `'norwegian'`, `'porter'`, `'portuguese'`, `'romanian'`, `'russian'`, `'serbian'`, `'spanish'`, `'swedish'`, `'tamil'`, `'turkish'`, or `'none'` if no stemming is to be used. Defaults to `'porter'`|
 |`stopwords`|`VARCHAR`|Qualified name of table containing a single `VARCHAR` column containing the desired stopwords, or `'none'` if no stopwords are to be used. Defaults to `'english'` for a pre-defined list of 571 English stopwords|
-|`ignore`|`VARCHAR`|Regular expression of patterns to be ignored. Defaults to `'(\\|[^a-z])+'`, ignoring all escaped and non-alphabetic lowercase characters|
+|`ignore`|`VARCHAR`|Regular expression of patterns to be ignored. Defaults to `'(\\.|[^a-z])+'`, ignoring all escaped and non-alphabetic lowercase characters|
 |`strip_accents`|`BOOLEAN`|Whether to remove accents (e.g. convert `á` to `a`). Defaults to `TRUE`|
 |`lower`|`BOOLEAN`|Whether to convert all text to lowercase. Defaults to `TRUE`|
 |`overwrite`|`BOOLEAN`|Whether to overwrite an existing index on a table. Defaults to `FALSE`|

--- a/docs/sql/functions/char.md
+++ b/docs/sql/functions/char.md
@@ -8,7 +8,7 @@ This section describes functions and operators for examining and manipulating st
 
 | Function | Description | Example | Result |
 |:---|:---|:---|:---|
-| *`string`* `\|\|` *`string`* | String concatenation | `'Duck' \|\| 'DB'` | `DuckDB` |
+| *`string`* `||` *`string`* | String concatenation | `'Duck' || 'DB'` | `DuckDB` |
 | *`string`*`[`*`index`*`]` | Alias for `array_extract`. | `'DuckDB'[3]` | `'k'` |
 | *`string`*`[`*`begin`*`:`*`end`*`]` | Alias for `array_slice`. Missing arguments are interprete as `NULL`s. | `'DuckDB'[:4]` | `'Duck'` |
 | `array_extract(`*`list`*`, `*`index`*`)` | Extract a single character using a (0-based) index. | `array_extract('DuckDB, 1)` | `'u'` |


### PR DESCRIPTION
 @Mytherin Two changes:

1. string concat operators looked off as the escape chars were rendered in the HTML:

![image](https://user-images.githubusercontent.com/1402801/142213374-4b360a88-14d2-42ff-8375-32916989d249.png)

2. the defaults of create_fts_index were not in sync. (cc @lnkuiper)