### PR TITLE
Adding Elixir driver to docs

### DIFF
--- a/docs/why_duckdb.md
+++ b/docs/why_duckdb.md
@@ -80,6 +80,7 @@ Here are some projects that we know of that use DuckDB. If you would like your p
 * [PHP example to integrate DuckDB using PHP-FFI](https://github.com/thomasbley/php-duckdb-integration)
 * [DuckDB Foreign Data Wrapper for PostgreSQL](https://github.com/alitrack/duckdb_fdw)
 * [Demo: CRUD operations with Qt5 and DuckDB](https://github.com/chilarai/qt-duckdb)
+* [Elixir driver](https://github.com/mpope9/exduckdb) and [Ecto adapter](https://github.com/mpope9/ecto_duckdb/) for DuckDB
 
 ## Testimonials
 See our [DuckDB Testimonial Twitter Wall](twitter_wall)


### PR DESCRIPTION
I was interested in using DuckDB in a personal Elixir project, and there didn't seem to be much support for it. I adapted the existing SQLite3 driver and Ecto (Elixir's ORM) adapter for DuckDB. _Most_ of the test suite passes at the moment, planning on doing more cleanup.