### PR TITLE
Docs: parquet_scan lists, Nested Types improvements

### DIFF
--- a/docs/sql/data_types/nested.md
+++ b/docs/sql/data_types/nested.md
@@ -198,10 +198,16 @@ CREATE TABLE map_table (map_col MAP(INT,DOUBLE));
 `MAP`s use bracket notation for retrieving values. This is due to the variety of types that can be used as a `MAP`'s key. Selecting from a `MAP` also returns a `LIST` rather than an individual value.
 ```sql
 -- Use bracket notation to retrieve a list containing the value at a key's location. This returns [42]
+-- Note that the expression in bracket notation must match the type of the map's key
 SELECT map([100, 5], [42, 43])[100];
 -- To retrieve the underlying value, use list selection syntax to grab the 0th element.
 -- This returns 42
 SELECT map([100, 5], [42, 43])[100][0];
+-- If the element is not in the map, an empty list will be returned. Returns []
+-- Note that the expression in bracket notation must match the type of the map's key else an error is returned
+SELECT map([100, 5], [42, 43])[123];
+-- The element_at function can also be used to retrieve a map value. This returns [42]
+SELECT element_at(map([100, 5], [42, 43]),100);
 ```
 
 ## Nesting

--- a/docs/sql/data_types/nested.md
+++ b/docs/sql/data_types/nested.md
@@ -148,7 +148,7 @@ The `row` function can be used to automatically convert multiple columns to a si
 #### Row function example:
 ```sql
 SELECT 
-    row(my_column,another_column) as my_struct_column
+    row(my_column, another_column) as my_struct_column
 FROM t1;
 ```
 
@@ -158,12 +158,12 @@ FROM t1;
 | {'my_column': 1, 'another_column': a} |
 | {'my_column': 2, 'another_column': b} |
 
-The `row` function may also be used with arbitrary expressions as input rather than column names. In the case of an expression, a key will be automatically generated in the format of 'vN' where N is an incrementing number (Ex: v1, v2, etc.). This can be combined with column names as an input in the same call to the `row` function. This example uses the same input table as above.
+The `row` function may also be used with arbitrary expressions as input rather than column names. In the case of an expression, a key will be automatically generated in the format of 'vN' where N is a number that refers to its parameter location in the row function (Ex: v1, v2, etc.). This can be combined with column names as an input in the same call to the `row` function. This example uses the same input table as above.
 
 #### Row function example with a column name, a constant, and an expression as input:
 ```sql
 SELECT 
-    row(my_column,42,my_column + 1) as my_struct_column
+    row(my_column, 42, my_column + 1) as my_struct_column
 FROM t1;
 ```
 #### Example Output:

--- a/docs/sql/data_types/nested.md
+++ b/docs/sql/data_types/nested.md
@@ -8,7 +8,7 @@ This section describes functions and operators for examining and manipulating ne
 
 | Name | Description | Rules when used in a column | Build from values | Define in DDL/CREATE |
 |:---|:---|:---|:---|:---|
-| LIST | An ordered sequence of data values of the same type. | Each row must have the same data type within each LIST, but can have any number of elements. | [1, 2, 3] | VARCHAR[ ] |
+| LIST | An ordered sequence of data values of the same type. | Each row must have the same data type within each LIST, but can have any number of elements. | [1, 2, 3] | INT[ ] |
 | STRUCT | A dictionary of multiple named values, where each key is a string, but the value can be a different type for each key. | Each row must have the same keys. | {'i': 42, 'j': 'a'} | STRUCT<i: INT, j: VARCHAR> |
 | MAP | A dictionary of multiple named values, each key having the same type and each value having the same type. Keys and values can be any type and can be different types from one another. | Rows may have different keys. | map([1,2],['a','b']) | MAP<INT, VARCHAR> |
 
@@ -34,6 +34,8 @@ SELECT ['duck', 'goose', NULL, 'heron'];
 SELECT [['duck', 'goose', 'heron'], NULL, ['frog', 'toad'], []];
 -- Create a list with the list_value function
 SELECT list_value(1, 2, 3);
+-- Create a table with an integer list column and a varchar list column
+CREATE TABLE list_table (int_list INT[], varchar_list VARCHAR[]);
 ```
 ### Retrieving from Lists
 Retrieving one or more values from a list can be accomplished using brackets and slicing notation, or through [list functions](../functions/nested#list-functions) like `list_extract`. Multiple equivalent functions are provided as aliases for compatibility with systems that refer to lists as arrays. For example, the function `array_slice`.
@@ -189,6 +191,8 @@ select map([1, 5], [42.001, -32.1]);
 -- Keys and/or values can also be nested types.
 -- This returns {[a, b]=[1.1, 2.2], [c, d]=[3.3, 4.4]}
 select map([['a', 'b'], ['c', 'd']], [[1.1, 2.2], [3.3, 4.4]]);
+-- Create a table with a map column that has integer keys and double values
+CREATE TABLE map_table (map_col MAP(INT,DOUBLE));
 ```
 ### Retrieving from Maps
 `MAP`s use bracket notation for retrieving values. This is due to the variety of types that can be used as a `MAP`'s key. Selecting from a `MAP` also returns a `LIST` rather than an individual value.

--- a/docs/sql/data_types/nested.md
+++ b/docs/sql/data_types/nested.md
@@ -4,10 +4,13 @@ title: Nested Types
 selected: Documentation/Data Types/Nested
 expanded: Data Types
 ---
-| Name | Description |
-|:---|:---|
-| LIST | An ordered sequence of data values of the same type. |
-| STRUCT | A dictionary of multiple named values, each name having the same type. |
+This section describes functions and operators for examining and manipulating nested values. DuckDB supports three nested data types: lists, structs, and maps.
+
+| Name | Description | Rules when used in a column | Build from values | Define in DDL/CREATE |
+|:---|:---|:---|:---|:---|
+| LIST | An ordered sequence of data values of the same type. | Each row must have the same data type within each LIST, but can have any number of elements. | [1, 2, 3] | VARCHAR[ ] |
+| STRUCT | A dictionary of multiple named values, where each key is a string, but the value can be a different type for each key. | Each row must have the same keys. | {'i': 42, 'j': 'a'} | STRUCT<i: INT, j: VARCHAR> |
+| MAP | A dictionary of multiple named values, each key having the same type and each value having the same type. Keys and values can be any type and can be different types from one another. | Rows may have different keys. | map([1,2],['a','b']) | MAP<INT, VARCHAR> |
 
 
 ## Lists
@@ -15,12 +18,13 @@ expanded: Data Types
 A `LIST` column can have values with different lengths, but they must all have the same underlying type.
 `LIST`s are typically used to store arrays of numbers, but can contain any uniform data type,
 including other `LIST`s and `STRUCT`s.
-`LIST`s are similar to Postgres's `ARRAY` type.
+`LIST`s are similar to Postgres's `ARRAY` type. DuckDB uses the `LIST` terminology, but some [array functions](../functions/nested#list-functions) are provided for Postgres compatibility.
 
-Lists can be created using the [`LIST_VALUE(expr, ...)`](../functions/nested#listfunctions) function
-or the equivalent array notation `[expr, ...]` notation.
+Lists can be created using the [`LIST_VALUE(expr, ...)`](../functions/nested#list-functions) function
+or the equivalent bracket notation `[expr, ...]`.
 The expressions can be constants or arbitrary expressions.
 
+### Creating Lists
 ```sql
 -- List of integers
 SELECT [1, 2, 3];
@@ -28,27 +32,59 @@ SELECT [1, 2, 3];
 SELECT ['duck', 'goose', NULL, 'heron'];
 -- List of lists with NULL values
 SELECT [['duck', 'goose', 'heron'], NULL, ['frog', 'toad'], []];
+-- Create a list with the list_value function
+SELECT list_value(1, 2, 3);
 ```
-
+### Retrieving from Lists
+Retrieving one or more values from a list can be accomplished using brackets and slicing notation, or through [list functions](../functions/nested#list-functions) like `list_extract`. Multiple equivalent functions are provided as aliases for compatibility with systems that refer to lists as arrays. For example, the function `array_slice`.
+```sql
+-- Retrieve an element from a list using brackets. This returns 'c'
+-- Note that we wrap the list creation in parenthesis so that it happens first.
+-- This is only needed in our basic examples here, not when working with a list column
+-- For example, this can't be parsed: SELECT ['a','b','c'][1]
+SELECT (['a','b','c'])[2];
+-- Use a negative index to grab the nth element from the end of the list. This returns 'c'
+SELECT (['a','b','c'])[-1];
+-- Any expression that evaluates to an integer can be used to retrieve a list value
+-- This includes using a column to determine which index to retrieve
+-- This returns 'c'
+SELECT (['a','b','c'])[1 + 1];
+-- The list_extract function may also be used in place of brackets for selecting individual elements. 
+-- This returns c
+SELECT list_extract(['a','b','c'], 2);
+-- Retrieve multiple list values using a bracketed slice syntax. This returns ['b','c']
+SELECT (['a','b','c'])[1:3];
+-- Single sided slices are also supported. Here, grab the first 2 elements. This returns ['a','b']
+SELECT (['a','b','c'])[:2];
+-- Use a negative index to grab the last 2 elements. This returns ['b','c']
+SELECT (['a','b','c'])[-2:];
+-- The array_slice function is also supported. This returns ['b','c']
+SELECT array_slice(['a','b','c'],1,3);
+```
 ## Structs
 
 Conceptually, a `STRUCT` column contains an ordered list of other columns called "entries".
-The entries are referenced by name using strings.
-Each value in the `STRUCT` column must have the same entry names,
-and each entry must have the same type.
+The entries are referenced by name using strings. This document refers to those entry names as keys.
+Each row in the `STRUCT` column must have the same keys. Each key must have the same type of value for each row.
 `STRUCT`s are typically used to nest multiple columns into a single column,
 and the nested column can be of any type, including other `STRUCT`s and `LIST`s.
-`STRUCT`s are similar to Postgres's `ROW` type.
+`STRUCT`s are similar to Postgres's `ROW` type. DuckDB also includes a `row` function as a special way to produce a struct, but does not have a `ROW` data type. See an example below and the [nested functions docs](../functions/nested#struct-functions) for details.
 
-Structs can be created using the [`STRUCT_PACK(name := expr, ...)`](../functions/nested#structfunctions) function
+Structs can be created using the [`STRUCT_PACK(name := expr, ...)`](../functions/nested#struct-functions) function
 or the equivalent array notation `{'name': expr, ...}` notation.
 The expressions can be constants or arbitrary expressions.
 
-```
+### Creating Structs
+```sql
 -- Struct of integers
 SELECT {'x': 1, 'y': 2, 'z': 3};
 -- Struct of strings with a NULL value
 SELECT {'yes:' 'duck', 'maybe': 'goose', 'huh': NULL, 'no': 'heron'};
+-- Struct with a different type for each key
+SELECT {'key1': 'string', 'key2': 1, 'key3': 12.345};
+-- Struct using the struct_pack function. 
+-- Note the lack of single quotes around the keys and the use of the := operator
+SELECT struct_pack(key1 := 'value1',key2 := 42);
 -- Struct of structs with NULL values
 SELECT {'birds':
             {'yes': 'duck', 'maybe': 'goose', 'huh': NULL, 'no': 'heron'},
@@ -58,12 +94,69 @@ SELECT {'birds':
             {'yes':'frog', 'maybe': 'salamander', 'huh': 'dragon', 'no':'toad'}
         };
 ```
+### Retrieving from Structs
+Retrieving a value from a struct can be accomplished using dot notation, bracket notation, or through [struct functions](../functions/nested#struct-functions) like `struct_extract`.
+```sql
+-- Use dot notation to retrieve the value at a key's location. This returns 1
+-- Note that we wrap the struct creation in parenthesis so that it happens first.
+-- This is only needed in our basic examples here, not when working with a struct column
+SELECT ({'x': 1, 'y': 2, 'z': 3}).x;
+-- If key contains a space, simply wrap it in double quotes. This returns 1
+-- Note: Use double quotes not single quotes 
+-- This is because this action is most similar to selecting a column from within the struct
+SELECT ({'x space': 1, 'y': 2, 'z': 3})."x space";
+-- Bracket notation may also be used. This returns 1
+-- Note: Use single quotes since the goal is to specify a certain string key. 
+-- Only constant expressions may be used inside the brackets (no columns)
+SELECT ({'x space': 1, 'y': 2, 'z': 3})['x space'];
+-- The struct_extract function is also equivalent. This returns 1
+SELECT struct_extract({'x space': 1, 'y': 2, 'z': 3},'x space');
+```
+
+### Creating Structs with the Row function
+The `row` function can be used to automatically convert multiple columns to a single struct column. The name of each input column is used as a key, and the value of each column becomes the struct's value at that key. Using a `row` function on the columns of this example table produces the output below.
+#### Example data table named t1:
+| my_column | another_column |
+|:---|:---|
+| 1 | a |
+| 2 | b |
+
+#### Row function example:
+```sql
+SELECT 
+    row(my_column,another_column) as my_struct_column
+FROM t1;
+```
+
+#### Example Output:
+| my_struct_column |
+|:---|
+| {'my_column': 1, 'another_column': a} |
+| {'my_column': 2, 'another_column': b} |
+
+The `row` function may also be used with arbitrary expressions as input rather than column names. In the case of an expression, a key will be automatically generated in the format of 'vN' where N is an incrementing number (Ex: v1, v2, etc.). This can be combined with column names as an input in the same call to the `row` function. This example uses the same input table as above.
+
+#### Row function example with a column name, a constant, and an expression as input:
+```sql
+SELECT 
+    row(my_column,42,my_column + 1) as my_struct_column
+FROM t1;
+```
+#### Example Output:
+| my_struct_column |
+|:---|
+| {'my_column': 1, 'v2': 42, 'v3': 2} |
+| {'my_column': 2, 'v2': 42, 'v3': 3} |
+
+
+## Maps
+
 
 ## Nesting
 
 `LIST`s and `STRUCT`s can be arbitrarily nested to any depth, so long as the type rules are observed.
 
-```
+```sql
 -- Struct with lists
 SELECT {'birds': ['duck', 'goose', 'heron'], 'aliens': NULL, 'amphibians': ['frog', 'toad']};
 ```

--- a/docs/sql/functions/nested.md
+++ b/docs/sql/functions/nested.md
@@ -12,13 +12,13 @@ In the descriptions, `l` is the three element list `[4, 5, 6]`.
 
 | Function | Description | Example | Result |
 |:---|:---|:---|:---|
+| *`list`*`[`*`index`*`]` | Bracket notation serves as an alias for `list_extract`. | `l[2]` | `6` |
 | `array_extract(`*`list`*`, `*`index`*`)` | Alias for `list_extract`. | `array_extract(l, 2)` | `6` |
 | `array_slice(`*`list`*`, `*`begin`*`, `*`end`*`)` | Extract a sublist using slice conventions. `NULL`s are interpreted as the bounds of the `LIST`. Negative values are accepted. | `array_slice(l, 1, NULL)` | `[5,6]` |
 | `list_element(`*`list`*`, `*`index`*`)` | Alias for `list_extract`. | `list_element(l, 2)` | `6` |
 | `list_extract(`*`list`*`, `*`index`*`)` | Extract the `index`th (0-based) value from the list. | `list_extract(l, 2)` | `6` |
 | `list_pack(`*`any`*`, ...)` | Alias for `list_value`. | `list_pack(4, 5, 6)` | `[4, 5, 6]` |
 | `list_value(`*`any`*`, ...)` | Create a `LIST` containing the argument values. | `list_value(4, 5, 6)` | `[4, 5, 6]` |
-| *`list`*`[`*`index`*`]` | Alias for `list_extract`. | `l[2]` | `6` |
 | *`list`*`[`*`begin`*`:`*`end`*`]` | Alias for `array_slice`. Missing arguments are interprete as `NULL`s. | `l[1:2]` | `[5, 6]` |
 | `array_length(`*`list`*`)` | Return the length of the list. |  `array_length([1, 2, 3])` | `3` |
 | `len(`*`list`*`)` | Alias for `array_length`. | `len([1, 2, 3])` | `3` |
@@ -34,10 +34,19 @@ In the descriptions, `l` is the three element list `[4, 5, 6]`.
 
 | Function | Description | Example | Result |
 |:---|:---|:---|:---|
-| *`struct`*`[`*`entry`*`]` | Alias for `struct_extract`. | `struct_extract(s, 'i')` | `4` |
+| *`struct`*`.`*`entry`* | Dot notation serves as an alias for `struct_extract`. | `({'i': 3, 's': 'string'}).s` | `string` |
+| *`struct`*`[`*`entry`*`]` | Bracket notation serves as an alias for `struct_extract`. | `({'i': 3, 's': 'string'})['s']` | `string` |
 | `row(`*`any`*`, ...)` | Create a `STRUCT` containing the argument values. If the values are column references, the entry name will be the column name; otherwise it will be the string `'vN'` where `N` is the (1-based) position of the argument. | `row(i, i % 4, i / 4)` | `{'i': 3, 'v2': 3, 'v3': 0}`|
 | `struct_extract(`*`struct`*`, `*`'entry'`*`)` | Extract the named entry from the struct. | `struct_extract(s, 'i')` | `4` |
 | `struct_pack(`*`name := any`*`, ...)` | Create a `STRUCT` containing the argument values. The entry name will be the bound variable name. | `struct_pack(i := 4, s := 'string')` | `{'i': 3, 's': 'string'}`|
+
+## Map Functions
+| Function | Description | Example | Result |
+|:---|:---|:---|:---|
+| `map[`*`entry`*`]` | Alias for `element_at` | `map([100, 5], ['a', 'b'])[100]` | 42 |
+| `element_at(`*`map, key`*`)` | Return a list containing the value for a given key or an empty list if the key is not contained in the map. The type of the key provided in the second parameter must match the type of the map's keys else an error is returned. | `SELECT element_at(map([100, 5], [42, 43]),100);` | 42 |
+| `cardinality(`*`map`*`)` | Return the size of the map (or the number of entries in the map). | `cardinality( map([4, 2], ['a', 'b']) );` | 2 |
+| `map()` | Returns an empty map. | `map()` | {} |
 
 ## Range Functions
 


### PR DESCRIPTION
Sorry for the branch name! I decided to knock out a few quick wins first.
This documents the list of filenames and the list of globs options for the parquet_scan function. I also included the Export statement as there is an option to export as parquet. A few other minor parquet docs tweaks are included.

I also beefed up the nested types docs quite a bit.

@mattico, do you have anything you would like to add or edit on the nested data types documentation? Thanks for your feedback in #110!