### PR TITLE
Rework Python and R connection examples

### DIFF
--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -10,11 +10,16 @@ The DuckDB Python API can be installed using [pip](https://pip.pypa.io): `pip in
 The standard DuckDB Python API provides a SQL interface compliant with the [DB-API 2.0 specification described by PEP 249](https://www.python.org/dev/peps/pep-0249/) similar to the [SQLite Python API](https://docs.python.org/3.7/library/sqlite3.html).
 
 ### Startup & Shutdown
-To use the module, you must first create a `Connection` object that represents the database. The connection object takes as parameter the database file to read and write from. The special value `:memory:` (the default) can be used to create an **in-memory database**. Note that for an in-memory database no data is persisted to disk (i.e. all data is lost when you exit the Python process). If you would like to connect to an existing database in read-only mode, you can set the `read_only` flag to `True`. Read-only mode is required if multiple Python processes want to access the same database file at the same time. 
+To use the module, you must first create a `Connection` object that represents the database. The connection object takes as parameter the database file to read and write from. The special value `:memory:` (the default) can be used to create an **in-memory database**. Note that for an in-memory database no data is persisted to disk (i.e. all data is lost when you exit the Python process). If you would like to connect to an existing database in read-only mode, you can set the `read_only` flag to `True`. Read-only mode is required if multiple Python processes want to access the same database file at the same time.
 
 ```python
 import duckdb
-con = duckdb.connect(database=':memory:', read_only=False)
+# to start an in-memory database
+con = duckdb.connect(database=':memory:')
+# to use a database file (not shared between processes)
+con = duckdb.connect(database='my-db.duckdb', read_only=False)
+# to use a database file (shared between processes)
+con = duckdb.connect(database='my-db.duckdb', read_only=True)
 ```
 If you want to create a second connection to an existing database, you can use the `cursor()` method. This might be useful for example to allow parallel threads running queries independently. A single connection is thread-safe but is locked for the duration of the queries, effectively serializing database access in this case. 
 

--- a/docs/api/r.md
+++ b/docs/api/r.md
@@ -11,11 +11,16 @@ The standard DuckDB R API implements the [DBI interface](https://CRAN.R-project.
 
 ### Startup & Shutdown
 
-To use DuckDB, you must first create a connection object that represents the database. The connection object takes as parameter the database file to read and write from. The special value `:memory:` (the default) can be used to create an **in-memory database**. Note that for an in-memory database no data is persisted to disk (i.e. all data is lost when you exit the R process). If you would like to connect to an existing database in read-only mode, set the `read_only` flag to `TRUE`. Read-only mode is required if multiple R processes want to access the same database file at the same time. 
+To use DuckDB, you must first create a connection object that represents the database. The connection object takes as parameter the database file to read and write from. The special value `:memory:` (the default) can be used to create an **in-memory database**. Note that for an in-memory database no data is persisted to disk (i.e. all data is lost when you exit the R process). If you would like to connect to an existing database in read-only mode, set the `read_only` flag to `TRUE`. Read-only mode is required if multiple R processes want to access the same database file at the same time.
 
 ```R
 library("DBI")
-con = dbConnect(duckdb::duckdb(), dbdir=":memory:", read_only=FALSE)
+# to start an in-memory database
+con = dbConnect(duckdb::duckdb(), dbdir=":memory:")
+# to use a database file (not shared between processes)
+con = dbConnect(duckdb::duckdb(), dbdir="my-db.duckdb", read_only=FALSE)
+# to use a database file (shared between processes)
+con = dbConnect(duckdb::duckdb(), dbdir="my-db.duckdb", read_only=TRUE)
 ```
 Connections are closed implicitly when they go out of scope or if they are explicitly closed using `dbDisconnect()`.
 


### PR DESCRIPTION
The existing examples did not show how to connect to a file and were somewhat confusing (as using a memory database implies read-only = false so it was unnecessary).