### PR TITLE
Add NodeJS Readme as Node.js Client API page

### DIFF
--- a/_data/menu.json
+++ b/_data/menu.json
@@ -93,6 +93,10 @@
                 {
                   "page": "C++",
                   "url": "/docs/api/cpp"
+                },
+                {
+                  "page": "Node.js",
+                  "url": "/docs/api/nodejs"
                 },               {
                   "page": "CLI",
                   "url": "/docs/api/cli"

--- a/docs/api/nodejs.md
+++ b/docs/api/nodejs.md
@@ -1,0 +1,107 @@
+---
+layout: docu
+title: Node.js API
+selected: Client APIs
+---
+
+# DuckDB Node Bindings
+
+This package provides a node.js API for [DuckDB](https://github.com/cwida/duckdb), the "SQLite for Analytics". The API for this client is somewhat compliant to the SQLite node.js client for easier transition (and transition you must eventually).
+
+Load the package and create a database object:
+
+```js
+var duckdb = require('duckdb');
+
+var db = new duckdb.Database(':memory:'); // or a file name for a persistent DB
+```
+
+Then you can run a query:
+
+```js
+db.all('SELECT 42 AS fortytwo', function(err, res) {
+  if (err) {
+    throw err;
+  }
+  console.log(res[0].fortytwo)
+});
+```
+
+Other available methods are `each`, where the callback is invoked for each row, `run` to execute a single statement without results and `exec`, which can execute several SQL commands at once but also does not return results. All those commands can work with prepared statements, taking the values for the parameters as additional arguments. For example like so:
+
+```js
+db.all('SELECT ?::INTEGER AS fortytwo, ?::STRING as hello', 42, 'Hello, World', function(err, res) {
+  if (err) {
+    throw err;
+  }
+  console.log(res[0].fortytwo)
+  console.log(res[0].hello)
+});
+```
+
+However, these are all shorthands for something much more elegant. A database can have multiple `Connection`s, those are created using `db.connect()`.
+
+```js
+var con = db.connect();
+```
+
+You can create multiple connections, each with their own transaction context.
+
+
+`Connection` objects also contain shorthands to directly call `run()`, `all()` and `each()` with parameters and callbacks, respectively, for example:
+
+```js
+con.all('SELECT 42 AS fortytwo', function(err, res) {
+  if (err) {
+    throw err;
+  }
+  console.log(res[0].fortytwo)
+});
+```
+
+From connections, you can create prepared statements (and only that) using `con.prepare()`:
+
+```js
+var stmt = con.prepare('select ?::INTEGER as fortytwo');
+``` 
+
+To execute this statement, you can call for example `all()` on the `stmt` object:
+
+```js
+stmt.all(42, function(err, res) {
+  if (err) {
+    throw err;
+  }
+  console.log(res[0].fortytwo)
+});
+```
+
+You can also execute the prepared statement multiple times. This is for example useful to fill a table with data:
+
+```js
+con.run('CREATE TABLE a (i INTEGER)');
+var stmt = con.prepare('INSERT INTO a VALUES (?)');
+for (var i = 0; i < 10; i++) {
+  stmt.run(i);
+}
+stmt.finalize();
+con.all('SELECT * FROM a', function(err, res) {
+  if (err) {
+    throw err;
+  }
+  console.log(res)
+});
+```
+
+`prepare()` can also take a callback which gets the prepared statement as an argument:
+
+```js
+var stmt = con.prepare('select ?::INTEGER as fortytwo', function(err, stmt) {
+  stmt.all(42, function(err, res) {
+    if (err) {
+      throw err;
+    }
+    console.log(res[0].fortytwo)
+  });
+});
+```

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -5,7 +5,7 @@ selected: Overview
 expanded: Client APIs
 ---
 
-There are various client APIs for DuckDB. DuckDB's "native" API is [C++](cpp), with "official" wrappers available for [C](c/overview), [Python](python), [R](r) and [Java](java).
+There are various client APIs for DuckDB. DuckDB's "native" API is [C++](cpp), with "official" wrappers available for [C](c/overview), [Python](python), [R](r), [Java](java), and [Node.js](nodejs).
 
 There are also contributed third-party DuckDB wrappers for [Ruby](https://github.com/suketa/ruby-duckdb), [Go](https://github.com/marcboeker/go-duckdb), [C#](https://github.com/Giorgi/DuckDB.NET) and [Rust](https://github.com/wangfenjin/duckdb-rs).
 


### PR DESCRIPTION
We should have some kind of page for this! I just grabbed the Readme contents as a starting point. We can revise it more later, if that's ok!
(Fixes #138 )