### PR TITLE
docs: correct import for query graph generator in profiling docs

### DIFF
--- a/docs/dev/profiling.md
+++ b/docs/dev/profiling.md
@@ -160,8 +160,8 @@ python scripts/generate_querygraph.py /path/to/file.json
 Alternatively, we can also use the Python API directly to generate the query graph file. This can be done using the following Python snippet:
 
 ```python
-import duckdb_query_graph.generate
-duckdb_query_graph.generate.generate('/path/to/file.json', '/path/to/out.html')
+import duckdb_query_graph
+duckdb_query_graph.generate('/path/to/file.json', '/path/to/out.html')
 ```
 
 This will show us the following query graph:


### PR DESCRIPTION
Also matching usage in the site's own scripts

https://github.com/duckdb/duckdb-web/blob/4eeb2673256ac95bfe5f38cc43df3be56bb900f8/scripts/benchmark_html.py#L5

https://github.com/duckdb/duckdb-web/blob/4eeb2673256ac95bfe5f38cc43df3be56bb900f8/scripts/benchmark_html.py#L208