### PR TITLE
Fix indentation in supporters.yml file

### DIFF
--- a/_data/supporters.yml
+++ b/_data/supporters.yml
@@ -16,6 +16,6 @@ silver:
     url: https://noteable.io
     logoimg: noteable.png
 
- - name: Mode
+  - name: Mode
     url: https://mode.com
     logoimg: mode.svg


### PR DESCRIPTION
With the previous `supporters.yml` file, `jekyll serve` failed for me with the following error message:
```console
                    ------------------------------------------------
      Jekyll 4.2.1   Please append `--trace` to the `serve` command 
                     for any additional information or backtrace. 
                    ------------------------------------------------
/usr/local/share/gems/gems/safe_yaml-1.0.5/lib/safe_yaml/load.rb:143:in `parse': (/home/szarnyasg/git/duck/duckdb-web/_data/supporters.yml): did not find expected key while parsing a block mapping at line 1 column 1 (Psych::SyntaxError)
	from /usr/local/share/gems/gems/safe_yaml-1.0.5/lib/safe_yaml/load.rb:143:in `load'
	from /usr/local/share/gems/gems/safe_yaml-1.0.5/lib/safe_yaml/load.rb:157:in `block in load_file'
	from /usr/local/share/gems/gems/safe_yaml-1.0.5/lib/safe_yaml/load.rb:157:in `open'
	from /usr/local/share/gems/gems/safe_yaml-1.0.5/lib/safe_yaml/load.rb:157:in `load_file'
```
This PR fixes the indentation.