### PR TITLE
Scalar Functions Docs Improvements

### DIFF
--- a/_data/menu_docs_current.json
+++ b/_data/menu_docs_current.json
@@ -373,6 +373,10 @@
               {
                 "page": "Nested Functions",
                 "url": "nested"
+              },
+              {
+                "page": "Utility Functions",
+                "url": "utility"
               }
             ]
           },

--- a/_data/menu_docs_current.json
+++ b/_data/menu_docs_current.json
@@ -397,6 +397,10 @@
             "url": "samples"
           },
           {
+            "page": "Catalog Functions",
+            "url": "catalog_functions"
+          },
+          {
             "page": "Configuration",
             "url": "configuration"
           },

--- a/docs/sql/catalog_functions.md
+++ b/docs/sql/catalog_functions.md
@@ -54,3 +54,11 @@ The table function that describes the catalog information for columns is `inform
 | `numeric_precision` |If data_type identifies a numeric type, this column contains the (declared or implicit) precision of the type for this column. The precision indicates the number of significant digits. For all other data types, this column is null.|`INTEGER`| `18` |
 | `numeric_scale` |If data_type identifies a numeric type, this column contains the (declared or implicit) scale of the type for this column. The precision indicates the number of significant digits. For all other data types, this column is null.|`INTEGER`| `2` |
 | `datetime_precision` |If data_type identifies a date, time, timestamp, or interval type, this column contains the (declared or implicit) fractional seconds precision of the type for this column, that is, the number of decimal digits maintained following the decimal point in the seconds value. No fractional seconds are currently supported in DuckDB. For all other data types, this column is null.|`INTEGER`| `0` |
+
+## Catalog Functions
+Several functions are also provided to see details about the schemas that are configured in the database.
+
+| Function | Description | Example | Result |
+|:---|:---|:---|:---|
+| `current_schema()` | Return the name of the currently active schema. Default is main. | `current_schema()` | `'main'` |
+| `current_schemas(boolean)` | Return list of schemas. Pass a parameter of `True` to include implicit schemas. | `current_schemas(true)` | `['temp', 'main', 'pg_catalog']` |

--- a/docs/sql/configuration.md
+++ b/docs/sql/configuration.md
@@ -18,6 +18,10 @@ PRAGMA default_null_order='nulls_last';
 
 -- show a list of all available settings
 SELECT * FROM duckdb_settings();
+
+-- return the current value of a specific setting
+-- this example returns 'automatic'
+SELECT current_setting('access_mode'); 
 ```
 
 ## **Configuration Reference**

--- a/docs/sql/data_types/overview.md
+++ b/docs/sql/data_types/overview.md
@@ -18,6 +18,7 @@ The table below shows all the built-in general-purpose data types. The alternati
 | `DECIMAL(s, p)` | | fixed-precision floating point number with the given scale and precision |
 | `HUGEINT` | | signed sixteen-byte integer|
 | `INTEGER` | `INT4`, `INT`, `SIGNED` | signed four-byte integer |
+| `INTERVAL` |  | date / time delta |
 | `REAL` | `FLOAT4`, `FLOAT` | single precision floating-point number (4 bytes)|
 | `SMALLINT` | `INT2`, `SHORT` | signed two-byte integer|
 | `TIME` | | time of day (no time zone) |

--- a/docs/sql/functions/blob.md
+++ b/docs/sql/functions/blob.md
@@ -9,4 +9,6 @@ This section describes functions and operators for examining and manipulating bl
 | Function | Description | Example | Result |
 |:---|:---|:---|:---|
 | *`blob`* `||` *`blob`* | Blob concatenation | `'\xAA'::BLOB || '\xBB'::BLOB` | \xAABB |
+| `decode(`*`blob`*`)` | Convert blob to varchar. Fails if blob is not valid utf-8. | `decode('\xC3\xBC'::BLOB)` | ü |
+| `encode(`*`string`*`)` | Convert varchar to blob. Converts utf-8 characters into literal encoding. | `encode('my_string_with_ü')` | my_string_with_\xC3\xBC |
 | `octet_length(`*`blob`*`)` | Number of bytes in blob | `octet_length('\xAABB'::BLOB)` | 2 |

--- a/docs/sql/functions/char.md
+++ b/docs/sql/functions/char.md
@@ -21,6 +21,8 @@ This section describes functions and operators for examining and manipulating st
 | `contains(`*`string`*`, `*`search_string`*`)` | Return true if `search_string` is found within `string` | `contains('abc','a')` | `true` |
 | `format(`*`format`*`, `*`parameters`*`...)` | Formats a string using fmt syntax | `format('Benchmark "{}" took {} seconds', 'CSV', 42)` | `Benchmark "CSV" took 42 seconds` |
 | `from_base64(`*`string`*`)`| Convert a base64 encoded string to a character string. | `from_base64('QQ==')` | `'A'` |
+| `instr(`*`string`*`, `*`characters`*`)`| Return location of first occurrence of `characters` in `string`, counting from 1. Returns 0 if no match found. | `instr('test test','es')` | 2 |
+| `lcase(`*`string`*`)` | Alias of `lower`. Convert *string* to lower case | `lcase('Hello')` | `hello` |
 | `left(`*`string`*`, `*`count`*`)`| Extract the left-most count characters | `left('hello', 2)` | `he` |
 | `length(`*`string`*`)` | Number of characters in *string* | `length('Hello')` | `5` |
 | *`string`*` LIKE `*`target`* | Returns true if the *string* matches the like specifier (see [Pattern Matching](/docs/sql/functions/patternmatching)) | `'hello' LIKE '%lo'` | `true` |
@@ -30,6 +32,7 @@ This section describes functions and operators for examining and manipulating st
 | `lpad(`*`string`*`, `*`count`*`, `*`character`*`)`| Pads the *string*  with the character from the left until it has count characters | `lpad('hello', 10, '>')` | `>>>>>hello` |
 | `ltrim(`*`string`*`)`| Removes any spaces from the left side of the *string* | `ltrim('␣␣␣␣test␣␣')` | `test␣␣` |
 | `ltrim(`*`string`*`, `*`characters`*`)`| Removes any occurrences of any of the *characters* from the left side of the *string* | `ltrim('>>>>test<<', '><')` | `test<<` |
+| `ucase(`*`string`*`)`| Alias of `upper`. Convert *string* to upper case | `ucase('Hello')` | `HELLO` |
 | `upper(`*`string`*`)`| Convert *string* to upper case | `upper('Hello')` | `HELLO` |
 | `printf(`*`format`*`, `*`parameters`*`...)` | Formats a *string* using printf syntax | `printf('Benchmark "%s" took %d seconds', 'CSV', 42)` | `Benchmark "CSV" took 42 seconds`     |
 | `regexp_full_match(`*`string`*`, `*`regex`*`)`| Returns true if the entire *string* matches the *regex* (see [Pattern Matching](/docs/sql/functions/patternmatching)) | `regexp_full_match('anabanana', '(an)*')` | `false` |
@@ -47,8 +50,20 @@ This section describes functions and operators for examining and manipulating st
 | `strip_accents(`*`string`*`)`| Strips accents from *string* | `strip_accents('mühleisen')` | `muhleisen` |
 | `string_split(`*`string`*`, `*`separator`*`)` | Splits the *string* along the *separator* | `string_split('hello␣world', '␣')` | `['hello', 'world']` |
 | `string_split_regex(`*`string`*`, `*`regex`*`)` | Splits the *string* along the *regex* | `string_split_regex('hello␣world; 42', ';?␣')` | `['hello', 'world', '42']` |
+| `substr(`*`string`*`, `*`start`*`, `*`length`*`)` | Alias of `substring`. Extract substring of *length* characters starting from character *start*. Note that a *start* value of `1` refers to the *first* character of the string. | `substr('Hello', 2, 2)` | `el` |
 | `substring(`*`string`*`, `*`start`*`, `*`length`*`)` | Extract substring of *length* characters starting from character *start*. Note that a *start* value of `1` refers to the *first* character of the string. | `substring('Hello', 2, 2)` | `el` |
+| `strpos(`*`string`*`, `*`characters`*`)`| Alias of `instr`. Return location of first occurrence of `characters` in `string`, counting from 1. Returns 0 if no match found. | `strpos('test test','es')` | 2 |
 | `to_base64(`*`blob`*`)`| Convert a blob to a base64 encoded string. Alias of base64. | `to_base64('A'::blob)` | `QQ==` |
 | `trim(`*`string`*`)`| Removes any spaces from either side of the *string* | `trim('␣␣␣␣test␣␣')` | `test` |
 | `trim(`*`string`*`, `*`characters`*`)`| Removes any occurrences of any of the *characters* from either side of the *string* | `trim('>>>>test<<', '><')` | `test` |
 | `unicode(`*`string`*`)`| Returns the unicode code of the first character of the *string* | `unicode('ü')` | `252` |
+
+
+## Text Similarity Functions
+These functions are used to measure the similarity of two strings using various metrics. 
+
+| Function | Description | Example | Result |
+|:---|:---|:---|:---|
+| `hamming(`*`string`*`,` *`string`*`)` | The number of positions with different characters for 2 strings of equal length. Different case is considered different. | `hamming('duck','luck')` | 1 |
+| `jaccard(`*`string`*`,` *`string`*`)` | The Jaccard similarity between two strings. Different case is considered different. Returns a number between 0 and 1. | `jaccard('duck','luck')` | 0.6 |
+| `levenshtein(`*`string`*`,` *`string`*`)` | The minimum number of single-character edits (insertions, deletions or substitutions) required to change one string to the other. Different case is considered different. | `levenshtein('duck','db')` | 3 |

--- a/docs/sql/functions/char.md
+++ b/docs/sql/functions/char.md
@@ -14,9 +14,13 @@ This section describes functions and operators for examining and manipulating st
 | `array_extract(`*`list`*`, `*`index`*`)` | Extract a single character using a (0-based) index. | `array_extract('DuckDB, 1)` | `'u'` |
 | `array_slice(`*`list`*`, `*`begin`*`, `*`end`*`)` | Extract a string using slice conventions. `NULL`s are interpreted as the bounds of the string. Negative values are accepted. | `array_slice('DuckDB, 4, NULL)` | `'DB'` |
 | `ascii(`*`string`*`)`| Returns an integer that represents the Unicode code point of the first character of the *string* | `ascii('Ω')` | `937` |
+| `base64(`*`blob`*`)`| Convert a blob to a base64 encoded string. Alias of to_base64. | `base64('A'::blob)` | `'QQ=='` |
+| `bit_length(`*`string`*`)`| Number of bits in a string. | `bit_length('abc')` | `24` |
 | `concat(`*`string`*`, ...)` | Concatenate many strings together | `concat('Hello', ' ', 'World')` | `Hello World` |
 | `concat_ws(`*`separator`*`, `*`string`*`, ...)` | Concatenate strings together separated by the specified separator | `concat_ws(',', 'Banana', 'Apple', 'Melon')` | `Banana,Apple,Melon` |
+| `contains(`*`string`*`, `*`search_string`*`)` | Return true if `search_string` is found within `string` | `contains('abc','a')` | `true` |
 | `format(`*`format`*`, `*`parameters`*`...)` | Formats a string using fmt syntax | `format('Benchmark "{}" took {} seconds', 'CSV', 42)` | `Benchmark "CSV" took 42 seconds` |
+| `from_base64(`*`string`*`)`| Convert a base64 encoded string to a character string. | `from_base64('QQ==')` | `'A'` |
 | `left(`*`string`*`, `*`count`*`)`| Extract the left-most count characters | `left('hello', 2)` | `he` |
 | `length(`*`string`*`)` | Number of characters in *string* | `length('Hello')` | `5` |
 | *`string`*` LIKE `*`target`* | Returns true if the *string* matches the like specifier (see [Pattern Matching](/docs/sql/functions/patternmatching)) | `'hello' LIKE '%lo'` | `true` |
@@ -44,6 +48,7 @@ This section describes functions and operators for examining and manipulating st
 | `string_split(`*`string`*`, `*`separator`*`)` | Splits the *string* along the *separator* | `string_split('hello␣world', '␣')` | `['hello', 'world']` |
 | `string_split_regex(`*`string`*`, `*`regex`*`)` | Splits the *string* along the *regex* | `string_split_regex('hello␣world; 42', ';?␣')` | `['hello', 'world', '42']` |
 | `substring(`*`string`*`, `*`start`*`, `*`length`*`)` | Extract substring of *length* characters starting from character *start*. Note that a *start* value of `1` refers to the *first* character of the string. | `substring('Hello', 2, 2)` | `el` |
+| `to_base64(`*`blob`*`)`| Convert a blob to a base64 encoded string. Alias of base64. | `to_base64('A'::blob)` | `QQ==` |
 | `trim(`*`string`*`)`| Removes any spaces from either side of the *string* | `trim('␣␣␣␣test␣␣')` | `test` |
 | `trim(`*`string`*`, `*`characters`*`)`| Removes any occurrences of any of the *characters* from either side of the *string* | `trim('>>>>test<<', '><')` | `test` |
 | `unicode(`*`string`*`)`| Returns the unicode code of the first character of the *string* | `unicode('ü')` | `252` |

--- a/docs/sql/functions/char.md
+++ b/docs/sql/functions/char.md
@@ -26,14 +26,17 @@ This section describes functions and operators for examining and manipulating st
 | `left(`*`string`*`, `*`count`*`)`| Extract the left-most count characters | `left('hello', 2)` | `he` |
 | `length(`*`string`*`)` | Number of characters in *string* | `length('Hello')` | `5` |
 | *`string`*` LIKE `*`target`* | Returns true if the *string* matches the like specifier (see [Pattern Matching](/docs/sql/functions/patternmatching)) | `'hello' LIKE '%lo'` | `true` |
+| `like_escape(`*`string`*`, `*`like_specifier`*`, `*`escape_character`*`)` | Returns true if the *string* matches the *like_specifier* (see [Pattern Matching](/docs/sql/functions/patternmatching)). *escape_character* is used to search for wildcard characters in the *string*. | `like_escape('a%c', 'a$%c', '$')` | `true` |
 | `list_element(`*`string`*`, `*`index`*`)` | An alias for `array_extract`. | `list_element('DuckDB, 1)` | `'u'` |
 | `list_extract(`*`string`*`, `*`index`*`)` | An alias for `array_extract`. | `list_extract('DuckDB, 1)` | `'u'` |
 | `lower(`*`string`*`)` | Convert *string* to lower case | `lower('Hello')` | `hello` |
 | `lpad(`*`string`*`, `*`count`*`, `*`character`*`)`| Pads the *string*  with the character from the left until it has count characters | `lpad('hello', 10, '>')` | `>>>>>hello` |
 | `ltrim(`*`string`*`)`| Removes any spaces from the left side of the *string* | `ltrim('␣␣␣␣test␣␣')` | `test␣␣` |
 | `ltrim(`*`string`*`, `*`characters`*`)`| Removes any occurrences of any of the *characters* from the left side of the *string* | `ltrim('>>>>test<<', '><')` | `test<<` |
+| `not_like_escape(`*`string`*`, `*`like_specifier`*`, `*`escape_character`*`)` | Returns false if the *string* matches the *like_specifier* (see [Pattern Matching](/docs/sql/functions/patternmatching)). *escape_character* is used to search for wildcard characters in the *string*. | `like_escape('a%c', 'a$%c', '$')` | `true` |
 | `ucase(`*`string`*`)`| Alias of `upper`. Convert *string* to upper case | `ucase('Hello')` | `HELLO` |
 | `upper(`*`string`*`)`| Convert *string* to upper case | `upper('Hello')` | `HELLO` |
+| `ord(`*`string`*`)`| Return ASCII character code of the leftmost character in a string.  | `ord('ü')` | `252` |
 | `printf(`*`format`*`, `*`parameters`*`...)` | Formats a *string* using printf syntax | `printf('Benchmark "%s" took %d seconds', 'CSV', 42)` | `Benchmark "CSV" took 42 seconds`     |
 | `regexp_full_match(`*`string`*`, `*`regex`*`)`| Returns true if the entire *string* matches the *regex* (see [Pattern Matching](/docs/sql/functions/patternmatching)) | `regexp_full_match('anabanana', '(an)*')` | `false` |
 | `regexp_matches(`*`string`*`, `*`regex`*`)`| Returns true if a part of *string* matches the *regex* (see [Pattern Matching](/docs/sql/functions/patternmatching)) | `regexp_matches('anabanana', '(an)*')` | `true` |

--- a/docs/sql/functions/char.md
+++ b/docs/sql/functions/char.md
@@ -67,6 +67,8 @@ These functions are used to measure the similarity of two strings using various 
 
 | Function | Description | Example | Result |
 |:---|:---|:---|:---|
+| `editdist3(`*`string`*`,` *`string`*`)` | Alias of `levenshtein` for SQLite compatibility. The minimum number of single-character edits (insertions, deletions or substitutions) required to change one string to the other. Different case is considered different. | `editdist3('duck','db')` | 3 |
 | `hamming(`*`string`*`,` *`string`*`)` | The number of positions with different characters for 2 strings of equal length. Different case is considered different. | `hamming('duck','luck')` | 1 |
 | `jaccard(`*`string`*`,` *`string`*`)` | The Jaccard similarity between two strings. Different case is considered different. Returns a number between 0 and 1. | `jaccard('duck','luck')` | 0.6 |
 | `levenshtein(`*`string`*`,` *`string`*`)` | The minimum number of single-character edits (insertions, deletions or substitutions) required to change one string to the other. Different case is considered different. | `levenshtein('duck','db')` | 3 |
+| `mismatches(`*`string`*`,` *`string`*`)` | The number of positions with different characters for 2 strings of equal length. Different case is considered different. | `mismatches('duck','luck')` | 1 |

--- a/docs/sql/functions/char.md
+++ b/docs/sql/functions/char.md
@@ -21,7 +21,7 @@ This section describes functions and operators for examining and manipulating st
 | `contains(`*`string`*`, `*`search_string`*`)` | Return true if `search_string` is found within `string` | `contains('abc','a')` | `true` |
 | `format(`*`format`*`, `*`parameters`*`...)` | Formats a string using fmt syntax | `format('Benchmark "{}" took {} seconds', 'CSV', 42)` | `Benchmark "CSV" took 42 seconds` |
 | `from_base64(`*`string`*`)`| Convert a base64 encoded string to a character string. | `from_base64('QQ==')` | `'A'` |
-| `instr(`*`string`*`, `*`characters`*`)`| Return location of first occurrence of `characters` in `string`, counting from 1. Returns 0 if no match found. | `instr('test test','es')` | 2 |
+| `instr(`*`string`*`, `*`search_string`*`)`| Return location of first occurrence of `search_string` in `string`, counting from 1. Returns 0 if no match found. | `instr('test test','es')` | 2 |
 | `lcase(`*`string`*`)` | Alias of `lower`. Convert *string* to lower case | `lcase('Hello')` | `hello` |
 | `left(`*`string`*`, `*`count`*`)`| Extract the left-most count characters | `left('hello', 2)` | `he` |
 | `length(`*`string`*`)` | Number of characters in *string* | `length('Hello')` | `5` |
@@ -33,14 +33,18 @@ This section describes functions and operators for examining and manipulating st
 | `lpad(`*`string`*`, `*`count`*`, `*`character`*`)`| Pads the *string*  with the character from the left until it has count characters | `lpad('hello', 10, '>')` | `>>>>>hello` |
 | `ltrim(`*`string`*`)`| Removes any spaces from the left side of the *string* | `ltrim('␣␣␣␣test␣␣')` | `test␣␣` |
 | `ltrim(`*`string`*`, `*`characters`*`)`| Removes any occurrences of any of the *characters* from the left side of the *string* | `ltrim('>>>>test<<', '><')` | `test<<` |
+| `nfc_normalize(`*`string`*`)`| Convert string to Unicode NFC normalized string. Useful for comparisons and ordering if text data is mixed between NFC normalized and not. | `nfc_normalize('ardèch')` | ``arde`ch`` |
 | `not_like_escape(`*`string`*`, `*`like_specifier`*`, `*`escape_character`*`)` | Returns false if the *string* matches the *like_specifier* (see [Pattern Matching](/docs/sql/functions/patternmatching)). *escape_character* is used to search for wildcard characters in the *string*. | `like_escape('a%c', 'a$%c', '$')` | `true` |
 | `ucase(`*`string`*`)`| Alias of `upper`. Convert *string* to upper case | `ucase('Hello')` | `HELLO` |
 | `upper(`*`string`*`)`| Convert *string* to upper case | `upper('Hello')` | `HELLO` |
 | `ord(`*`string`*`)`| Return ASCII character code of the leftmost character in a string.  | `ord('ü')` | `252` |
+| `position(`*`search_string`*` in `*`string`*`)` | Return location of first occurrence of `search_string` in `string`, counting from 1. Returns 0 if no match found. | `position('b' in 'abc')` | `2` |
+| `prefix(`*`string`*`, `*`search_string`*`)` | Return true if *string* starts with *search_string*. | `prefix('abc', 'ab')` | `true` |
 | `printf(`*`format`*`, `*`parameters`*`...)` | Formats a *string* using printf syntax | `printf('Benchmark "%s" took %d seconds', 'CSV', 42)` | `Benchmark "CSV" took 42 seconds`     |
 | `regexp_full_match(`*`string`*`, `*`regex`*`)`| Returns true if the entire *string* matches the *regex* (see [Pattern Matching](/docs/sql/functions/patternmatching)) | `regexp_full_match('anabanana', '(an)*')` | `false` |
 | `regexp_matches(`*`string`*`, `*`regex`*`)`| Returns true if a part of *string* matches the *regex* (see [Pattern Matching](/docs/sql/functions/patternmatching)) | `regexp_matches('anabanana', '(an)*')` | `true` |
 | `regexp_replace(`*`string`*`, `*`regex`*`, `*`replacement`*`, `*`modifiers`*`)`| Replaces the first occurrence of *regex* with the *replacement*, use `'g'` modifier to replace all occurrences instead (see [Pattern Matching](/docs/sql/functions/patternmatching)) | `select regexp_replace('hello', '[lo]', '-')` | `he-lo` |
+| `regexp_split_to_array(`*`string`*`, `*`regex`*`)` | Alias of `string_split_regex`. Splits the *string* along the *regex* | `regexp_split_to_array('hello␣world; 42', ';?␣')` | `['hello', 'world', '42']` |
 | `repeat(`*`string`*`, `*`count`*`)`| Repeats the *string* *count* number of times | `repeat('A', 5)` | `AAAAA` |
 | `replace(`*`string`*`, `*`source`*`, `*`target`*`)`| Replaces any occurrences of the *source* with *target* in *string* | `replace('hello', 'l', '-')` | `he--o` |
 | `reverse(`*`string`*`)`| Reverses the *string* | `reverse('hello')` | `olleh` |
@@ -50,11 +54,16 @@ This section describes functions and operators for examining and manipulating st
 | `rtrim(`*`string`*`, `*`characters`*`)`| Removes any occurrences of any of the *characters* from the right side of the *string* | `rtrim('>>>>test<<', '><')` | `>>>>test` |
 | *`string`*` SIMILAR TO `*`regex`* | Returns `true` if the *string* matches the *regex*; identical to `regexp_full_match` (see [Pattern Matching](/docs/sql/functions/patternmatching)) | `'hello' SIMILAR TO 'l+'` | `false` |
 | `strlen(`*`string`*`)` | Number of bytes in *string* | `length('🤦🏼‍♂️')` | `1` |
+| `strpos(`*`string`*`, `*`search_string`*`)`| Alias of `instr`. Return location of first occurrence of `search_string` in `string`, counting from 1. Returns 0 if no match found. | `strpos('test test','es')` | 2 |
 | `strip_accents(`*`string`*`)`| Strips accents from *string* | `strip_accents('mühleisen')` | `muhleisen` |
+| `str_split(`*`string`*`, `*`separator`*`)` | Alias of `string_split`. Splits the *string* along the *separator* | `str_split('hello␣world', '␣')` | `['hello', 'world']` |
+| `str_split_regex(`*`string`*`, `*`regex`*`)` | Alias of `string_split_regex`. Splits the *string* along the *regex* | `str_split_regex('hello␣world; 42', ';?␣')` | `['hello', 'world', '42']` |
 | `string_split(`*`string`*`, `*`separator`*`)` | Splits the *string* along the *separator* | `string_split('hello␣world', '␣')` | `['hello', 'world']` |
 | `string_split_regex(`*`string`*`, `*`regex`*`)` | Splits the *string* along the *regex* | `string_split_regex('hello␣world; 42', ';?␣')` | `['hello', 'world', '42']` |
+| `string_to_array(`*`string`*`, `*`separator`*`)` | Alias of `string_split`. Splits the *string* along the *separator* | `string_to_array('hello␣world', '␣')` | `['hello', 'world']` |
 | `substr(`*`string`*`, `*`start`*`, `*`length`*`)` | Alias of `substring`. Extract substring of *length* characters starting from character *start*. Note that a *start* value of `1` refers to the *first* character of the string. | `substr('Hello', 2, 2)` | `el` |
 | `substring(`*`string`*`, `*`start`*`, `*`length`*`)` | Extract substring of *length* characters starting from character *start*. Note that a *start* value of `1` refers to the *first* character of the string. | `substring('Hello', 2, 2)` | `el` |
+| `suffix(`*`string`*`, `*`search_string`*`)` | Return true if *string* ends with *search_string*. | `suffix('abc', 'bc')` | `true` |
 | `strpos(`*`string`*`, `*`characters`*`)`| Alias of `instr`. Return location of first occurrence of `characters` in `string`, counting from 1. Returns 0 if no match found. | `strpos('test test','es')` | 2 |
 | `to_base64(`*`blob`*`)`| Convert a blob to a base64 encoded string. Alias of base64. | `to_base64('A'::blob)` | `QQ==` |
 | `trim(`*`string`*`)`| Removes any spaces from either side of the *string* | `trim('␣␣␣␣test␣␣')` | `test` |

--- a/docs/sql/functions/char.md
+++ b/docs/sql/functions/char.md
@@ -33,11 +33,9 @@ This section describes functions and operators for examining and manipulating st
 | `lpad(`*`string`*`, `*`count`*`, `*`character`*`)`| Pads the *string*  with the character from the left until it has count characters | `lpad('hello', 10, '>')` | `>>>>>hello` |
 | `ltrim(`*`string`*`)`| Removes any spaces from the left side of the *string* | `ltrim('␣␣␣␣test␣␣')` | `test␣␣` |
 | `ltrim(`*`string`*`, `*`characters`*`)`| Removes any occurrences of any of the *characters* from the left side of the *string* | `ltrim('>>>>test<<', '><')` | `test<<` |
+| `md5(`*`value`*`)` | Returns the [MD5 hash](https://en.wikipedia.org/wiki/MD5) of the *value*  | `md5('123')` | `'202cb962ac59075b964b07152d234b70'` |
 | `nfc_normalize(`*`string`*`)`| Convert string to Unicode NFC normalized string. Useful for comparisons and ordering if text data is mixed between NFC normalized and not. | `nfc_normalize('ardèch')` | ``arde`ch`` |
 | `not_like_escape(`*`string`*`, `*`like_specifier`*`, `*`escape_character`*`)` | Returns false if the *string* matches the *like_specifier* (see [Pattern Matching](/docs/sql/functions/patternmatching)). *escape_character* is used to search for wildcard characters in the *string*. | `like_escape('a%c', 'a$%c', '$')` | `true` |
-| `ucase(`*`string`*`)`| Alias of `upper`. Convert *string* to upper case | `ucase('Hello')` | `HELLO` |
-| `upper(`*`string`*`)`| Convert *string* to upper case | `upper('Hello')` | `HELLO` |
-| `md5(`*`value`*`)` | Returns the [MD5 hash](https://en.wikipedia.org/wiki/MD5) of the *value*  | `md5('123')` | `'202cb962ac59075b964b07152d234b70'` |
 | `ord(`*`string`*`)`| Return ASCII character code of the leftmost character in a string.  | `ord('ü')` | `252` |
 | `position(`*`search_string`*` in `*`string`*`)` | Return location of first occurrence of `search_string` in `string`, counting from 1. Returns 0 if no match found. | `position('b' in 'abc')` | `2` |
 | `prefix(`*`string`*`, `*`search_string`*`)` | Return true if *string* starts with *search_string*. | `prefix('abc', 'ab')` | `true` |
@@ -69,7 +67,9 @@ This section describes functions and operators for examining and manipulating st
 | `to_base64(`*`blob`*`)`| Convert a blob to a base64 encoded string. Alias of base64. | `to_base64('A'::blob)` | `QQ==` |
 | `trim(`*`string`*`)`| Removes any spaces from either side of the *string* | `trim('␣␣␣␣test␣␣')` | `test` |
 | `trim(`*`string`*`, `*`characters`*`)`| Removes any occurrences of any of the *characters* from either side of the *string* | `trim('>>>>test<<', '><')` | `test` |
+| `ucase(`*`string`*`)`| Alias of `upper`. Convert *string* to upper case | `ucase('Hello')` | `HELLO` |
 | `unicode(`*`string`*`)`| Returns the unicode code of the first character of the *string* | `unicode('ü')` | `252` |
+| `upper(`*`string`*`)`| Convert *string* to upper case | `upper('Hello')` | `HELLO` |
 
 
 ## Text Similarity Functions

--- a/docs/sql/functions/date.md
+++ b/docs/sql/functions/date.md
@@ -24,16 +24,19 @@ Dates can also be manipulated with the [timestamp functions](/docs/sql/functions
 |:---|:---|:---|:---|
 | `current_date` | Current date (at start of current transaction) | | |
 | `date_diff(`*`part`*`, `*`startdate`*`, `*`enddate`*`)` | The number of [partition](/docs/sql/functions/datepart) boundaries between the dates | `date_diff('month', DATE '1992-09-15', DATE '1992-11-14')` | `2` |
+| `datediff(`*`part`*`, `*`startdate`*`, `*`enddate`*`)` | Alias of date_diff. The number of [partition](/docs/sql/functions/datepart) boundaries between the dates | `datediff('month', DATE '1992-09-15', DATE '1992-11-14')` | `2` |
 | `date_part(`*`part`*`, `*`date`*`)` | Get the [subfield](/docs/sql/functions/datepart) (equivalent to `extract`) | `date_part('year', DATE '1992-09-20')` | `1992` |
+| `datepart(`*`part`*`, `*`date`*`)` | Alias of date_part. Get the [subfield](/docs/sql/functions/datepart) (equivalent to `extract`) | `datepart('year', DATE '1992-09-20')` | `1992` |
 | `date_sub(`*`part`*`, `*`startdate`*`, `*`enddate`*`)` | The number of complete [partitions](/docs/sql/functions/datepart) between the dates | `date_sub('month', DATE '1992-09-15', DATE '1992-11-14')` | `1` |
+| `datesub(`*`part`*`, `*`startdate`*`, `*`enddate`*`)` | Alias of date_sub. The number of complete [partitions](/docs/sql/functions/datepart) between the dates | `datesub('month', DATE '1992-09-15', DATE '1992-11-14')` | `1` |
 | `date_trunc(`*`part`*`, `*`date`*`)` | Truncate to specified [precision](/docs/sql/functions/datepart) | `date_trunc('month', DATE '1992-03-07')` | `1992-03-01` |
+| `datetrunc(`*`part`*`, `*`date`*`)` | Alias of date_trunc. Truncate to specified [precision](/docs/sql/functions/datepart) | `datetrunc('month', DATE '1992-03-07')` | `1992-03-01` |
 | `dayname(`*`date`*`)` | The (English) name of the weekday | `dayname(DATE '1992-09-20')` | `Sunday` |
 | `extract(`*`part`* `from `*`date`*`)` | Get [subfield](/docs/sql/functions/datepart) from a date | `extract('year' FROM DATE '1992-09-20')` | `1992` |
 | `greatest(`*`date`*`, `*`date`*`)` | The later of two dates | `greatest(DATE '1992-09-20', DATE '1992-03-07')` | `1992-09-20` |
-| `last_day(`*`date`*`)` | The last day of the month | `last_day(DATE '1992-09-20')` | `1992-09-30` |
+| `last_day(`*`date`*`)` | The last day of the corresponding month in the date | `last_day(DATE '1992-09-20')` | `1992-09-30` |
 | `least(`*`date`*`, `*`date`*`)` | The earlier of two dates | `least(DATE '1992-09-20', DATE '1992-03-07')` | `1992-03-07` |
 | `monthname(`*`date`*`)` | The (English) name of the month | `monthname(DATE '1992-09-20')` | `September` |
-| `last_day(`*`date`*`)` | Last day of the corresponding month in the date | `last_day(DATE '1992-09-20')` | `1992-09-30` |
 | `strftime(date, format)` | Converts a date to a string according to the [format string](/docs/sql/functions/dateformat) | `strftime(date '1992-01-01', '%a, %-d %B %Y')` | `Wed, 1 January 1992` |
 
 There are also dedicated extraction functions to get the [subfields](/docs/sql/functions/datepart).

--- a/docs/sql/functions/datepart.md
+++ b/docs/sql/functions/datepart.md
@@ -73,6 +73,7 @@ There are dedicated extraction functions to get certain subfields:
 | `isoyear(`*`date`*`)` | ISO Year number (Starts on Monday of week containing Jan 4th) | `isoyear(date '2022-01-01')` | `2021` |
 | `week(`*`date`*`)` | ISO Week | `week(date '1992-02-15')` | `7` |
 | `weekofyear(`*`date`*`)` | ISO Week (synonym) | `weekofyear(date '1992-02-15')` | `7` |
+| `yearweek(`*`date`*`)` | `BIGINT` of combined ISO Year number and 2-digit version of ISO Week number | `yearweek(date '1992-02-15')` | `199207` |
 | `dayofyear(`*`date`*`)` | Numeric ISO weekday (Monday = 1, Sunday = 7) | `isodow(date '1992-02-15')` | `46` |
 | `quarter(`*`date`*`)` | Quarter | `quarter(date '1992-02-15')` | `1` |
 | `era(`*`date`*`)` | Calendar era | `era(date '0044-03-15 (BC)')` | `0` |

--- a/docs/sql/functions/nested.md
+++ b/docs/sql/functions/nested.md
@@ -52,6 +52,7 @@ In the descriptions, `l` is the three element list `[4, 5, 6]`.
 |:---|:---|:---|:---|
 | `map[`*`entry`*`]` | Alias for `element_at` | `map([100, 5], ['a', 'b'])[100]` | `[a]` |
 | `element_at(`*`map, key`*`)` | Return a list containing the value for a given key or an empty list if the key is not contained in the map. The type of the key provided in the second parameter must match the type of the map's keys else an error is returned. | `element_at(map([100, 5], [42, 43]),100);` | `[42]` |
+| `map_extract(`*`map, key`*`)` | Alias of `element_at`. Return a list containing the value for a given key or an empty list if the key is not contained in the map. The type of the key provided in the second parameter must match the type of the map's keys else an error is returned. | `map_extract(map([100, 5], [42, 43]),100);` | `[42]` |
 | `cardinality(`*`map`*`)` | Return the size of the map (or the number of entries in the map). | `cardinality( map([4, 2], ['a', 'b']) );` | `2` |
 | `map()` | Returns an empty map. | `map()` | `{}` |
 

--- a/docs/sql/functions/numeric.md
+++ b/docs/sql/functions/numeric.md
@@ -52,6 +52,7 @@ The table below shows the available mathematical functions.
 | `ln(x)` | computes the natural logarithm of *x* | `ln(2)` | 0.693 |
 | `log(x)` | computes the 10-log of *x* | `log(100)` | 2 |
 | `log2(x)` | computes the 2-log of *x* | `log2(8)` | 3 |
+| `log10(x)` | alias of `log`. computes the 10-log of *x* | `log10(1000)` | 3 |
 | `pi()` | returns the value of pi | `pi()` | 3.141592653589793 |
 | `pow(x, y)` | computes x to the power of y | `pow(2, 3)` | 8 |
 | `radians(x)` | converts degrees to radians | `radians(90)` | 1.5707963267948966 |

--- a/docs/sql/functions/numeric.md
+++ b/docs/sql/functions/numeric.md
@@ -67,4 +67,3 @@ The table below shows the available mathematical functions.
 | `xor(x)` | bitwise XOR | `xor(17, 5)` | 20 |
 | `tan(x)` | computes the tangent of x | `tan(90)` | -1.995200412208242 |
 | `@` | absolute value (parentheses optional if operating on a column) | `@(-2)` | 2 |
-| `!__postfix` | See `!` operator. Factorial of x. Computes the product of the current integer and all integers below it. Function name must be wrapped in double quotes. | `"!__postfix"(5)` | 120 |

--- a/docs/sql/functions/numeric.md
+++ b/docs/sql/functions/numeric.md
@@ -20,8 +20,9 @@ The table below shows the available mathematical operators for numeric types.
 | `|` | bitwise OR | `32 | 3` | 35 |
 | `<<` | bitwise shift left | `1 << 4` | 16 |
 | `>>` | bitwise shift right | `8 >> 2` | 2 |
+| `!` | factorial of x. Computes the product of the current integer and all integers below it  | `4!` | 24 |
 
-The modulo and bitwise operators work only on integral data types, whereas the others are available for all numeric data types.
+The modulo, bitwise, and factorial operators work only on integral data types, whereas the others are available for all numeric data types.
 
 ## Numeric Functions
 The table below shows the available mathematical functions.
@@ -29,7 +30,6 @@ The table below shows the available mathematical functions.
 | Function | Description | Example | Result |
 |:---|:---|:---|:---|
 | `abs(x)` | absolute value | `abs(-17.4)` | 17.4 |
-| `@` | absolute value (parentheses optional if operating on a column) | `@(-2)` | 2 |
 | `acos(x)` | computes the arccosine of x | `acos(0.5)` | 1.0471975511965976 |
 | `asin(x)` | computes the arcsine of x | `asin(0.5)` | 0.5235987755982989 |
 | `atan2(x)` | computes the arctangent of x | `atan2(0.5)` | 0.4636476090008061 |
@@ -43,16 +43,19 @@ The table below shows the available mathematical functions.
 | `cot(x)` | computes the cotangent of x | `cot(0.5)` | 1.830487721712452 |
 | `degrees(x)` | converts radians to degrees | `degrees(pi())` | 180 |
 | `even(x)` | round to next even number by rounding away from zero. | `even(2.9)` | 4 |
+| `factorial(x)` | See `!` operator. Computes the product of the current integer and all integers below it | `factorial(4)` | 24 |
 | `floor(x)` | rounds the number down | `floor(17.4)` | 17 |
+| `gamma(x)` | interpolation of (x-1) factorial (so decimal inputs are allowed) | `gamma(5.5)` | 52.34277778455352 |
 | `greatest(x1, x2, ...)` | selects the largest value | `greatest(3, 2, 4, 4)` | 4 |
 | `least(x1, x2, ...)` | selects the smallest value | `least(3, 2, 4, 4)` | 2 |
+| `lgamma(x)` | computes the log of the `gamma` function. | `lgamma(2)` | 0 |
 | `ln(x)` | computes the natural logarithm of *x* | `ln(2)` | 0.693 |
 | `log(x)` | computes the 10-log of *x* | `log(100)` | 2 |
 | `log2(x)` | computes the 2-log of *x* | `log2(8)` | 3 |
 | `pi()` | returns the value of pi | `pi()` | 3.141592653589793 |
 | `pow(x, y)` | computes x to the power of y | `pow(2, 3)` | 8 |
 | `radians(x)` | converts degrees to radians | `radians(90)` | 1.5707963267948966 |
-| `random()` | returns a random number between 0 and 1 | `random()` | ... |
+| `random()` | returns a random number between 0 and 1 | `random()` | various |
 | `round(v numeric, s int)` | round to *s* decimal places | `round(42.4332, 2)` | 42.43 |
 | `setseed(x)` | sets the seed to be used for the random function | `setseed(0.42)` | |
 | `sin(x)` | computes the sin of x | `sin(90)` | 0.8939966636005579 |
@@ -60,3 +63,5 @@ The table below shows the available mathematical functions.
 | `sqrt(x)` | returns the square root of the number | `sqrt(9)` | 3 |
 | `xor(x)` | bitwise XOR | `xor(17, 5)` | 20 |
 | `tan(x)` | computes the tangent of x | `tan(90)` | -1.995200412208242 |
+| `@` | absolute value (parentheses optional if operating on a column) | `@(-2)` | 2 |
+| `!__postfix` | See `!` operator. Factorial of x. Computes the product of the current integer and all integers below it. Function name must be wrapped in double quotes. | `"!__postfix"(5)` | 120 |

--- a/docs/sql/functions/numeric.md
+++ b/docs/sql/functions/numeric.md
@@ -37,6 +37,7 @@ The table below shows the available mathematical functions.
 | `bit_count(x)` | returns the number of bits that are set | `bit_count(31)` | 5 |
 | `cbrt(x)` | returns the cube root of the number | `cbrt(8)` | 2 |
 | `ceil(x)` | rounds the number up | `ceil(17.4)` | 18 |
+| `ceiling(x)` | rounds the number up. Alias of `ceil`. | `ceiling(17.4)` | 18 |
 | `chr(x)` | returns a character which is corresponding the the ASCII code value or Unicode code point | `chr(65)` | A |
 | `cos(x)` | computes the cosine of x | `cos(90)` | -0.4480736161291701 |
 | `cot(x)` | computes the cotangent of x | `cot(0.5)` | 1.830487721712452 |

--- a/docs/sql/functions/numeric.md
+++ b/docs/sql/functions/numeric.md
@@ -42,6 +42,7 @@ The table below shows the available mathematical functions.
 | `cos(x)` | computes the cosine of x | `cos(90)` | -0.4480736161291701 |
 | `cot(x)` | computes the cotangent of x | `cot(0.5)` | 1.830487721712452 |
 | `degrees(x)` | converts radians to degrees | `degrees(pi())` | 180 |
+| `even(x)` | round to next even number by rounding away from zero. | `even(2.9)` | 4 |
 | `floor(x)` | rounds the number down | `floor(17.4)` | 17 |
 | `greatest(x1, x2, ...)` | selects the largest value | `greatest(3, 2, 4, 4)` | 4 |
 | `least(x1, x2, ...)` | selects the smallest value | `least(3, 2, 4, 4)` | 2 |

--- a/docs/sql/functions/numeric.md
+++ b/docs/sql/functions/numeric.md
@@ -53,8 +53,10 @@ The table below shows the available mathematical functions.
 | `log(x)` | computes the 10-log of *x* | `log(100)` | 2 |
 | `log2(x)` | computes the 2-log of *x* | `log2(8)` | 3 |
 | `log10(x)` | alias of `log`. computes the 10-log of *x* | `log10(1000)` | 3 |
+| `nextafter(x, y)` | return the next floating point value after *x* in the direction of *y* | `nextafter(1::float, 2::float)` | 1.0000001 |
 | `pi()` | returns the value of pi | `pi()` | 3.141592653589793 |
 | `pow(x, y)` | computes x to the power of y | `pow(2, 3)` | 8 |
+| `power(x, y)` | Alias of `pow`. computes x to the power of y | `power(2, 3)` | 8 |
 | `radians(x)` | converts degrees to radians | `radians(90)` | 1.5707963267948966 |
 | `random()` | returns a random number between 0 and 1 | `random()` | various |
 | `round(v numeric, s int)` | round to *s* decimal places | `round(42.4332, 2)` | 42.43 |

--- a/docs/sql/functions/numeric.md
+++ b/docs/sql/functions/numeric.md
@@ -14,6 +14,8 @@ The table below shows the available mathematical operators for numeric types.
 | `*` | multiplication | `2 * 3` | 6 |
 | `/` | division | `4 / 2` | 2 |
 | `%` | modulo (remainder) | `5 % 4` | 1 |
+| `**` | exponent | `3 ** 4` | 81 |
+| `^` | exponent (alias for `**`) | `3 ^ 4` | 81 |
 | `&` | bitwise AND | `91 & 15` | 11 |
 | `|` | bitwise OR | `32 | 3` | 35 |
 | `<<` | bitwise shift left | `1 << 4` | 16 |
@@ -27,6 +29,7 @@ The table below shows the available mathematical functions.
 | Function | Description | Example | Result |
 |:---|:---|:---|:---|
 | `abs(x)` | absolute value | `abs(-17.4)` | 17.4 |
+| `@` | absolute value (parentheses optional if operating on a column) | `@(-2)` | 2 |
 | `acos(x)` | computes the arccosine of x | `acos(0.5)` | 1.0471975511965976 |
 | `asin(x)` | computes the arcsine of x | `asin(0.5)` | 0.5235987755982989 |
 | `atan2(x)` | computes the arctangent of x | `atan2(0.5)` | 0.4636476090008061 |

--- a/docs/sql/functions/patternmatching.md
+++ b/docs/sql/functions/patternmatching.md
@@ -29,6 +29,13 @@ Some examples:
 'abc' NOT LIKE '%c'  -- FALSE
 ```
 
+The keyword `ILIKE` can be used instead of `LIKE` to make the match case-insensitive according to the active locale. 
+
+```sql
+'abc' ILIKE '%C' -- TRUE
+'abc' NOT ILIKE '%C' -- FALSE
+```
+
 To search within a string for a character that is a wildcard (`%` or `_`), the pattern must use an `ESCAPE` clause and an escape character to indicate the wildcard should be treated as a literal character instead of a wildcard. See an example below.
 
 Additionally, the function `like_escape` has the same functionality as a `LIKE` expression with an `ESCAPE` clause, but using function syntax. See the [Text Functions Docs](/docs/sql/functions/char) for details.
@@ -39,7 +46,15 @@ Additionally, the function `like_escape` has the same functionality as a `LIKE` 
 'azc' LIKE 'a$%c' ESCAPE '$'  -- FALSE
 ```
 
-<!--The key word ILIKE can be used instead of LIKE to make the match case-insensitive according to the active locale. This is not in the SQL standard.-->
+There are also alternative characters that can be used as keywords in place of `LIKE` expressions. These enhance Postgres compatibility.
+
+| LIKE-style | Postgres-style |
+|:---|:---|
+| `LIKE` | `~~` |
+| `NOT LIKE` | `!~~` |
+| `ILIKE` | `~~*` |
+| `NOT ILIKE` | `!~~*` |
+
 
 ## SIMILAR TO
 <div id="rrdiagram2"></div>
@@ -56,6 +71,13 @@ Some examples:
 'abc' SIMILAR TO '.*(b|d).*' -- TRUE
 'abc' SIMILAR TO '(b|c).*'   -- FALSE
 ```
+
+There are also alternative characters that can be used as keywords in place of `SIMILAR TO` expressions. These follow POSIX syntax.
+
+| SIMILAR TO-style | POSIX-style |
+|:---|:---|
+| `SIMILAR TO` | `~` |
+| `NOT SIMILAR TO` | `!~` |
 
 ## Regular Expressions
 

--- a/docs/sql/functions/patternmatching.md
+++ b/docs/sql/functions/patternmatching.md
@@ -15,6 +15,8 @@ The `LIKE` expression returns true if the string matches the supplied pattern. (
 
 If pattern does not contain percent signs or underscores, then the pattern only represents the string itself; in that case `LIKE` acts like the equals operator. An underscore (`_`) in pattern stands for (matches) any single character; a percent sign (`%`) matches any sequence of zero or more characters.
 
+`LIKE` pattern matching always covers the entire string. Therefore, if it's desired to match a sequence anywhere within a string, the pattern must start and end with a percent sign.
+
 Some examples:
 
 ```sql
@@ -24,9 +26,18 @@ Some examples:
 'abc' LIKE 'c'   -- FALSE
 'abc' LIKE 'c%'  -- FALSE
 'abc' LIKE '%c'  -- TRUE
+'abc' NOT LIKE '%c'  -- FALSE
 ```
 
-`LIKE` pattern matching always covers the entire string. Therefore, if it's desired to match a sequence anywhere within a string, the pattern must start and end with a percent sign.
+To search within a string for a character that is a wildcard (`%` or `_`), the pattern must use an `ESCAPE` clause and an escape character to indicate the wildcard should be treated as a literal character instead of a wildcard. See an example below.
+
+Additionally, the function `like_escape` has the same functionality as a `LIKE` expression with an `ESCAPE` clause, but using function syntax. See the [Text Functions Docs](/docs/sql/functions/char) for details.
+
+```sql
+--Search for strings with 'a' then a literal percent sign then 'c'
+'a%c' LIKE 'a$%c' ESCAPE '$'  -- TRUE
+'azc' LIKE 'a$%c' ESCAPE '$'  -- FALSE
+```
 
 <!--The key word ILIKE can be used instead of LIKE to make the match case-insensitive according to the active locale. This is not in the SQL standard.-->
 

--- a/docs/sql/functions/utility.md
+++ b/docs/sql/functions/utility.md
@@ -18,5 +18,6 @@ The functions below are difficult to categorize into specific function types and
 | `currval('sequence_name')` | Return the current value of the sequence. Note that `nextval` must be called at least once prior to calling `currval`. | `currval('my_sequence_name')` | `1` |
 | `gen_random_uuid()` | Alias of `uuid`. Return a random uuid similar to this: eeccb8c5-9943-b2bb-bb5e-222f4e14b687. | `gen_random_uuid()` | various |
 | `icu_sort_key(string , collator)` | Surrogate key used to sort special characters according to the specific locale. Collator parameter is optional. Valid only when ICU extension is installed. | `icu_sort_key('ö','DE')` | 460145960106 |
+| `md5(string)` | Return an md5 one-way hash of the *string*. | `md5('123')` | `'202cb962ac59075b964b07152d234b70'` |
 | `nextval('sequence_name')` | Return the following value of the sequence. | `nextval('my_sequence_name')` | `2` |
 | `uuid()` | Return a random uuid similar to this: eeccb8c5-9943-b2bb-bb5e-222f4e14b687. | `uuid()` | various |

--- a/docs/sql/functions/utility.md
+++ b/docs/sql/functions/utility.md
@@ -11,3 +11,4 @@ The functions below are difficult to categorize into specific function types and
 | Function | Description | Example | Result |
 |:---|:---|:---|:---|
 | `alias(column)` | Return the name of the column | `alias(column1)` | `'column1'` |
+| `coalesce(expr, ...)` | Return the first expression that evaluates to a non-`NULL` value. Accepts 1 or more parameters. Each expression can be a column, literal value, 

--- a/docs/sql/functions/utility.md
+++ b/docs/sql/functions/utility.md
@@ -1,0 +1,13 @@
+---
+layout: docu
+title: Utility Functions
+selected: Documentation/Functions/Utility Functions
+expanded: Functions
+---
+
+## Utility Functions
+The functions below are difficult to categorize into specific function types and are broadly useful. 
+
+| Function | Description | Example | Result |
+|:---|:---|:---|:---|
+| `alias(column)` | Return the name of the column | `alias(column1)` | `'column1'` |

--- a/docs/sql/functions/utility.md
+++ b/docs/sql/functions/utility.md
@@ -12,6 +12,8 @@ The functions below are difficult to categorize into specific function types and
 |:---|:---|:---|:---|
 | `alias(column)` | Return the name of the column | `alias(column1)` | `'column1'` |
 | `coalesce(expr, ...)` | Return the first expression that evaluates to a non-`NULL` value. Accepts 1 or more parameters. Each expression can be a column, literal value, function result, or many others.  | `coalesce(NULL,NULL,'default_string')` | `'default_string'` |
+| `current_schema()` | Return the name of the currently active schema. Default is main. | `current_schema()` | `'main'` |
+| `current_schemas(boolean)` | Return list of schemas. Pass a parameter of `True` to include implicit schemas. | `current_schemas(true)` | `['temp', 'main', 'pg_catalog']` |
 | `current_setting('setting_name')` | Return the current value of the configuration setting | `current_setting('access_mode')` | `'automatic'` |
 | `currval('sequence_name')` | Return the current value of the sequence. Note that `nextval` must be called at least once prior to calling `currval`. | `currval('my_sequence_name')` | `1` |
 | `nextval('sequence_name')` | Return the following value of the sequence. | `nextval('my_sequence_name')` | `2` |

--- a/docs/sql/functions/utility.md
+++ b/docs/sql/functions/utility.md
@@ -20,4 +20,9 @@ The functions below are difficult to categorize into specific function types and
 | `icu_sort_key(string , collator)` | Surrogate key used to sort special characters according to the specific locale. Collator parameter is optional. Valid only when ICU extension is installed. | `icu_sort_key('ö','DE')` | 460145960106 |
 | `md5(string)` | Return an md5 one-way hash of the *string*. | `md5('123')` | `'202cb962ac59075b964b07152d234b70'` |
 | `nextval('sequence_name')` | Return the following value of the sequence. | `nextval('my_sequence_name')` | `2` |
+| `pg_typeof(expression)` | Returns the lower case name of the data type of the result of the expression. For Postgres compatibility. | `pg_typeof('abc')` | `'varchar'` |
+| `stats(expression)` | Returns a string with statistics about the expression. Expression can be a column, constant, or SQL expression. | `stats(5)` | `'[Min: 5, Max: 5][Has Null: false]'` |
+| `txid_current()` | Returns the current transaction's ID (a `BIGINT`). It will assign a new one if the current transaction does not have one already. | `txid_current()` | various |
+| `typeof(expression)` | Returns the name of the data type of the result of the expression. | `typeof('abc')` | `'VARCHAR'` |
 | `uuid()` | Return a random uuid similar to this: eeccb8c5-9943-b2bb-bb5e-222f4e14b687. | `uuid()` | various |
+| `version()` | Return the currently active version of DuckDB in this format: `v0.3.2` | `version()` | various |

--- a/docs/sql/functions/utility.md
+++ b/docs/sql/functions/utility.md
@@ -11,4 +11,7 @@ The functions below are difficult to categorize into specific function types and
 | Function | Description | Example | Result |
 |:---|:---|:---|:---|
 | `alias(column)` | Return the name of the column | `alias(column1)` | `'column1'` |
-| `coalesce(expr, ...)` | Return the first expression that evaluates to a non-`NULL` value. Accepts 1 or more parameters. Each expression can be a column, literal value, 
+| `coalesce(expr, ...)` | Return the first expression that evaluates to a non-`NULL` value. Accepts 1 or more parameters. Each expression can be a column, literal value, function result, or many others.  | `coalesce(NULL,NULL,'default_string')` | `'default_string'` |
+| `current_setting('setting_name')` | Return the current value of the configuration setting | `current_setting('access_mode')` | `'automatic'` |
+| `currval('sequence_name')` | Return the current value of the sequence. Note that `nextval` must be called at least once prior to calling `currval`. | `currval('my_sequence_name')` | `1` |
+| `nextval('sequence_name')` | Return the following value of the sequence. | `nextval('my_sequence_name')` | `2` |

--- a/docs/sql/functions/utility.md
+++ b/docs/sql/functions/utility.md
@@ -16,4 +16,7 @@ The functions below are difficult to categorize into specific function types and
 | `current_schemas(boolean)` | Return list of schemas. Pass a parameter of `True` to include implicit schemas. | `current_schemas(true)` | `['temp', 'main', 'pg_catalog']` |
 | `current_setting('setting_name')` | Return the current value of the configuration setting | `current_setting('access_mode')` | `'automatic'` |
 | `currval('sequence_name')` | Return the current value of the sequence. Note that `nextval` must be called at least once prior to calling `currval`. | `currval('my_sequence_name')` | `1` |
+| `gen_random_uuid()` | Alias of `uuid`. Return a random uuid similar to this: eeccb8c5-9943-b2bb-bb5e-222f4e14b687. | `gen_random_uuid()` | various |
+| `icu_sort_key(string , collator)` | Surrogate key used to sort special characters according to the specific locale. Collator parameter is optional. | `icu_sort_key('ö','DE')` | 460145960106 |
 | `nextval('sequence_name')` | Return the following value of the sequence. | `nextval('my_sequence_name')` | `2` |
+| `uuid()` | Return a random uuid similar to this: eeccb8c5-9943-b2bb-bb5e-222f4e14b687. | `uuid()` | various |

--- a/docs/sql/functions/utility.md
+++ b/docs/sql/functions/utility.md
@@ -17,6 +17,6 @@ The functions below are difficult to categorize into specific function types and
 | `current_setting('setting_name')` | Return the current value of the configuration setting | `current_setting('access_mode')` | `'automatic'` |
 | `currval('sequence_name')` | Return the current value of the sequence. Note that `nextval` must be called at least once prior to calling `currval`. | `currval('my_sequence_name')` | `1` |
 | `gen_random_uuid()` | Alias of `uuid`. Return a random uuid similar to this: eeccb8c5-9943-b2bb-bb5e-222f4e14b687. | `gen_random_uuid()` | various |
-| `icu_sort_key(string , collator)` | Surrogate key used to sort special characters according to the specific locale. Collator parameter is optional. | `icu_sort_key('ö','DE')` | 460145960106 |
+| `icu_sort_key(string , collator)` | Surrogate key used to sort special characters according to the specific locale. Collator parameter is optional. Valid only when ICU extension is installed. | `icu_sort_key('ö','DE')` | 460145960106 |
 | `nextval('sequence_name')` | Return the following value of the sequence. | `nextval('my_sequence_name')` | `2` |
 | `uuid()` | Return a random uuid similar to this: eeccb8c5-9943-b2bb-bb5e-222f4e14b687. | `uuid()` | various |

--- a/docs/sql/statements/create_sequence.md
+++ b/docs/sql/statements/create_sequence.md
@@ -23,6 +23,16 @@ SELECT nextval('serial');
      101
 ```
 
+Optionally you may also view the current number from this sequence. 
+Note that the `nextval` function must have already been called before calling `currval`.
+```sql
+SELECT currval('serial');
+
+ currval
+---------
+     101
+```
+
 Use this sequence in an `INSERT` command:
 
 ```sql

--- a/js/expressions/like.js
+++ b/js/expressions/like.js
@@ -4,7 +4,13 @@ function GenerateLike(options = {}) {
 		Expression("string"),
 		Optional(Keyword("NOT"), "skip"),
 		Keyword("LIKE"),
-		Expression("pattern")
+		Expression("pattern"),
+		Optional(
+			Sequence([
+				Keyword('ESCAPE'),
+				Expression('escape_character')
+			])
+		)
 	])
 }
 


### PR DESCRIPTION
This documents many additional scalar functions. Let me know what feedback you have! Some other changes to how functions are documented include:

- Added a Utility Functions page
- Exposed the Catalog Functions page already made by @hawkfish (and made slight tweaks)
- Added a Text Similarity Functions section to the text functions page (open to feedback here!)
- Added alternative syntax to pattern matching docs (Ex: ~~ instead of LIKE)

Remaining TODOs include:

- [ ] Adding the GLOB syntax to the pattern matching docs (upcoming PR in next few days)
- [ ] make_date / make_time functions (I think you had already done some work here @hawkfish?)
- [ ] enum_first / etc. (@pdet - I think you may have some work on those already maybe?)
- [ ] Documenting other types of functions like macros and table functions
- [ ] Automating the construction of the scalar docs. I've built a basic parser for pulling the existing markdown tables that can be used to build a flat file that contains all of the descriptions and examples we currently have. I likely need a bit of help on the exact next steps to take here!
- [ ] Standardizing how we handle aliases. In some cases we have another column for aliases, in others we have another row. Let me know which format you prefer!
- [ ] Splitting up the text functions into sections.