### PR TITLE
Add module alias for pyarrow

### DIFF
--- a/docs/guides/python/import_arrow.md
+++ b/docs/guides/python/import_arrow.md
@@ -10,7 +10,7 @@ selected: Import From Apache Arrow
 
 ```py
 import duckdb
-import pyarrow
+import pyarrow as pa
 
 # connect to an in-memory database
 con = duckdb.connect()


### PR DESCRIPTION
pyarrow is used as `pa` in code, but there was not `pa` alias defined.

All other imports of pyarrow are fine:
![image](https://user-images.githubusercontent.com/10337788/168235891-a878067b-a230-4fbc-ae5a-60100f66a021.png)
