### PR TITLE
Issue with jekyll serve related to webrick

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,6 @@ The site is built using [Jekyll](https://jekyllrb.com/). To build the site local
 gem uninstall eventmachine
 gem install eventmachine --platform ruby
 ```
+You might have to install `webrick` to get `jekyll serve` to work, you can do so by running `gem install webrick`.  
 Finally, navigate to the directory where you have cloned duckdb-web and run `jekyll serve`. The website can then be browsed by going to `localhost:4000` in your browser.
 


### PR DESCRIPTION
Added an extra line to the README providing help when faced with the following error:
```
<internal:/Users/user_name/.rubies/ruby-3.1.2/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require': cannot load such file -- webrick (LoadError)
```