### PR TITLE
added missing closing parenthese in foreign key railroad diagram

### DIFF
--- a/js/statements/createtable.js
+++ b/js/statements/createtable.js
@@ -24,6 +24,7 @@ function GenerateTableConstraints(options) {
 			Keyword("KEY"),
 			Keyword("("),
 			OneOrMore(Expression("column-name"), ","),
+			Keyword(")"),
 			Keyword("REFERENCES"),
 			Expression("foreign-table"),
 			Keyword("("),


### PR DESCRIPTION
On sql/statements/create_table there was a parenthese missing to close the list of columns