### PR TITLE
'.jekyll-metadata' folder added to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ autoconf/autom4te.cache
 #==============================================================================#
 # Directories to ignore (do not add trailing '/'s, they skip symlinks).
 #==============================================================================#
+# Metadata created when running jekyll locally
+.jekyll-metadata
+
 # External projects that are tracked independently.
 projects/*
 !projects/*.*


### PR DESCRIPTION
Small annoyance removed, every time jekyll does anything, it creates/alters .jekyll-metadata and it shows up in the untracked files list.

If this shouldn't be ignored, let me know and please also tell me how to stop it from showing up in the untracked files 👍 