### PR TITLE
small typo: 'hiearchy -> hierarchy

### DIFF
--- a/docs/sql/query_syntax/with.md
+++ b/docs/sql/query_syntax/with.md
@@ -39,7 +39,7 @@ SELECT * FROM cte2;
 
 #### Tree traversal
 
-`WITH RECURSIVE` can be used to traverse trees. For example, take a hiearchy of tags:
+`WITH RECURSIVE` can be used to traverse trees. For example, take a hierarchy of tags:
 
 ![](with-recursive-tree-example.png)
 


### PR DESCRIPTION
Fixes a small typo on the WITH clause documentation page