### PR TITLE
Generated column doc

### DIFF
--- a/docs/sql/statements/create_table.md
+++ b/docs/sql/statements/create_table.md
@@ -58,7 +58,7 @@ CREATE TABLE IF NOT EXISTS t1(i INTEGER, j INTEGER);
 
 The `[type] [GENERATED ALWAYS] AS ( expr ) [VIRTUAL|STORED]` syntax will create a generated column. The data in this kind of column is generated from its expression, which can reference other (regular or generated) columns of the table. Since they are produced by calculations, these columns can not be inserted into directly.
 
-It is also possible to leave out the type when declaring a generated column. Since an expression has a return type, its type will be automatically derived from the expression.
+When possible, DuckDB will infer the type of the generated column based on the expression's return type. This often allows the type to be left out when declaring a generated column. 
   
 Generated columns come in two varieties: `VIRTUAL` and `STORED`.  
 The data of virtual generated columns is not stored on disk, instead it is computed from the expression every time the column is referenced (through a select statement).  
@@ -70,7 +70,7 @@ Currently only the `VIRTUAL` kind is supported, and it is also the default optio
 ```sql
 -- The simplest syntax for a generated column. 
 -- The type is derived from the expression, and it is assume to be VIRTUAL
-CREATE TABLE t1(x FLOAT, two_x GENERATED ALWAYS AS (2 * x))
+CREATE TABLE t1(x FLOAT, two_x AS (2 * x))
 
 -- Fully specifying the same generated column for completeness
 CREATE TABLE t1(x FLOAT, two_x FLOAT GENERATED ALWAYS AS (2 * x) VIRTUAL)

--- a/docs/sql/statements/create_table.md
+++ b/docs/sql/statements/create_table.md
@@ -69,7 +69,7 @@ Currently only the `VIRTUAL` kind is supported, and it is also the default optio
 
 ```sql
 -- The simplest syntax for a generated column. 
--- The type is derived from the expression, and the varient defaults to VIRTUAL
+-- The type is derived from the expression, and the variant defaults to VIRTUAL
 CREATE TABLE t1(x FLOAT, two_x AS (2 * x))
 
 -- Fully specifying the same generated column for completeness

--- a/docs/sql/statements/create_table.md
+++ b/docs/sql/statements/create_table.md
@@ -58,7 +58,7 @@ CREATE TABLE IF NOT EXISTS t1(i INTEGER, j INTEGER);
 
 The `[type] [GENERATED ALWAYS] AS ( expr ) [VIRTUAL|STORED]` syntax will create a generated column. The data in this kind of column is generated from its expression, which can reference other (regular or generated) columns of the table. Since they are produced by calculations, these columns can not be inserted into directly.
 
-When possible, DuckDB will infer the type of the generated column based on the expression's return type. This often allows the type to be left out when declaring a generated column. 
+DuckDB can infer the type of the generated column based on the expression's return type. This allows you to leave out the type when declaring a generated column. It is possible to explicitly set a type, but insertions into the referenced columns might fail if the type can not be cast to the type of the generated column.
   
 Generated columns come in two varieties: `VIRTUAL` and `STORED`.  
 The data of virtual generated columns is not stored on disk, instead it is computed from the expression every time the column is referenced (through a select statement).  
@@ -69,7 +69,7 @@ Currently only the `VIRTUAL` kind is supported, and it is also the default optio
 
 ```sql
 -- The simplest syntax for a generated column. 
--- The type is derived from the expression, and it is assume to be VIRTUAL
+-- The type is derived from the expression, and the varient defaults to VIRTUAL
 CREATE TABLE t1(x FLOAT, two_x AS (2 * x))
 
 -- Fully specifying the same generated column for completeness

--- a/docs/sql/statements/create_table.md
+++ b/docs/sql/statements/create_table.md
@@ -22,6 +22,7 @@ CREATE TABLE t1 AS SELECT 42 AS i, 84 AS j;
 -- create a table from a CSV file using AUTO-DETECT (i.e., Automatically detecting column names and types)
 CREATE TABLE t1 AS SELECT * FROM read_csv_auto ('path/file.csv');
 ```
+### Temporary Tables
 
 Temporary tables can be created using a `CREATE TEMP TABLE` statement (see diagram below). 
 Temporary tables are session scoped (similar to Postgres for example), meaning that only the specific connection that created them can access them, and once the connection to DuckDB is closed they will be automatically dropped. 
@@ -35,12 +36,16 @@ CREATE TEMP TABLE t1 AS SELECT * FROM read_csv_auto ('path/file.csv');
 SET temp_directory='/path/to/directory/';
 ```
 
+### Create or Replace
+
 The `CREATE OR REPLACE` syntax allows a new table to be created or for an existing table to be overwritten by the new table. This is shorthand for dropping the existing table and then creating the new one.
 
 ```sql
 -- create a table with two integer columns (i and j) even if t1 already exists
 CREATE OR REPLACE TABLE t1(i INTEGER, j INTEGER);
 ```
+
+### If Not Exists
 
 The `IF NOT EXISTS` syntax will only proceed with the creation of the table if it does not already exist. If the table already exists, no action will be taken and the existing table will remain in the database. 
 
@@ -49,16 +54,27 @@ The `IF NOT EXISTS` syntax will only proceed with the creation of the table if i
 CREATE TABLE IF NOT EXISTS t1(i INTEGER, j INTEGER);
 ```
 
-The `[type] [GENERATED ALWAYS] AS ( expr ) [VIRTUAL|STORED]` syntax will create a generated column, these columns can not be inserted into directly. Instead their data is generated from their expression, which can reference other (regular or generated) columns of the table.
+### Generated Columns
 
-Because an expression has a return type, it is also possible to leave out the type when declaring a generated column, its type will then be derived from the expression.
+The `[type] [GENERATED ALWAYS] AS ( expr ) [VIRTUAL|STORED]` syntax will create a generated column. The data in this kind of column is generated from its expression, which can reference other (regular or generated) columns of the table. Since they are produced by calculations, these columns can not be inserted into directly.
+
+It is also possible to leave out the type when declaring a generated column. Since an expression has a return type, its type will be automatically derived from the expression.
   
-Generated columns come in two varieties; `VIRTUAL` and `STORED`.  
+Generated columns come in two varieties: `VIRTUAL` and `STORED`.  
 The data of virtual generated columns is not stored on disk, instead it is computed from the expression every time the column is referenced (through a select statement).  
 
 The data of stored generated columns is stored on disk and is computed every time the data of their dependencies change (through an insert/update/drop statement).  
 
 Currently only the `VIRTUAL` kind is supported, and it is also the default option if the last field is left blank.
+
+```sql
+-- The simplest syntax for a generated column. 
+-- The type is derived from the expression, and it is assume to be VIRTUAL
+CREATE TABLE t1(x FLOAT, two_x GENERATED ALWAYS AS (2 * x))
+
+-- Fully specifying the same generated column for completeness
+CREATE TABLE t1(x FLOAT, two_x FLOAT GENERATED ALWAYS AS (2 * x) VIRTUAL)
+```
 
 ### Syntax
 <div id="rrdiagram"></div>

--- a/docs/sql/statements/create_table.md
+++ b/docs/sql/statements/create_table.md
@@ -49,5 +49,16 @@ The `IF NOT EXISTS` syntax will only proceed with the creation of the table if i
 CREATE TABLE IF NOT EXISTS t1(i INTEGER, j INTEGER);
 ```
 
+The `[type] [GENERATED ALWAYS] AS ( expr ) [VIRTUAL|STORED]` syntax will create a generated column, these columns can not be inserted into directly. Instead their data is generated from their expression, which can reference other (regular or generated) columns of the table.
+
+Because an expression has a return type, it is also possible to leave out the type when declaring a generated column, its type will then be derived from the expression.
+  
+Generated columns come in two varieties; `VIRTUAL` and `STORED`.  
+The data of virtual generated columns is not stored on disk, instead it is computed from the expression every time the column is referenced (through a select statement).  
+
+The data of stored generated columns is stored on disk and is computed every time the data of their dependencies change (through an insert/update/drop statement).  
+
+Currently only the `VIRTUAL` kind is supported, and it is also the default option if the last field is left blank.
+
 ### Syntax
 <div id="rrdiagram"></div>

--- a/js/statements/createtable.js
+++ b/js/statements/createtable.js
@@ -51,11 +51,7 @@ function GenerateGeneratedColumnSyntax(options) {
 }
 
 function GenerateOptionalGeneratedType(options) {
-	return OptionalSequence(
-		Choice(0, [
-			Keyword("VIRTUAL"),
-			Keyword("STORED")
-		]), "skip");
+	return Optional(Choice(0, [Keyword("VIRTUAL"), Keyword("STORED")]), "skip");
 }
 
 function GenerateCreateTable(options = {}) {
@@ -83,12 +79,16 @@ function GenerateCreateTable(options = {}) {
 									Expandable("column-constraints", options, "column-constraints", GenerateColumnConstraints)
 								]),
 								Sequence([
-									GenerateOptionalType(),
-									GenerateGeneratedColumnSyntax(),
-									Keyword("("),
-									Expression("expr"),
-									Keyword(")"),
-									GenerateOptionalGeneratedType(),
+									Sequence([
+										GenerateOptionalType(),
+										GenerateGeneratedColumnSyntax(),
+									]),
+									Sequence([
+										Keyword("("),
+										Expression("expr"),
+										Keyword(")"),
+										GenerateOptionalGeneratedType(),
+									])
 								]),
 							])
 						]), ","),

--- a/js/statements/createtable.js
+++ b/js/statements/createtable.js
@@ -34,6 +34,23 @@ function GenerateTableConstraints(options) {
 	]), ",", "skip")]
 }
 
+function GenerateGeneratedColumnDefinition(options) {
+	return [
+		Sequence([
+			Sequence([
+				GenerateOptionalType(),
+				GenerateGeneratedColumnSyntax(),
+			]),
+			Sequence([
+				Keyword("("),
+				Expression("expr"),
+				Keyword(")"),
+				GenerateOptionalGeneratedType(),
+			])
+		])
+	];
+}
+
 function GenerateOptionalType(options) {
 	return Optional(Sequence([
 		Expression("type-name"),
@@ -78,18 +95,7 @@ function GenerateCreateTable(options = {}) {
 									Expression("type-name"),
 									Expandable("column-constraints", options, "column-constraints", GenerateColumnConstraints)
 								]),
-								Sequence([
-									Sequence([
-										GenerateOptionalType(),
-										GenerateGeneratedColumnSyntax(),
-									]),
-									Sequence([
-										Keyword("("),
-										Expression("expr"),
-										Keyword(")"),
-										GenerateOptionalGeneratedType(),
-									])
-								]),
+								Expandable("generated-column", options, "generated-column", GenerateGeneratedColumnDefinition),
 							])
 						]), ","),
 						Expandable("table-constraints", options, "table-constraints", GenerateTableConstraints),


### PR DESCRIPTION
This PR adds documentation for generated columns to the duckdb docs.

Syntax for it is added to the Syntax railroad diagram of `create_table`, this portion is made expandable under the name `generated-column`.  

This is what it looks like before it's expanded:
<img width="854" alt="image" src="https://user-images.githubusercontent.com/17162323/171613800-23bd4d57-eecf-4c53-bee5-1c4a9d0c556c.png">
And this is after:
<img width="1008" alt="image" src="https://user-images.githubusercontent.com/17162323/171613891-a2e35802-fbf2-4ef9-86f0-0f619c3b827f.png">


I've also added a brief description of generated columns to `create_table`. We might want to move this description to its own page later, but I felt this was the best place for it, since generated columns are only supported in `CREATE TABLE` statement for now.

PS:
I've had some issues with a bug where the VIRTUAL|GENERATED options were clipping through the options below, which almost magically disappeared, so please verify that this also works for you by running the site locally with jekyll