### PR TITLE
Add a dead link-checker CI job

### DIFF
--- a/.github/workflows/LinkChecker.yml
+++ b/.github/workflows/LinkChecker.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           python-version: '3.9'
 
-    - name: Link Checker
-      run: |
-        pip install linkchecker --user
-        linkchecker www.duckdb.org
+      - name: Link Checker
+        run: |
+          pip install linkchecker --user
+          linkchecker www.duckdb.org

--- a/.github/workflows/LinkChecker.yml
+++ b/.github/workflows/LinkChecker.yml
@@ -3,6 +3,7 @@ on: [push]
 jobs:
   LinkChecker:
     name: Link Checker
+    if: github.repository == 'duckdb/duckdb-web'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/LinkChecker.yml
+++ b/.github/workflows/LinkChecker.yml
@@ -1,0 +1,20 @@
+name: LinkChecker
+on: [push]
+jobs:
+  LinkChecker:
+    name: Link Checker
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+
+    - name: Link Checker
+      run: |
+        pip install linkchecker --user
+        linkchecker www.duckdb.org


### PR DESCRIPTION
Currently this only runs on pushes in the master. Ideally we would run the dead-link check on every PR to check for dead links resulting from changes made to the website, but that is significantly more complex to setup.