### PR TITLE
Documentation fix for atan and stddev_pop aggregate.

### DIFF
--- a/docs/archive/0.2.8/sql/aggregates.md
+++ b/docs/archive/0.2.8/sql/aggregates.md
@@ -58,7 +58,6 @@ The table below shows the available statistical aggregate functions.
 | `regr_avgy(y,x)` | Returns the average of the dependent variable for non-null pairs in a group, where x is the independent variable and y is the dependent variable. | - | - |
 | `regr_count(y,x)` | Returns the number of non-null number pairs in a group. | `(SUM(x*y) - SUM(x) * SUM(y) / COUNT(*)) / COUNT(*)` | - |
 | `regr_intercept(y,x)` | Returns the intercept of the univariate linear regression line for non-null pairs in a group. | `AVG(y)-REGR_SLOPE(y,x)*AVG(x)` | - |
-| `stddev_pop(y,x)` | Returns the population standard deviation (square root of variance) of non-NULL values. | - | - |
 | `regr_r2(y,x)` | Returns the coefficient of determination for non-null pairs in a group. | - | - |
 | `regr_slope(y,x)` | Returns the slope of the linear regression line for non-null pairs in a group.| `COVAR_POP(x,y) / VAR_POP(x)` | - |
 | `regr_sxx(y,x)` | -  | `REGR_COUNT(y, x) * VAR_POP(x)` | - |

--- a/docs/archive/0.2.9/sql/aggregates.md
+++ b/docs/archive/0.2.9/sql/aggregates.md
@@ -64,7 +64,6 @@ The table below shows the available statistical aggregate functions.
 | `regr_avgy(y,x)` | Returns the average of the dependent variable for non-null pairs in a group, where x is the independent variable and y is the dependent variable. | - | - |
 | `regr_count(y,x)` | Returns the number of non-null number pairs in a group. | `(SUM(x*y) - SUM(x) * SUM(y) / COUNT(*)) / COUNT(*)` | - |
 | `regr_intercept(y,x)` | Returns the intercept of the univariate linear regression line for non-null pairs in a group. | `AVG(y)-REGR_SLOPE(y,x)*AVG(x)` | - |
-| `stddev_pop(y,x)` | Returns the population standard deviation (square root of variance) of non-NULL values. | - | - |
 | `regr_r2(y,x)` | Returns the coefficient of determination for non-null pairs in a group. | - | - |
 | `regr_slope(y,x)` | Returns the slope of the linear regression line for non-null pairs in a group.| `COVAR_POP(x,y) / VAR_POP(x)` | - |
 | `regr_sxx(y,x)` | -  | `REGR_COUNT(y, x) * VAR_POP(x)` | - |

--- a/docs/archive/0.3.0/sql/aggregates.md
+++ b/docs/archive/0.3.0/sql/aggregates.md
@@ -64,7 +64,6 @@ The table below shows the available statistical aggregate functions.
 | `regr_avgy(y,x)` | Returns the average of the dependent variable for non-null pairs in a group, where x is the independent variable and y is the dependent variable. | - | - |
 | `regr_count(y,x)` | Returns the number of non-null number pairs in a group. | `(SUM(x*y) - SUM(x) * SUM(y) / COUNT(*)) / COUNT(*)` | - |
 | `regr_intercept(y,x)` | Returns the intercept of the univariate linear regression line for non-null pairs in a group. | `AVG(y)-REGR_SLOPE(y,x)*AVG(x)` | - |
-| `stddev_pop(y,x)` | Returns the population standard deviation (square root of variance) of non-NULL values. | - | - |
 | `regr_r2(y,x)` | Returns the coefficient of determination for non-null pairs in a group. | - | - |
 | `regr_slope(y,x)` | Returns the slope of the linear regression line for non-null pairs in a group.| `COVAR_POP(x,y) / VAR_POP(x)` | - |
 | `regr_sxx(y,x)` | -  | `REGR_COUNT(y, x) * VAR_POP(x)` | - |

--- a/docs/archive/0.3.0/sql/functions/numeric.md
+++ b/docs/archive/0.3.0/sql/functions/numeric.md
@@ -30,7 +30,7 @@ The table below shows the available mathematical functions.
 | `abs(x)` | absolute value | `abs(-17.4)` | 17.4 |
 | `acos(x)` | computes the arccosine of x | `acos(0.5)` | 1.0471975511965976 |
 | `asin(x)` | computes the arcsine of x | `asin(0.5)` | 0.5235987755982989 |
-| `atan2(x)` | computes the arctangent of x | `atan2(0.5)` | 0.4636476090008061 |
+| `atan2(x)` | computes the arctangent of x | `atan(0.5)` | 0.4636476090008061 |
 | `atan2(x, y)` | computes the arctangent (x, y) | `atan2(0.5, 0.5)` | 0.7853981633974483 |
 | `bit_count(x)` | returns the number of bits that are set | `bit_count(31)` | 5 |
 | `cbrt(x)` | returns the cube root of the number | `cbrt(8)` | 2 |

--- a/docs/archive/0.3.0/sql/functions/numeric.md
+++ b/docs/archive/0.3.0/sql/functions/numeric.md
@@ -30,7 +30,7 @@ The table below shows the available mathematical functions.
 | `abs(x)` | absolute value | `abs(-17.4)` | 17.4 |
 | `acos(x)` | computes the arccosine of x | `acos(0.5)` | 1.0471975511965976 |
 | `asin(x)` | computes the arcsine of x | `asin(0.5)` | 0.5235987755982989 |
-| `atan2(x)` | computes the arctangent of x | `atan(0.5)` | 0.4636476090008061 |
+| `atan(x)` | computes the arctangent of x | `atan(0.5)` | 0.4636476090008061 |
 | `atan2(x, y)` | computes the arctangent (x, y) | `atan2(0.5, 0.5)` | 0.7853981633974483 |
 | `bit_count(x)` | returns the number of bits that are set | `bit_count(31)` | 5 |
 | `cbrt(x)` | returns the cube root of the number | `cbrt(8)` | 2 |

--- a/docs/archive/0.3.1/sql/aggregates.md
+++ b/docs/archive/0.3.1/sql/aggregates.md
@@ -64,7 +64,6 @@ The table below shows the available statistical aggregate functions.
 | `regr_avgy(y,x)` | Returns the average of the dependent variable for non-null pairs in a group, where x is the independent variable and y is the dependent variable. | - | - |
 | `regr_count(y,x)` | Returns the number of non-null number pairs in a group. | `(SUM(x*y) - SUM(x) * SUM(y) / COUNT(*)) / COUNT(*)` | - |
 | `regr_intercept(y,x)` | Returns the intercept of the univariate linear regression line for non-null pairs in a group. | `AVG(y)-REGR_SLOPE(y,x)*AVG(x)` | - |
-| `stddev_pop(y,x)` | Returns the population standard deviation (square root of variance) of non-NULL values. | - | - |
 | `regr_r2(y,x)` | Returns the coefficient of determination for non-null pairs in a group. | - | - |
 | `regr_slope(y,x)` | Returns the slope of the linear regression line for non-null pairs in a group.| `COVAR_POP(x,y) / VAR_POP(x)` | - |
 | `regr_sxx(y,x)` | -  | `REGR_COUNT(y, x) * VAR_POP(x)` | - |

--- a/docs/archive/0.3.1/sql/functions/numeric.md
+++ b/docs/archive/0.3.1/sql/functions/numeric.md
@@ -29,7 +29,7 @@ The table below shows the available mathematical functions.
 | `abs(x)` | absolute value | `abs(-17.4)` | 17.4 |
 | `acos(x)` | computes the arccosine of x | `acos(0.5)` | 1.0471975511965976 |
 | `asin(x)` | computes the arcsine of x | `asin(0.5)` | 0.5235987755982989 |
-| `atan2(x)` | computes the arctangent of x | `atan2(0.5)` | 0.4636476090008061 |
+| `atan2(x)` | computes the arctangent of x | `atan(0.5)` | 0.4636476090008061 |
 | `atan2(x, y)` | computes the arctangent (x, y) | `atan2(0.5, 0.5)` | 0.7853981633974483 |
 | `bit_count(x)` | returns the number of bits that are set | `bit_count(31)` | 5 |
 | `cbrt(x)` | returns the cube root of the number | `cbrt(8)` | 2 |

--- a/docs/archive/0.3.1/sql/functions/numeric.md
+++ b/docs/archive/0.3.1/sql/functions/numeric.md
@@ -29,7 +29,7 @@ The table below shows the available mathematical functions.
 | `abs(x)` | absolute value | `abs(-17.4)` | 17.4 |
 | `acos(x)` | computes the arccosine of x | `acos(0.5)` | 1.0471975511965976 |
 | `asin(x)` | computes the arcsine of x | `asin(0.5)` | 0.5235987755982989 |
-| `atan2(x)` | computes the arctangent of x | `atan(0.5)` | 0.4636476090008061 |
+| `atan(x)` | computes the arctangent of x | `atan(0.5)` | 0.4636476090008061 |
 | `atan2(x, y)` | computes the arctangent (x, y) | `atan2(0.5, 0.5)` | 0.7853981633974483 |
 | `bit_count(x)` | returns the number of bits that are set | `bit_count(31)` | 5 |
 | `cbrt(x)` | returns the cube root of the number | `cbrt(8)` | 2 |

--- a/docs/archive/0.3.2/sql/aggregates.md
+++ b/docs/archive/0.3.2/sql/aggregates.md
@@ -68,7 +68,6 @@ The table below shows the available statistical aggregate functions.
 | `regr_avgy(y,x)` | Returns the average of the dependent variable for non-null pairs in a group, where x is the independent variable and y is the dependent variable. | - | - |
 | `regr_count(y,x)` | Returns the number of non-null number pairs in a group. | `(SUM(x*y) - SUM(x) * SUM(y) / COUNT(*)) / COUNT(*)` | - |
 | `regr_intercept(y,x)` | Returns the intercept of the univariate linear regression line for non-null pairs in a group. | `AVG(y)-REGR_SLOPE(y,x)*AVG(x)` | - |
-| `stddev_pop(y,x)` | Returns the population standard deviation (square root of variance) of non-NULL values. | - | - |
 | `regr_r2(y,x)` | Returns the coefficient of determination for non-null pairs in a group. | - | - |
 | `regr_slope(y,x)` | Returns the slope of the linear regression line for non-null pairs in a group.| `COVAR_POP(x,y) / VAR_POP(x)` | - |
 | `regr_sxx(y,x)` | -  | `REGR_COUNT(y, x) * VAR_POP(x)` | - |

--- a/docs/archive/0.3.2/sql/functions/numeric.md
+++ b/docs/archive/0.3.2/sql/functions/numeric.md
@@ -29,7 +29,7 @@ The table below shows the available mathematical functions.
 | `abs(x)` | absolute value | `abs(-17.4)` | 17.4 |
 | `acos(x)` | computes the arccosine of x | `acos(0.5)` | 1.0471975511965976 |
 | `asin(x)` | computes the arcsine of x | `asin(0.5)` | 0.5235987755982989 |
-| `atan2(x)` | computes the arctangent of x | `atan2(0.5)` | 0.4636476090008061 |
+| `atan2(x)` | computes the arctangent of x | `atan(0.5)` | 0.4636476090008061 |
 | `atan2(x, y)` | computes the arctangent (x, y) | `atan2(0.5, 0.5)` | 0.7853981633974483 |
 | `bit_count(x)` | returns the number of bits that are set | `bit_count(31)` | 5 |
 | `cbrt(x)` | returns the cube root of the number | `cbrt(8)` | 2 |

--- a/docs/archive/0.3.2/sql/functions/numeric.md
+++ b/docs/archive/0.3.2/sql/functions/numeric.md
@@ -29,7 +29,7 @@ The table below shows the available mathematical functions.
 | `abs(x)` | absolute value | `abs(-17.4)` | 17.4 |
 | `acos(x)` | computes the arccosine of x | `acos(0.5)` | 1.0471975511965976 |
 | `asin(x)` | computes the arcsine of x | `asin(0.5)` | 0.5235987755982989 |
-| `atan2(x)` | computes the arctangent of x | `atan(0.5)` | 0.4636476090008061 |
+| `atan(x)` | computes the arctangent of x | `atan(0.5)` | 0.4636476090008061 |
 | `atan2(x, y)` | computes the arctangent (x, y) | `atan2(0.5, 0.5)` | 0.7853981633974483 |
 | `bit_count(x)` | returns the number of bits that are set | `bit_count(31)` | 5 |
 | `cbrt(x)` | returns the cube root of the number | `cbrt(8)` | 2 |

--- a/docs/archive/0.3.3/sql/aggregates.md
+++ b/docs/archive/0.3.3/sql/aggregates.md
@@ -68,7 +68,6 @@ The table below shows the available statistical aggregate functions.
 | `regr_avgy(y,x)` | Returns the average of the dependent variable for non-null pairs in a group, where x is the independent variable and y is the dependent variable. | - | - |
 | `regr_count(y,x)` | Returns the number of non-null number pairs in a group. | `(SUM(x*y) - SUM(x) * SUM(y) / COUNT(*)) / COUNT(*)` | - |
 | `regr_intercept(y,x)` | Returns the intercept of the univariate linear regression line for non-null pairs in a group. | `AVG(y)-REGR_SLOPE(y,x)*AVG(x)` | - |
-| `stddev_pop(y,x)` | Returns the population standard deviation (square root of variance) of non-NULL values. | - | - |
 | `regr_r2(y,x)` | Returns the coefficient of determination for non-null pairs in a group. | - | - |
 | `regr_slope(y,x)` | Returns the slope of the linear regression line for non-null pairs in a group.| `COVAR_POP(x,y) / VAR_POP(x)` | - |
 | `regr_sxx(y,x)` | -  | `REGR_COUNT(y, x) * VAR_POP(x)` | - |

--- a/docs/archive/0.3.3/sql/functions/numeric.md
+++ b/docs/archive/0.3.3/sql/functions/numeric.md
@@ -32,7 +32,7 @@ The table below shows the available mathematical functions.
 | `abs(x)` | absolute value | `abs(-17.4)` | 17.4 |
 | `acos(x)` | computes the arccosine of x | `acos(0.5)` | 1.0471975511965976 |
 | `asin(x)` | computes the arcsine of x | `asin(0.5)` | 0.5235987755982989 |
-| `atan2(x)` | computes the arctangent of x | `atan(0.5)` | 0.4636476090008061 |
+| `atan(x)` | computes the arctangent of x | `atan(0.5)` | 0.4636476090008061 |
 | `atan2(x, y)` | computes the arctangent (x, y) | `atan2(0.5, 0.5)` | 0.7853981633974483 |
 | `bit_count(x)` | returns the number of bits that are set | `bit_count(31)` | 5 |
 | `cbrt(x)` | returns the cube root of the number | `cbrt(8)` | 2 |

--- a/docs/archive/0.3.3/sql/functions/numeric.md
+++ b/docs/archive/0.3.3/sql/functions/numeric.md
@@ -32,7 +32,7 @@ The table below shows the available mathematical functions.
 | `abs(x)` | absolute value | `abs(-17.4)` | 17.4 |
 | `acos(x)` | computes the arccosine of x | `acos(0.5)` | 1.0471975511965976 |
 | `asin(x)` | computes the arcsine of x | `asin(0.5)` | 0.5235987755982989 |
-| `atan2(x)` | computes the arctangent of x | `atan2(0.5)` | 0.4636476090008061 |
+| `atan2(x)` | computes the arctangent of x | `atan(0.5)` | 0.4636476090008061 |
 | `atan2(x, y)` | computes the arctangent (x, y) | `atan2(0.5, 0.5)` | 0.7853981633974483 |
 | `bit_count(x)` | returns the number of bits that are set | `bit_count(31)` | 5 |
 | `cbrt(x)` | returns the cube root of the number | `cbrt(8)` | 2 |

--- a/docs/archive/0.3.4/sql/aggregates.md
+++ b/docs/archive/0.3.4/sql/aggregates.md
@@ -68,7 +68,6 @@ The table below shows the available statistical aggregate functions.
 | `regr_avgy(y,x)` | Returns the average of the dependent variable for non-null pairs in a group, where x is the independent variable and y is the dependent variable. | - | - |
 | `regr_count(y,x)` | Returns the number of non-null number pairs in a group. | `(SUM(x*y) - SUM(x) * SUM(y) / COUNT(*)) / COUNT(*)` | - |
 | `regr_intercept(y,x)` | Returns the intercept of the univariate linear regression line for non-null pairs in a group. | `AVG(y)-REGR_SLOPE(y,x)*AVG(x)` | - |
-| `stddev_pop(y,x)` | Returns the population standard deviation (square root of variance) of non-NULL values. | - | - |
 | `regr_r2(y,x)` | Returns the coefficient of determination for non-null pairs in a group. | - | - |
 | `regr_slope(y,x)` | Returns the slope of the linear regression line for non-null pairs in a group.| `COVAR_POP(x,y) / VAR_POP(x)` | - |
 | `regr_sxx(y,x)` | -  | `REGR_COUNT(y, x) * VAR_POP(x)` | - |

--- a/docs/archive/0.3.4/sql/functions/descriptions.txt
+++ b/docs/archive/0.3.4/sql/functions/descriptions.txt
@@ -179,7 +179,7 @@ docs\sql\functions\numeric.md 	 Numeric Operators		 bitwise shift left 	 `1 << 4
 docs\sql\functions\numeric.md 	 Numeric Operators		 bitwise shift right 	 `8 >> 2` 	2	 `>>` 		
 docs\sql\functions\numeric.md 	 Numeric Functions	 `acos(x)` 	 computes the arccosine of x 	 `acos(0.5)` 	 1.0471975511965976			
 docs\sql\functions\numeric.md 	 Numeric Functions	 `asin(x)` 	 computes the arcsine of x 	 `asin(0.5)` 	 0.5235987755982989			
-docs\sql\functions\numeric.md 	 Numeric Functions	 `atan2(x)` 	 computes the arctangent of x 	 `atan(0.5)` 	 0.4636476090008061			
+docs\sql\functions\numeric.md 	 Numeric Functions	 `atan(x)` 	 computes the arctangent of x 	 `atan(0.5)` 	 0.4636476090008061			
 docs\sql\functions\numeric.md 	 Numeric Functions	 `atan2(x, y)` 	 computes the arctangent (x, y) 	 `atan2(0.5, 0.5)` 	 0.7853981633974483			
 docs\sql\functions\numeric.md 	 Numeric Functions	 `bit_count(x)` 	 returns the number of bits that are set 	 `bit_count(31)` 	 5			
 docs\sql\functions\numeric.md 	 Numeric Functions	 `cbrt(x)` 	 returns the cube root of the number 	 `cbrt(8)` 	 2			

--- a/docs/archive/0.3.4/sql/functions/descriptions.txt
+++ b/docs/archive/0.3.4/sql/functions/descriptions.txt
@@ -179,7 +179,7 @@ docs\sql\functions\numeric.md 	 Numeric Operators		 bitwise shift left 	 `1 << 4
 docs\sql\functions\numeric.md 	 Numeric Operators		 bitwise shift right 	 `8 >> 2` 	2	 `>>` 		
 docs\sql\functions\numeric.md 	 Numeric Functions	 `acos(x)` 	 computes the arccosine of x 	 `acos(0.5)` 	 1.0471975511965976			
 docs\sql\functions\numeric.md 	 Numeric Functions	 `asin(x)` 	 computes the arcsine of x 	 `asin(0.5)` 	 0.5235987755982989			
-docs\sql\functions\numeric.md 	 Numeric Functions	 `atan2(x)` 	 computes the arctangent of x 	 `atan2(0.5)` 	 0.4636476090008061			
+docs\sql\functions\numeric.md 	 Numeric Functions	 `atan2(x)` 	 computes the arctangent of x 	 `atan(0.5)` 	 0.4636476090008061			
 docs\sql\functions\numeric.md 	 Numeric Functions	 `atan2(x, y)` 	 computes the arctangent (x, y) 	 `atan2(0.5, 0.5)` 	 0.7853981633974483			
 docs\sql\functions\numeric.md 	 Numeric Functions	 `bit_count(x)` 	 returns the number of bits that are set 	 `bit_count(31)` 	 5			
 docs\sql\functions\numeric.md 	 Numeric Functions	 `cbrt(x)` 	 returns the cube root of the number 	 `cbrt(8)` 	 2			

--- a/docs/archive/0.3.4/sql/functions/numeric.md
+++ b/docs/archive/0.3.4/sql/functions/numeric.md
@@ -32,7 +32,7 @@ The table below shows the available mathematical functions.
 | `abs(x)` | absolute value | `abs(-17.4)` | 17.4 |
 | `acos(x)` | computes the arccosine of x | `acos(0.5)` | 1.0471975511965976 |
 | `asin(x)` | computes the arcsine of x | `asin(0.5)` | 0.5235987755982989 |
-| `atan2(x)` | computes the arctangent of x | `atan(0.5)` | 0.4636476090008061 |
+| `atan(x)` | computes the arctangent of x | `atan(0.5)` | 0.4636476090008061 |
 | `atan2(x, y)` | computes the arctangent (x, y) | `atan2(0.5, 0.5)` | 0.7853981633974483 |
 | `bit_count(x)` | returns the number of bits that are set | `bit_count(31)` | 5 |
 | `cbrt(x)` | returns the cube root of the number | `cbrt(8)` | 2 |

--- a/docs/archive/0.3.4/sql/functions/numeric.md
+++ b/docs/archive/0.3.4/sql/functions/numeric.md
@@ -32,7 +32,7 @@ The table below shows the available mathematical functions.
 | `abs(x)` | absolute value | `abs(-17.4)` | 17.4 |
 | `acos(x)` | computes the arccosine of x | `acos(0.5)` | 1.0471975511965976 |
 | `asin(x)` | computes the arcsine of x | `asin(0.5)` | 0.5235987755982989 |
-| `atan2(x)` | computes the arctangent of x | `atan2(0.5)` | 0.4636476090008061 |
+| `atan2(x)` | computes the arctangent of x | `atan(0.5)` | 0.4636476090008061 |
 | `atan2(x, y)` | computes the arctangent (x, y) | `atan2(0.5, 0.5)` | 0.7853981633974483 |
 | `bit_count(x)` | returns the number of bits that are set | `bit_count(31)` | 5 |
 | `cbrt(x)` | returns the cube root of the number | `cbrt(8)` | 2 |

--- a/docs/archive/0.4.0/sql/aggregates.md
+++ b/docs/archive/0.4.0/sql/aggregates.md
@@ -68,7 +68,6 @@ The table below shows the available statistical aggregate functions.
 | `regr_avgy(y,x)` | Returns the average of the dependent variable for non-null pairs in a group, where x is the independent variable and y is the dependent variable. | - | - |
 | `regr_count(y,x)` | Returns the number of non-null number pairs in a group. | `(SUM(x*y) - SUM(x) * SUM(y) / COUNT(*)) / COUNT(*)` | - |
 | `regr_intercept(y,x)` | Returns the intercept of the univariate linear regression line for non-null pairs in a group. | `AVG(y)-REGR_SLOPE(y,x)*AVG(x)` | - |
-| `stddev_pop(y,x)` | Returns the population standard deviation (square root of variance) of non-NULL values. | - | - |
 | `regr_r2(y,x)` | Returns the coefficient of determination for non-null pairs in a group. | - | - |
 | `regr_slope(y,x)` | Returns the slope of the linear regression line for non-null pairs in a group.| `COVAR_POP(x,y) / VAR_POP(x)` | - |
 | `regr_sxx(y,x)` | -  | `REGR_COUNT(y, x) * VAR_POP(x)` | - |

--- a/docs/archive/0.4.0/sql/functions/descriptions.txt
+++ b/docs/archive/0.4.0/sql/functions/descriptions.txt
@@ -179,7 +179,7 @@ docs\sql\functions\numeric.md 	 Numeric Operators		 bitwise shift left 	 `1 << 4
 docs\sql\functions\numeric.md 	 Numeric Operators		 bitwise shift right 	 `8 >> 2` 	2	 `>>` 		
 docs\sql\functions\numeric.md 	 Numeric Functions	 `acos(x)` 	 computes the arccosine of x 	 `acos(0.5)` 	 1.0471975511965976			
 docs\sql\functions\numeric.md 	 Numeric Functions	 `asin(x)` 	 computes the arcsine of x 	 `asin(0.5)` 	 0.5235987755982989			
-docs\sql\functions\numeric.md 	 Numeric Functions	 `atan2(x)` 	 computes the arctangent of x 	 `atan(0.5)` 	 0.4636476090008061			
+docs\sql\functions\numeric.md 	 Numeric Functions	 `atan(x)` 	 computes the arctangent of x 	 `atan(0.5)` 	 0.4636476090008061			
 docs\sql\functions\numeric.md 	 Numeric Functions	 `atan2(x, y)` 	 computes the arctangent (x, y) 	 `atan2(0.5, 0.5)` 	 0.7853981633974483			
 docs\sql\functions\numeric.md 	 Numeric Functions	 `bit_count(x)` 	 returns the number of bits that are set 	 `bit_count(31)` 	 5			
 docs\sql\functions\numeric.md 	 Numeric Functions	 `cbrt(x)` 	 returns the cube root of the number 	 `cbrt(8)` 	 2			

--- a/docs/archive/0.4.0/sql/functions/descriptions.txt
+++ b/docs/archive/0.4.0/sql/functions/descriptions.txt
@@ -179,7 +179,7 @@ docs\sql\functions\numeric.md 	 Numeric Operators		 bitwise shift left 	 `1 << 4
 docs\sql\functions\numeric.md 	 Numeric Operators		 bitwise shift right 	 `8 >> 2` 	2	 `>>` 		
 docs\sql\functions\numeric.md 	 Numeric Functions	 `acos(x)` 	 computes the arccosine of x 	 `acos(0.5)` 	 1.0471975511965976			
 docs\sql\functions\numeric.md 	 Numeric Functions	 `asin(x)` 	 computes the arcsine of x 	 `asin(0.5)` 	 0.5235987755982989			
-docs\sql\functions\numeric.md 	 Numeric Functions	 `atan2(x)` 	 computes the arctangent of x 	 `atan2(0.5)` 	 0.4636476090008061			
+docs\sql\functions\numeric.md 	 Numeric Functions	 `atan2(x)` 	 computes the arctangent of x 	 `atan(0.5)` 	 0.4636476090008061			
 docs\sql\functions\numeric.md 	 Numeric Functions	 `atan2(x, y)` 	 computes the arctangent (x, y) 	 `atan2(0.5, 0.5)` 	 0.7853981633974483			
 docs\sql\functions\numeric.md 	 Numeric Functions	 `bit_count(x)` 	 returns the number of bits that are set 	 `bit_count(31)` 	 5			
 docs\sql\functions\numeric.md 	 Numeric Functions	 `cbrt(x)` 	 returns the cube root of the number 	 `cbrt(8)` 	 2			

--- a/docs/archive/0.4.0/sql/functions/numeric.md
+++ b/docs/archive/0.4.0/sql/functions/numeric.md
@@ -33,7 +33,7 @@ The table below shows the available mathematical functions.
 | `abs(x)` | absolute value | `abs(-17.4)` | 17.4 |
 | `acos(x)` | computes the arccosine of x | `acos(0.5)` | 1.0471975511965976 |
 | `asin(x)` | computes the arcsine of x | `asin(0.5)` | 0.5235987755982989 |
-| `atan2(x)` | computes the arctangent of x | `atan(0.5)` | 0.4636476090008061 |
+| `atan(x)` | computes the arctangent of x | `atan(0.5)` | 0.4636476090008061 |
 | `atan2(x, y)` | computes the arctangent (x, y) | `atan2(0.5, 0.5)` | 0.7853981633974483 |
 | `bit_count(x)` | returns the number of bits that are set | `bit_count(31)` | 5 |
 | `cbrt(x)` | returns the cube root of the number | `cbrt(8)` | 2 |

--- a/docs/archive/0.4.0/sql/functions/numeric.md
+++ b/docs/archive/0.4.0/sql/functions/numeric.md
@@ -33,7 +33,7 @@ The table below shows the available mathematical functions.
 | `abs(x)` | absolute value | `abs(-17.4)` | 17.4 |
 | `acos(x)` | computes the arccosine of x | `acos(0.5)` | 1.0471975511965976 |
 | `asin(x)` | computes the arcsine of x | `asin(0.5)` | 0.5235987755982989 |
-| `atan2(x)` | computes the arctangent of x | `atan2(0.5)` | 0.4636476090008061 |
+| `atan2(x)` | computes the arctangent of x | `atan(0.5)` | 0.4636476090008061 |
 | `atan2(x, y)` | computes the arctangent (x, y) | `atan2(0.5, 0.5)` | 0.7853981633974483 |
 | `bit_count(x)` | returns the number of bits that are set | `bit_count(31)` | 5 |
 | `cbrt(x)` | returns the cube root of the number | `cbrt(8)` | 2 |

--- a/docs/sql/aggregates.md
+++ b/docs/sql/aggregates.md
@@ -68,7 +68,6 @@ The table below shows the available statistical aggregate functions.
 | `regr_avgy(y,x)` | Returns the average of the dependent variable for non-null pairs in a group, where x is the independent variable and y is the dependent variable. | - | - |
 | `regr_count(y,x)` | Returns the number of non-null number pairs in a group. | `(SUM(x*y) - SUM(x) * SUM(y) / COUNT(*)) / COUNT(*)` | - |
 | `regr_intercept(y,x)` | Returns the intercept of the univariate linear regression line for non-null pairs in a group. | `AVG(y)-REGR_SLOPE(y,x)*AVG(x)` | - |
-| `stddev_pop(y,x)` | Returns the population standard deviation (square root of variance) of non-NULL values. | - | - |
 | `regr_r2(y,x)` | Returns the coefficient of determination for non-null pairs in a group. | - | - |
 | `regr_slope(y,x)` | Returns the slope of the linear regression line for non-null pairs in a group.| `COVAR_POP(x,y) / VAR_POP(x)` | - |
 | `regr_sxx(y,x)` | -  | `REGR_COUNT(y, x) * VAR_POP(x)` | - |

--- a/docs/sql/functions/numeric.md
+++ b/docs/sql/functions/numeric.md
@@ -33,7 +33,7 @@ The table below shows the available mathematical functions.
 | `abs(x)` | absolute value | `abs(-17.4)` | 17.4 |
 | `acos(x)` | computes the arccosine of x | `acos(0.5)` | 1.0471975511965976 |
 | `asin(x)` | computes the arcsine of x | `asin(0.5)` | 0.5235987755982989 |
-| `atan2(x)` | computes the arctangent of x | `atan(0.5)` | 0.4636476090008061 |
+| `atan(x)` | computes the arctangent of x | `atan(0.5)` | 0.4636476090008061 |
 | `atan2(x, y)` | computes the arctangent (x, y) | `atan2(0.5, 0.5)` | 0.7853981633974483 |
 | `bit_count(x)` | returns the number of bits that are set | `bit_count(31)` | 5 |
 | `cbrt(x)` | returns the cube root of the number | `cbrt(8)` | 2 |

--- a/docs/sql/functions/numeric.md
+++ b/docs/sql/functions/numeric.md
@@ -33,7 +33,7 @@ The table below shows the available mathematical functions.
 | `abs(x)` | absolute value | `abs(-17.4)` | 17.4 |
 | `acos(x)` | computes the arccosine of x | `acos(0.5)` | 1.0471975511965976 |
 | `asin(x)` | computes the arcsine of x | `asin(0.5)` | 0.5235987755982989 |
-| `atan2(x)` | computes the arctangent of x | `atan2(0.5)` | 0.4636476090008061 |
+| `atan2(x)` | computes the arctangent of x | `atan(0.5)` | 0.4636476090008061 |
 | `atan2(x, y)` | computes the arctangent (x, y) | `atan2(0.5, 0.5)` | 0.7853981633974483 |
 | `bit_count(x)` | returns the number of bits that are set | `bit_count(31)` | 5 |
 | `cbrt(x)` | returns the cube root of the number | `cbrt(8)` | 2 |


### PR DESCRIPTION
Hi 👋 - I noticed two functions described in the docs that result in errors in the terminal.

Firstly `atan2` is listed twice in [Numeric Functions](https://duckdb.org/docs/sql/functions/numeric#numeric-functions), with both one and two arguments. I believe the first listing should be changed to `atan`.

``` bash
duckdb> select atan2(0.5);
Error: Binder Error: No function matches the given name and argument types 'atan2(DECIMAL(2,1))'. You might need to add explicit type casts.
	Candidate functions:
	atan2(DOUBLE, DOUBLE) -> DOUBLE

LINE 1: select atan2(0.5);
               ^
duckdb> select atan(0.5);
┌─────────────────────┐
│      atan(0.5)      │
├─────────────────────┤
│ 0.46364760900080615 │
└─────────────────────┘
```

Secondly, `stddev_pop` is mentioned twice in [Statistical Aggregates](https://duckdb.org/docs/sql/aggregates#statistical-aggregates), I believe the first listing isn't needed.

```bash
duckdb> select stddev_pop(y, x) from
   ...>     (select * from (values (11, 22), (13, 29), (12, 21)) as t(x, y));
Binder Error: No function matches the given name and argument types 'stddev_pop(INTEGER, INTEGER)'. You might need to add explicit type casts.
        Candidate functions:
        stddev_pop(DOUBLE) -> DOUBLE

LINE 1: select stddev_pop(y, x) from
               ^
```