### PR TITLE
feat: link to out-of-tree scanner usage docs

### DIFF
--- a/_data/menu_docs_current.json
+++ b/_data/menu_docs_current.json
@@ -626,6 +626,14 @@
             {
               "page": "JSON",
               "url": "json"
+            },
+            {
+              "page": "SQLite Scanner",
+              "url": "sqlite_scanner"
+            },
+            {
+              "page": "Postgres Scanner",
+              "url": "postgres_scanner"
             }
           ]
         }

--- a/docs/extensions/postgres_scanner.md
+++ b/docs/extensions/postgres_scanner.md
@@ -1,0 +1,7 @@
+---
+layout: docu
+title: Postgres Scanner
+selected: Documentation/Postgres Scanner
+---
+
+See [here](https://github.com/duckdblabs/postgresscanner#usage) for usage

--- a/docs/extensions/sqlite_scanner.md
+++ b/docs/extensions/sqlite_scanner.md
@@ -1,0 +1,7 @@
+---
+layout: docu
+title: SQLite Scanner
+selected: Documentation/SQLite Scanner
+---
+
+See [here](https://github.com/duckdblabs/sqlite_scanner#usage) for usage


### PR DESCRIPTION
Not sure if we want to inline these docs, or just leave them in the readme?