### PR TITLE
Mention disconnect/shutdown behaviour

### DIFF
--- a/docs/api/r.md
+++ b/docs/api/r.md
@@ -22,7 +22,7 @@ con = dbConnect(duckdb::duckdb(), dbdir="my-db.duckdb", read_only=FALSE)
 # to use a database file (shared between processes)
 con = dbConnect(duckdb::duckdb(), dbdir="my-db.duckdb", read_only=TRUE)
 ```
-Connections are closed implicitly when they go out of scope or if they are explicitly closed using `dbDisconnect()`.
+Connections are closed implicitly when they go out of scope or if they are explicitly closed using `dbDisconnect()`. To shut down the database instance associated with the connection, use `dbDisconnect(con, shutdown=TRUE)`
 
 ### Querying
 DuckDB supports the standard DBI methods to send queries and retreive result sets. `dbExecute()` is meant for queries where no results are expected like `CREATE TABLE` or `UPDATE` etc. and `dbGetQuery()` is meant to be used for queries that produce results (e.g. `SELECT`). Below an example.


### PR DESCRIPTION
As per [Issue 3451](https://github.com/duckdb/duckdb/issues/3451) in the main duckdb repo, the default behaviour of dbDisconnect may not be what users expect. Describing this in the docs may make it clearer for users, until a decision is made on whether to change the default.