### PR TITLE
Add Guides / Data Viewers to sidebar tree

### DIFF
--- a/_data/menu_docs_current.json
+++ b/_data/menu_docs_current.json
@@ -134,7 +134,18 @@
               "url": "dbeaver"
             }
           ]
+        },
+        {
+          "page": "Data Viewers",
+          "slug": "data_viewers",
+          "subfolderitems": [
+            {
+              "page": "Tad",
+              "url": "tad"
+            }
+          ]
         }
+
       ]
     },
     {


### PR DESCRIPTION
This PR adds an entry "Data Viewers" to the sidebar tree under "Guides", so that all top-level sections and sub-sections in "Guides" are now included in the sidebar tree.
Omitting this was an unfortunate oversight from my previous PR #251 