### PR TITLE
Fix dead link

### DIFF
--- a/docs/api/r.md
+++ b/docs/api/r.md
@@ -7,7 +7,7 @@ selected: Client APIs
 The DuckDB R API can be installed using `install.packages`. Please see the [installation page](../installation?environment=r) for details.
 
 ## Basic API Usage
-The standard DuckDB R API implements the [DBI interface](https://CRAN.R-project.org/package=DBI) for R. If you are not familiar with DBI yet, see [here for an introduction](https://db.rstudio.com/dbi/).
+The standard DuckDB R API implements the [DBI interface](https://CRAN.R-project.org/package=DBI) for R. If you are not familiar with DBI yet, see [here for an introduction](https://solutions.rstudio.com/db/r-packages/DBI/).
 
 ### Startup & Shutdown
 

--- a/docs/archive/0.2.8/api/r.md
+++ b/docs/archive/0.2.8/api/r.md
@@ -7,7 +7,7 @@ selected: Client APIs
 The DuckDB R API can be installed using `install.packages`. Please see the [installation page](../installation?environment=r) for details.
 
 ## Basic API Usage
-The standard DuckDB R API implements the [DBI interface](https://CRAN.R-project.org/package=DBI) for R. If you are not familiar with DBI yet, see [here for an introduction](https://db.rstudio.com/dbi/).
+The standard DuckDB R API implements the [DBI interface](https://CRAN.R-project.org/package=DBI) for R. If you are not familiar with DBI yet, see [here for an introduction](https://solutions.rstudio.com/db/r-packages/DBI/).
 
 ### Startup & Shutdown
 

--- a/docs/archive/0.2.9/api/r.md
+++ b/docs/archive/0.2.9/api/r.md
@@ -7,7 +7,7 @@ selected: Client APIs
 The DuckDB R API can be installed using `install.packages`. Please see the [installation page](../installation?environment=r) for details.
 
 ## Basic API Usage
-The standard DuckDB R API implements the [DBI interface](https://CRAN.R-project.org/package=DBI) for R. If you are not familiar with DBI yet, see [here for an introduction](https://db.rstudio.com/dbi/).
+The standard DuckDB R API implements the [DBI interface](https://CRAN.R-project.org/package=DBI) for R. If you are not familiar with DBI yet, see [here for an introduction](https://solutions.rstudio.com/db/r-packages/DBI/).
 
 ### Startup & Shutdown
 

--- a/docs/archive/0.3.0/api/r.md
+++ b/docs/archive/0.3.0/api/r.md
@@ -7,7 +7,7 @@ selected: Client APIs
 The DuckDB R API can be installed using `install.packages`. Please see the [installation page](../installation?environment=r) for details.
 
 ## Basic API Usage
-The standard DuckDB R API implements the [DBI interface](https://CRAN.R-project.org/package=DBI) for R. If you are not familiar with DBI yet, see [here for an introduction](https://db.rstudio.com/dbi/).
+The standard DuckDB R API implements the [DBI interface](https://CRAN.R-project.org/package=DBI) for R. If you are not familiar with DBI yet, see [here for an introduction](https://solutions.rstudio.com/db/r-packages/DBI/).
 
 ### Startup & Shutdown
 

--- a/docs/archive/0.3.1/api/r.md
+++ b/docs/archive/0.3.1/api/r.md
@@ -7,7 +7,7 @@ selected: Client APIs
 The DuckDB R API can be installed using `install.packages`. Please see the [installation page](../installation?environment=r) for details.
 
 ## Basic API Usage
-The standard DuckDB R API implements the [DBI interface](https://CRAN.R-project.org/package=DBI) for R. If you are not familiar with DBI yet, see [here for an introduction](https://db.rstudio.com/dbi/).
+The standard DuckDB R API implements the [DBI interface](https://CRAN.R-project.org/package=DBI) for R. If you are not familiar with DBI yet, see [here for an introduction](https://solutions.rstudio.com/db/r-packages/DBI/).
 
 ### Startup & Shutdown
 

--- a/docs/archive/0.3.2/api/r.md
+++ b/docs/archive/0.3.2/api/r.md
@@ -7,7 +7,7 @@ selected: Client APIs
 The DuckDB R API can be installed using `install.packages`. Please see the [installation page](../installation?environment=r) for details.
 
 ## Basic API Usage
-The standard DuckDB R API implements the [DBI interface](https://CRAN.R-project.org/package=DBI) for R. If you are not familiar with DBI yet, see [here for an introduction](https://db.rstudio.com/dbi/).
+The standard DuckDB R API implements the [DBI interface](https://CRAN.R-project.org/package=DBI) for R. If you are not familiar with DBI yet, see [here for an introduction](https://solutions.rstudio.com/db/r-packages/DBI/).
 
 ### Startup & Shutdown
 

--- a/docs/archive/0.3.3/api/r.md
+++ b/docs/archive/0.3.3/api/r.md
@@ -7,7 +7,7 @@ selected: Client APIs
 The DuckDB R API can be installed using `install.packages`. Please see the [installation page](../installation?environment=r) for details.
 
 ## Basic API Usage
-The standard DuckDB R API implements the [DBI interface](https://CRAN.R-project.org/package=DBI) for R. If you are not familiar with DBI yet, see [here for an introduction](https://db.rstudio.com/dbi/).
+The standard DuckDB R API implements the [DBI interface](https://CRAN.R-project.org/package=DBI) for R. If you are not familiar with DBI yet, see [here for an introduction](https://solutions.rstudio.com/db/r-packages/DBI/).
 
 ### Startup & Shutdown
 

--- a/docs/archive/0.3.4/api/r.md
+++ b/docs/archive/0.3.4/api/r.md
@@ -7,7 +7,7 @@ selected: Client APIs
 The DuckDB R API can be installed using `install.packages`. Please see the [installation page](../installation?environment=r) for details.
 
 ## Basic API Usage
-The standard DuckDB R API implements the [DBI interface](https://CRAN.R-project.org/package=DBI) for R. If you are not familiar with DBI yet, see [here for an introduction](https://db.rstudio.com/dbi/).
+The standard DuckDB R API implements the [DBI interface](https://CRAN.R-project.org/package=DBI) for R. If you are not familiar with DBI yet, see [here for an introduction](https://solutions.rstudio.com/db/r-packages/DBI/).
 
 ### Startup & Shutdown
 

--- a/docs/archive/0.4.0/api/r.md
+++ b/docs/archive/0.4.0/api/r.md
@@ -7,7 +7,7 @@ selected: Client APIs
 The DuckDB R API can be installed using `install.packages`. Please see the [installation page](../installation?environment=r) for details.
 
 ## Basic API Usage
-The standard DuckDB R API implements the [DBI interface](https://CRAN.R-project.org/package=DBI) for R. If you are not familiar with DBI yet, see [here for an introduction](https://db.rstudio.com/dbi/).
+The standard DuckDB R API implements the [DBI interface](https://CRAN.R-project.org/package=DBI) for R. If you are not familiar with DBI yet, see [here for an introduction](https://solutions.rstudio.com/db/r-packages/DBI/).
 
 ### Startup & Shutdown
 


### PR DESCRIPTION
The [old DBI link](https://db.rstudio.com/dbi/) appears to be dead, this PR moves that link to [here](https://solutions.rstudio.com/db/r-packages/DBI/)