### PR TITLE
autocomplete relative pos and close on enter

### DIFF
--- a/css/search.css
+++ b/css/search.css
@@ -29,7 +29,8 @@ input[type=submit] {
 	color: #fff;
 }
 .autocomplete-items {
-	position: absolute;
+	/* relative position does not cover up the search results */
+	position: relative;
 	border: 1px solid #d4d4d4;
 	border-bottom: none;
 	border-top: none;

--- a/js/search.js
+++ b/js/search.js
@@ -159,8 +159,11 @@ inp.addEventListener("keydown", function(e) {
 		/*If the ENTER key is pressed, prevent the form from being submitted,*/
 		e.preventDefault();
 		if (currentFocus > -1) {
-		/*and simulate a click on the "active" item:*/
-		if (x) x[currentFocus].click();
+			/*and simulate a click on the "active" item:*/
+			if (x) x[currentFocus].click();
+		} else {
+			/*Close the suggestion list on enter so that the user can view the main document list */
+			closeAllLists();
 		}
 	}
 });


### PR DESCRIPTION
Love the search! Super fast, super easy, nice search suggestions. 2 small tweaks:

The autocomplete is covering up the main list, so I changed it to relative position. I also made it so that if you hit enter and you haven't picked anything in the autocomplete list, it will still close the autocomplete list (so that you can see the main list).

NOTE: I am not sure how this would work on mobile. I did test with a very small browser window, so maybe that triggered the mobile layout? What's the best way to test that?