### PR TITLE
Fix code example in Guides>Python>SQL on Arrow guide

### DIFF
--- a/docs/guides/python/sql_on_arrow.md
+++ b/docs/guides/python/sql_on_arrow.md
@@ -21,7 +21,7 @@ my_arrow_table = pa.Table.from_pydict({'i':[1,2,3,4],
                                        'j':["one", "two", "three", "four"]})
 
 # query the Apache Arrow Table "my_arrow_table" and return as an Arrow Table
-results = con.execute("SELECT * FROM my_arrow_dataset WHERE i = 2").arrow()
+results = con.execute("SELECT * FROM my_arrow_table WHERE i = 2").arrow()
 ```
 
 ## Apache Arrow Datasets


### PR DESCRIPTION
Fix small typo in the guide [SQL on Arrow](https://duckdb.org/docs/guides/python/sql_on_arrow).