### PR TITLE
Pandas Analyze sample size documentation

### DIFF
--- a/docs/archive/0.4.0/api/python.md
+++ b/docs/archive/0.4.0/api/python.md
@@ -62,20 +62,7 @@ print(con.fetchall())
 ## Efficient Transfer
 Transferring large datasets to and from DuckDB uses a separate API built around [NumPy](https://numpy.org) and [Pandas](https://pandas.pydata.org), or [Apache Arrow](https://arrow.apache.org/). This API works with entire columns of data instead of scalar values and is therefore far more efficient. 
 
-### Pandas.DataFrame 'object' columns
-This is not true for pandas.DataFrame columns of an `object` dtype, since this stores values of arbitrary type.  
-To convert these columns to DuckDB, we first go through an analyze phase before converting the values.
-
-In this analyze phase a sample of all the rows of the column are analyzed to determine the target type.
-This sample size is by default set to 1000, but can be changed by setting the `pandas_analyze_sample` config option.
-```py
-# example setting the sample size to 100000
-duckdb.default_connection.execute("SET GLOBAL pandas_analyze_sample=100000")
-```
-
-### Registering Python Objects
-
-By default, DuckDB will automatically be able to query a Pandas DataFrame or Arrow object that is stored in a Python variable by name. DuckDB supports querying multiple types of Apache Arrow objects including [tables](https://arrow.apache.org/docs/python/generated/pyarrow.Table.html), [datasets](https://arrow.apache.org/docs/python/generated/pyarrow.dataset.Dataset.html), [recordbatchreaders](https://arrow.apache.org/docs/python/generated/pyarrow.ipc.RecordBatchStreamReader.html), and [scanners](https://arrow.apache.org/docs/python/generated/pyarrow.dataset.Scanner.html). See the Python [guides](../guides/index#python-client) for more examples.
+By default, DuckDB will automatically be able to query a Pandas DataFrame or Arrow object that is stored in a Python variable by name. DuckDB supports querying multiple types of Apache Arrow objects including [tables](https://arrow.apache.org/docs/python/generated/pyarrow.Table.html), [datasets](https://arrow.apache.org/docs/python/generated/pyarrow.dataset.Dataset.html), [recordbatchreaders](https://arrow.apache.org/docs/python/generated/pyarrow.ipc.RecordBatchStreamReader.html), and [scanners](https://arrow.apache.org/docs/python/generated/pyarrow.dataset.Scanner.html). See the Python [guides](/docs/guides/index#python-client) for more examples.
 
 DuckDB also supports "registering" a DataFrame or Arrow object as a virtual table, comparable to a SQL `VIEW`. This is useful when querying a DataFrame/Arrow object that is stored in another way (as a class variable, or a value in a dictionary). Below is a Pandas example:
 

--- a/docs/guides/python/import_pandas.md
+++ b/docs/guides/python/import_pandas.md
@@ -23,3 +23,21 @@ con.execute("CREATE TABLE my_table AS SELECT * FROM my_df")
 # insert into the table "my_table" from the DataFrame "my_df"
 con.execute("INSERT INTO my_table SELECT * FROM my_df")
 ```
+
+## 'object' columns
+
+pandas.DataFrame columns of an `object` dtype require some special care, since this stores values of arbitrary type.
+
+To convert these columns to DuckDB, we first go through an analyze phase before converting the values.
+
+In this analyze phase a sample of all the rows of the column are analyzed to determine the target type.
+
+This sample size is by default set to 1000.
+
+If the type picked during the analyze step is wrong, this will result in a "Failed to cast value:" error, in which case you will need to increase the sample size.
+
+The sample size can be changed by setting the `pandas_analyze_sample` config option.
+```py
+# example setting the sample size to 100000
+duckdb.default_connection.execute("SET GLOBAL pandas_analyze_sample=100000")
+```


### PR DESCRIPTION
This PR fixes my old attempt at documenting this setting

Previously I added it to the archive ..

And the placement of it was not great either, so now I've moved it to the "import from pandas" documentation page, which feels like a more suitable place for this information.