### PR TITLE
Add mention and link to third-party Common Lisp bindings

### DIFF
--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -7,6 +7,6 @@ expanded: Client APIs
 
 There are various client APIs for DuckDB. DuckDB's "native" API is [C++](cpp), with "official" wrappers available for [C](c/overview), [Python](python/overview), [R](r), [Java](java), [Node.js](nodejs/overview), [WebAssembly/WASM](wasm), [ODBC API](odbc/overview), [Julia](julia), and a [Command Line Interface (CLI)](cli).
 
-There are also contributed third-party DuckDB wrappers for [Ruby](https://github.com/suketa/ruby-duckdb), [Go](https://github.com/marcboeker/go-duckdb), [C#](https://github.com/Giorgi/DuckDB.NET) and [Rust](https://github.com/wangfenjin/duckdb-rs).
+There are also contributed third-party DuckDB wrappers for [Ruby](https://github.com/suketa/ruby-duckdb), [Go](https://github.com/marcboeker/go-duckdb), [C#](https://github.com/Giorgi/DuckDB.NET), [Rust](https://github.com/wangfenjin/duckdb-rs) and [Common Lisp](https://github.com/ak-coram/cl-duckdb).
 
 ### Pages in this Section


### PR DESCRIPTION
I'd like to include a mention of these bindings for people who are interested in using DuckDB from Common Lisp. I hope this is acceptable. Thanks!