### PR TITLE
Add missing closing parenthesis in C++ API docs

### DIFF
--- a/docs/api/cpp.md
+++ b/docs/api/cpp.md
@@ -31,7 +31,7 @@ Connections expose the `Query()` method to send a SQL query string to DuckDB fro
 con.Query("CREATE TABLE integers(i INTEGER, j INTEGER)");
 
 // insert three rows into the table
-con.Query("INSERT INTO integers VALUES (3, 4), (5, 6), (7, NULL)";
+con.Query("INSERT INTO integers VALUES (3, 4), (5, 6), (7, NULL)");
 
 MaterializedQueryResult result = con.Query("SELECT * FROM integers");
 if (!result->success) {


### PR DESCRIPTION
Using the C++ API docs I noticed a missing closing parenthesis in the example INSERT query. This super tiny PR fixes this typo.