### PR TITLE
Add pandas dataframe specificity

### DIFF
--- a/docs/guides/python/execute_sql.md
+++ b/docs/guides/python/execute_sql.md
@@ -20,7 +20,7 @@ After connecting, SQL queries can be executed using the `execute` command.
 results = con.execute("SELECT 42").fetchall()
 ```
 
-By default, a list of Python objects is returned. Use `df` if you would like the result to be returned as a Python dataframe instead.
+By default, a list of Python objects is returned. Use `df` if you would like the result to be returned as a Python pandas dataframe instead.
 
 ```py
 results = con.execute("SELECT 42").df()


### PR DESCRIPTION
Addresses #424 to clarify which type of Python dataframe is returned from `.df()` when using the Python API.