### PR TITLE
Update window function documentation.

### DIFF
--- a/docs/sql/window_functions.md
+++ b/docs/sql/window_functions.md
@@ -215,6 +215,35 @@ ORDER BY 1, 2
 
 The three window functions will also share the data layout, which will improve performance.
 
+Multiple windows can be defined in the same `WINDOW` clause by comma-separating them:
+
+```sql
+SELECT "Plant", "Date",
+    MIN("MWh") OVER seven AS "MWh 7-day Moving Minimum",
+    AVG("MWh") OVER seven AS "MWh 7-day Moving Average",
+    MAX("MWh") OVER seven AS "MWh 7-day Moving Maximum",
+    MIN("MWh") OVER three AS "MWh 3-day Moving Minimum",
+    AVG("MWh") OVER three AS "MWh 3-day Moving Average",
+    MAX("MWh") OVER three AS "MWh 3-day Moving Maximum"
+FROM "Generation History"
+WINDOW
+    seven AS (
+        PARTITION BY "Plant"
+        ORDER BY "Date" ASC
+        RANGE BETWEEN INTERVAL 3 DAYS PRECEDING
+                  AND INTERVAL 3 DAYS FOLLOWING),
+    three AS (
+        PARTITION BY "Plant"
+        ORDER BY "Date" ASC
+        RANGE BETWEEN INTERVAL 1 DAYS PRECEDING
+        AND INTERVAL 1 DAYS FOLLOWING)
+ORDER BY 1, 2
+```
+
+The queries above do not use a number of clauses commonly found in select statements, like
+`WHERE`, `GROUP BY`, etc. For more complex queries you can find where `WINDOW` clauses fall in
+the canonical order of a select statement [here](../sql/statements/select).
+
 ### Box and Whisker Queries
 
 All aggregates can be used as windowing functions, including the complex statistical functions.


### PR DESCRIPTION
This change adds to two clarifications to the window function docs:

1. How to specify multiple windows in the same `WINDOW` clause.
2. Where to find `WINDOW` in the canonical order of a select statement.

---

This was on my to-do list and I'm just getting around to it. I expressed some confusion in Discord a week or two ago and @Alex-Monahan suggested I updated the docs.

I generated the docs and tested the link -- it works.

Happy to make any changes -- just let me know!