### PR TITLE
Fix relational_api_pandas.md

### DIFF
--- a/docs/guides/python/relational_api_pandas.md
+++ b/docs/guides/python/relational_api_pandas.md
@@ -19,7 +19,7 @@ input_df = pandas.DataFrame.from_dict({'i':[1,2,3,4],
                                        'j':["one", "two", "three", "four"]})
 
 # create a DuckDB relation from a dataframe
-rel = con.df(input_df)
+rel = con.from_df(input_df)
 
 # chain together relational operators (this is a lazy operation, so the operations are not yet executed)
 # equivalent to: SELECT i, j, i*2 as two_i FROM input_df ORDER BY i desc limit 2


### PR DESCRIPTION
Using `from rel = con.df(input_df)` results in a `TypeError` error. Changed to `rel = con.from_df(input_df)`.  

In reference to [Issue #525](https://github.com/duckdb/duckdb-web/issues/525).  

Thanks!