### PR TITLE
Fix #510: move DuckDB to after the page title instead of before

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,7 +6,7 @@
 	{% if page.title == "DuckDB" %}
     <title>{{ page.title }}</title>
 	{% else %}
-    <title>DuckDB - {{ page.title }}</title>
+    <title>{{ page.title }} - DuckDB</title>
 	{% endif %}
 
 	<link rel="stylesheet" href="{{ site.baseurl }}/css/normalize.css">

--- a/_layouts/docu.html
+++ b/_layouts/docu.html
@@ -6,7 +6,7 @@
 	{% if page.title == "DuckDB" %}
 	<title>{{ page.title }}</title>
 	{% else %}
-	<title>DuckDB - {{ page.title }}</title>
+	<title>{{ page.title }} - DuckDB</title>
 	{% endif %}
 
 	<script src="{{ site.baseurl }}/js/jquery-3.5.1.min.js"></script>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -6,7 +6,7 @@
 	{% if page.title == "DuckDB" %}
     <title>{{ page.title }}</title>
 	{% else %}
-    <title>DuckDB - {{ page.title }}</title>
+    <title>{{ page.title }} - DuckDB</title>
 	{% endif %}
 
 	<link rel="stylesheet" href="/duckdb-web-new/css/main.css">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -6,7 +6,7 @@
 	{% if page.title == "DuckDB" %}
     <title>{{ page.title }}</title>
 	{% else %}
-    <title>DuckDB - {{ page.title }}</title>
+    <title>{{ page.title }} - DuckDB</title>
 	{% endif %}
 	
 	<link rel="stylesheet" href="{{ site.baseurl }}/css/normalize.css">


### PR DESCRIPTION
Fixes #510 

This also seems to be standard in other projects - e.g. Spark, Presto and ClickHouse all follow this same convention.