### PR TITLE
Python API docs - add duckdb.sql, read_csv methods, and split the Python API docs into multiple (hopefully more clear) pages

### DIFF
--- a/_data/menu_docs_dev.json
+++ b/_data/menu_docs_dev.json
@@ -231,6 +231,18 @@
                   "url": "overview"
                 },
                 {
+                  "page": "Data Ingestion",
+                  "url": "data_ingestion"
+                },
+                {
+                  "page": "Result Conversion",
+                  "url": "result_conversion"
+                },
+                {
+                  "page": "DB API",
+                  "url": "dbapi"
+                },
+                {
                   "page": "API Reference",
                   "url": "reference"
                 }

--- a/docs/api/python/data_ingestion.md
+++ b/docs/api/python/data_ingestion.md
@@ -1,0 +1,112 @@
+---
+layout: docu
+title: Data Ingestion
+selected: Client APIs
+---
+
+#### CSV Files
+CSV files can be read using the `read_csv` function, called either from within Python or directly from within SQL. By default, the `read_csv` function attempts to auto-detect the CSV settings by sampling from the provided file. 
+
+```py
+import duckdb
+# read from a file using fully auto-detected settings
+duckdb.read_csv('example.csv')
+# read multiple CSV files from a folder
+duckdb.read_csv('folder/*.csv')
+# specify options on how the CSV is formatted internally
+duckdb.read_csv('example.csv', header=False, sep=',')
+# override types of the first two columns
+duckdb.read_csv('example.csv', dtype=['int', 'varchar'])
+# use the (experimental) parallel CSV reader
+duckdb.read_csv('example.csv', parallel=True)
+# directly read a CSV file from within SQL
+duckdb.sql("SELECT * FROM 'example.csv'")
+# call read_csv from within SQL
+duckdb.sql("SELECT * FROM read_csv_auto('example.csv')")
+```
+
+See the [CSV Loading](../../data/csv) page for more information.
+
+#### Parquet Files
+Parquet files can be read using the `read_parquet` function, called either from within Python or directly from within SQL.
+
+```py
+import duckdb
+# read from a single Parquet file
+duckdb.read_parquet('example.parquet')
+# read multiple Parquet files from a folder
+duckdb.read_parquet('folder/*.parquet')
+# directly read a Parquet file from within SQL
+duckdb.sql("SELECT * FROM 'example.parquet'")
+# call read_parquet from within SQL
+duckdb.sql("SELECT * FROM read_parquet('example.parquet')")
+```
+
+See the [Parquet Loading](../../data/parquet) page for more information.
+
+#### JSON Files
+JSON files can be read using the `read_json` function, called either from within Python or directly from within SQL. By default, the `read_json` function will automatically detect if a file contains newline-delimited JSON or regular JSON, and will detect the schema of the objects stored within the JSON file.
+
+```py
+import duckdb
+# read from a single JSON file
+duckdb.read_json('example.json')
+# read multiple JSON files from a folder
+duckdb.read_json('folder/*.json')
+# directly read a JSON file from within SQL
+duckdb.sql("SELECT * FROM 'example.json'")
+# call read_json from within SQL
+duckdb.sql("SELECT * FROM read_json_auto('example.json')")
+```
+
+#### DataFrames & Arrow Tables
+
+DuckDB is automatically able to query a Pandas DataFrame or Arrow object that is stored in a Python variable by name. DuckDB supports querying multiple types of Apache Arrow objects including [tables](https://arrow.apache.org/docs/python/generated/pyarrow.Table.html), [datasets](https://arrow.apache.org/docs/python/generated/pyarrow.dataset.Dataset.html), [recordbatchreaders](https://arrow.apache.org/docs/python/generated/pyarrow.ipc.RecordBatchStreamReader.html), and [scanners](https://arrow.apache.org/docs/python/generated/pyarrow.dataset.Scanner.html). See the Python [guides](../../guides/index#python-client) for more examples.
+
+```python
+import duckdb
+import pandas as pd
+test_df = pd.DataFrame.from_dict({"i":[1, 2, 3, 4], "j":["one", "two", "three", "four"]})
+duckdb.sql('SELECT * FROM test_df').fetchall()
+# [(1, 'one'), (2, 'two'), (3, 'three'), (4, 'four')]
+```
+
+DuckDB also supports "registering" a DataFrame or Arrow object as a virtual table, comparable to a SQL `VIEW`. This is useful when querying a DataFrame/Arrow object that is stored in another way (as a class variable, or a value in a dictionary). Below is a Pandas example:
+
+If your Pandas DataFrame is stored in another location, here is an example of manually registering it:
+```python
+import duckdb
+import pandas as pd
+my_dictionary = {}
+my_dictionary['test_df'] = pd.DataFrame.from_dict({"i":[1, 2, 3, 4], "j":["one", "two", "three", "four"]})
+duckdb.register('test_df_view', my_dictionary['test_df'])
+duckdb.sql('SELECT * FROM test_df_view').fetchall()
+# [(1, 'one'), (2, 'two'), (3, 'three'), (4, 'four')]
+```
+
+You can also create a persistent table in DuckDB from the contents of the DataFrame (or the view):
+
+```python
+# create a new table from the contents of a DataFrame
+con.execute('CREATE TABLE test_df_table AS SELECT * FROM test_df')
+# insert into an existing table from the contents of a DataFrame
+con.execute('INSERT INTO test_df_table SELECT * FROM test_df')
+```
+
+##### Pandas DataFrames - 'object' columns
+
+pandas.DataFrame columns of an `object` dtype require some special care, since this stores values of arbitrary type.
+
+To convert these columns to DuckDB, we first go through an analyze phase before converting the values.
+
+In this analyze phase a sample of all the rows of the column are analyzed to determine the target type.
+
+This sample size is by default set to 1000.
+
+If the type picked during the analyze step is wrong, this will result in a "Failed to cast value:" error, in which case you will need to increase the sample size.
+
+The sample size can be changed by setting the `pandas_analyze_sample` config option.
+```py
+# example setting the sample size to 100000
+duckdb.default_connection.execute("SET GLOBAL pandas_analyze_sample=100000")
+```

--- a/docs/api/python/data_ingestion.md
+++ b/docs/api/python/data_ingestion.md
@@ -61,7 +61,7 @@ duckdb.sql("SELECT * FROM read_json_auto('example.json')")
 
 #### DataFrames & Arrow Tables
 
-DuckDB is automatically able to query a Pandas DataFrame or Arrow object that is stored in a Python variable by name. DuckDB supports querying multiple types of Apache Arrow objects including [tables](https://arrow.apache.org/docs/python/generated/pyarrow.Table.html), [datasets](https://arrow.apache.org/docs/python/generated/pyarrow.dataset.Dataset.html), [RecordBatchReaders](https://arrow.apache.org/docs/python/generated/pyarrow.ipc.RecordBatchStreamReader.html), and [scanners](https://arrow.apache.org/docs/python/generated/pyarrow.dataset.Scanner.html). See the Python [guides](../../guides/index#python-client) for more examples.
+DuckDB is automatically able to query a Pandas DataFrame, Polars DataFrame, or Arrow object that is stored in a Python variable by name. DuckDB supports querying multiple types of Apache Arrow objects including [tables](https://arrow.apache.org/docs/python/generated/pyarrow.Table.html), [datasets](https://arrow.apache.org/docs/python/generated/pyarrow.dataset.Dataset.html), [RecordBatchReaders](https://arrow.apache.org/docs/python/generated/pyarrow.ipc.RecordBatchStreamReader.html), and [scanners](https://arrow.apache.org/docs/python/generated/pyarrow.dataset.Scanner.html). See the Python [guides](../../guides/index#python-client) for more examples.
 
 ```python
 import duckdb

--- a/docs/api/python/data_ingestion.md
+++ b/docs/api/python/data_ingestion.md
@@ -61,7 +61,7 @@ duckdb.sql("SELECT * FROM read_json_auto('example.json')")
 
 #### DataFrames & Arrow Tables
 
-DuckDB is automatically able to query a Pandas DataFrame or Arrow object that is stored in a Python variable by name. DuckDB supports querying multiple types of Apache Arrow objects including [tables](https://arrow.apache.org/docs/python/generated/pyarrow.Table.html), [datasets](https://arrow.apache.org/docs/python/generated/pyarrow.dataset.Dataset.html), [recordbatchreaders](https://arrow.apache.org/docs/python/generated/pyarrow.ipc.RecordBatchStreamReader.html), and [scanners](https://arrow.apache.org/docs/python/generated/pyarrow.dataset.Scanner.html). See the Python [guides](../../guides/index#python-client) for more examples.
+DuckDB is automatically able to query a Pandas DataFrame or Arrow object that is stored in a Python variable by name. DuckDB supports querying multiple types of Apache Arrow objects including [tables](https://arrow.apache.org/docs/python/generated/pyarrow.Table.html), [datasets](https://arrow.apache.org/docs/python/generated/pyarrow.dataset.Dataset.html), [RecordBatchReaders](https://arrow.apache.org/docs/python/generated/pyarrow.ipc.RecordBatchStreamReader.html), and [scanners](https://arrow.apache.org/docs/python/generated/pyarrow.dataset.Scanner.html). See the Python [guides](../../guides/index#python-client) for more examples.
 
 ```python
 import duckdb

--- a/docs/api/python/dbapi.md
+++ b/docs/api/python/dbapi.md
@@ -1,0 +1,64 @@
+---
+layout: docu
+title: Python DB API
+selected: Client APIs
+---
+
+The standard DuckDB Python API provides a SQL interface compliant with the [DB-API 2.0 specification described by PEP 249](https://www.python.org/dev/peps/pep-0249/) similar to the [SQLite Python API](https://docs.python.org/3.7/library/sqlite3.html).
+
+### Startup & Shutdown
+To use the module, you must first create a `Connection` object that represents the database. The connection object takes as parameter the database file to read and write from. If the database file does not exist, it will be created (the file extension may be `.db`, `.duckdb`, or anything else). The special value `:memory:` (the default) can be used to create an **in-memory database**. Note that for an in-memory database no data is persisted to disk (i.e. all data is lost when you exit the Python process). If you would like to connect to an existing database in read-only mode, you can set the `read_only` flag to `True`. Read-only mode is required if multiple Python processes want to access the same database file at the same time.
+
+```python
+import duckdb
+# to start an in-memory database
+con = duckdb.connect(database=':memory:')
+# to use a database file (not shared between processes)
+con = duckdb.connect(database='my-db.duckdb', read_only=False)
+# to use a database file (shared between processes)
+con = duckdb.connect(database='my-db.duckdb', read_only=True)
+```
+If you want to create a second connection to an existing database, you can use the `cursor()` method. This might be useful for example to allow parallel threads running queries independently. A single connection is thread-safe but is locked for the duration of the queries, effectively serializing database access in this case.
+
+Connections are closed implicitly when they go out of scope or if they are explicitly closed using `close()`.  Once the last connection to a database instance is closed, the database instance is closed as well.
+
+### Querying
+SQL queries can be sent to DuckDB using the `execute()` method of connections. Once a query has been executed, results can be retrieved using the `fetchone` and `fetchall` methods on the connection. Below is a short example:
+
+```python
+# create a table
+con.execute("CREATE TABLE items(item VARCHAR, value DECIMAL(10,2), count INTEGER)")
+# insert two items into the table
+con.execute("INSERT INTO items VALUES ('jeans', 20.0, 1), ('hammer', 42.2, 2)")
+
+# retrieve the items again
+con.execute("SELECT * FROM items")
+print(con.fetchall())
+# [('jeans', 20.0, 1), ('hammer', 42.2, 2)]
+```
+
+The `description` property of the connection object contains the column names as per the standard.
+
+DuckDB also supports prepared statements in the API with the `execute` and `executemany` methods. The values may be passed as an additional parameter after a query that contains `?` or `$1` (dollar symbol and a number) placeholders. Using the `?` notation adds the values in the same sequence as passed within the Python parameter. Using the `$` notation allows for values to be reused within the SQL statement based on the number and index of the value found within the Python parameter.
+
+Here are some examples:
+
+```python
+# insert a row using prepared statements
+con.execute("INSERT INTO items VALUES (?, ?, ?)", ['laptop', 2000, 1])
+
+# insert several rows using prepared statements
+con.executemany("INSERT INTO items VALUES (?, ?, ?)", [['chainsaw', 500, 10], ['iphone', 300, 2]] )
+
+# query the database using a prepared statement
+con.execute("SELECT item FROM items WHERE value > ?", [400])
+print(con.fetchall())
+# [('laptop',), ('chainsaw',)]
+
+# query using $ notation for prepared statement and reused values
+con.execute("select $1, $1, $2", ["duck", "goose"])
+print(con.fetchall())
+# [('duck', 'duck', 'goose')]
+```
+
+> Do *not* use `executemany` to insert large amounts of data into DuckDB. See the [data ingestion page](data_ingestion) for better options.

--- a/docs/api/python/overview.md
+++ b/docs/api/python/overview.md
@@ -73,12 +73,13 @@ duckdb.sql('SELECT 42').fetchnumpy() # NumPy Arrays
 ```
 
 ## Writing Data To Disk
-DuckDB supports writing Relation objects directly to disk in a variety of formats.
+DuckDB supports writing Relation objects directly to disk in a variety of formats. The [`COPY`](/docs/sql/statements/copy) statement can be used to write data to disk using SQL as an alternative.
 
 ```py
 import duckdb
-duckdb.sql('SELECT 42').write_parquet('out.parquet')   # Write to a Parquet file
-duckdb.sql('SELECT 42').write_csv('out.csv')           # Write to a CSV file
+duckdb.sql('SELECT 42').write_parquet('out.parquet') # Write to a Parquet file
+duckdb.sql('SELECT 42').write_csv('out.csv')         # Write to a CSV file
+duckdb.sql("COPY (SELECT 42) TO 'out.parquet'")      # Copy to a parquet file
 ```
 
 ## Persistent Storage

--- a/docs/api/python/overview.md
+++ b/docs/api/python/overview.md
@@ -7,163 +7,95 @@ selected: Client APIs
 The DuckDB Python API can be installed using [pip](https://pip.pypa.io): `pip install duckdb`. Please see the [installation page](../../installation?environment=python) for details. It is also possible to install DuckDB using [conda](https://docs.conda.io): `conda install python-duckdb -c conda-forge`.
 
 ## Basic API Usage
-The standard DuckDB Python API provides a SQL interface compliant with the [DB-API 2.0 specification described by PEP 249](https://www.python.org/dev/peps/pep-0249/) similar to the [SQLite Python API](https://docs.python.org/3.7/library/sqlite3.html).
+The most straight-forward manner of running SQL queries using DuckDB is using the `duckdb.sql` command.
 
-### Startup & Shutdown
-To use the module, you must first create a `Connection` object that represents the database. The connection object takes as parameter the database file to read and write from. If the database file does not exist, it will be created (the file extension may be `.db`, `.duckdb`, or anything else). The special value `:memory:` (the default) can be used to create an **in-memory database**. Note that for an in-memory database no data is persisted to disk (i.e. all data is lost when you exit the Python process). If you would like to connect to an existing database in read-only mode, you can set the `read_only` flag to `True`. Read-only mode is required if multiple Python processes want to access the same database file at the same time.
-
-```python
+```py
 import duckdb
-# to start an in-memory database
-con = duckdb.connect(database=':memory:')
-# to use a database file (not shared between processes)
-con = duckdb.connect(database='my-db.duckdb', read_only=False)
-# to use a database file (shared between processes)
-con = duckdb.connect(database='my-db.duckdb', read_only=True)
-```
-If you want to create a second connection to an existing database, you can use the `cursor()` method. This might be useful for example to allow parallel threads running queries independently. A single connection is thread-safe but is locked for the duration of the queries, effectively serializing database access in this case.
-
-Connections are closed implicitly when they go out of scope or if they are explicitly closed using `close()`.  Once the last connection to a database instance is closed, the database instance is closed as well.
-
-### Querying
-SQL queries can be sent to DuckDB using the `execute()` method of connections. Once a query has been executed, results can be retrieved using the `fetchone` and `fetchall` methods on the connection. Below is a short example:
-
-```python
-# create a table
-con.execute("CREATE TABLE items(item VARCHAR, value DECIMAL(10,2), count INTEGER)")
-# insert two items into the table
-con.execute("INSERT INTO items VALUES ('jeans', 20.0, 1), ('hammer', 42.2, 2)")
-
-# retrieve the items again
-con.execute("SELECT * FROM items")
-print(con.fetchall())
-# [('jeans', 20.0, 1), ('hammer', 42.2, 2)]
+duckdb.sql('SELECT 42').show()
 ```
 
-The `description` property of the connection object contains the column names as per the standard.
+This will run queries using an **in-memory database** that is stored globally inside the Python module. The result of the query is returned as a **Relation**. A relation is a symbolic representation of the query. The query is not executed until the result is fetched or requested to be printed to the screen.
 
-DuckDB also supports prepared statements in the API with the `execute` and `executemany` methods. The values may be passed as an additional parameter after a query that contains `?` or `$1` (dollar symbol and a number) placeholders. Using the `?` notation adds the values in the same sequence as passed within the Python parameter. Using the `$` notation allows for values to be reused within the SQL statement based on the number and index of the value found within the Python parameter.
+Relations can be referenced in subsequent queries by storing them inside variables, and using them as tables. This way queries can be constructed incrementally.
 
-Here are some examples:
-
-```python
-# insert a row using prepared statements
-con.execute("INSERT INTO items VALUES (?, ?, ?)", ['laptop', 2000, 1])
-
-# insert several rows using prepared statements
-con.executemany("INSERT INTO items VALUES (?, ?, ?)", [['chainsaw', 500, 10], ['iphone', 300, 2]] )
-
-# query the database using a prepared statement
-con.execute("SELECT item FROM items WHERE value > ?", [400])
-print(con.fetchall())
-# [('laptop',), ('chainsaw',)]
-
-# query using $ notation for prepared statement and reused values
-con.execute("select $1, $1, $2", ["duck", "goose"])
-print(con.fetchall())
-# [('duck', 'duck', 'goose')]
+```py
+import duckdb
+r1 = duckdb.sql('SELECT 42 AS i')
+duckdb.sql('SELECT i * 2 AS k FROM r1').show()
 ```
 
-> Do *not* use `executemany` to insert large amounts of data into DuckDB. See below for better options.
+## Data Input
+DuckDB can ingest data from a wide variety of formats - both on-disk and in-memory. See the [data ingestion page](data_ingestion) for more information.
 
-## Efficient Transfer
-Transferring large datasets to and from DuckDB uses a separate API built around [NumPy](https://numpy.org) and [Pandas](https://pandas.pydata.org), or [Apache Arrow](https://arrow.apache.org/). This API works with entire columns of data instead of scalar values and is therefore far more efficient.
+```py
+import duckdb
+duckdb.read_csv('example.csv')                # read a CSV file into a Relation
+duckdb.read_parquet('example.parquet')        # read a Parquet file into a Relation
+duckdb.read_json('example.json')              # read a JSON file into a Relation
 
-By default, DuckDB will automatically be able to query a Pandas DataFrame or Arrow object that is stored in a Python variable by name. DuckDB supports querying multiple types of Apache Arrow objects including [tables](https://arrow.apache.org/docs/python/generated/pyarrow.Table.html), [datasets](https://arrow.apache.org/docs/python/generated/pyarrow.dataset.Dataset.html), [recordbatchreaders](https://arrow.apache.org/docs/python/generated/pyarrow.ipc.RecordBatchStreamReader.html), and [scanners](https://arrow.apache.org/docs/python/generated/pyarrow.dataset.Scanner.html). See the Python [guides](../../guides/index#python-client) for more examples.
+duckdb.sql('SELECT * FROM "example.csv"')     # directly query a CSV file
+duckdb.sql('SELECT * FROM "example.parquet"') # directly query a Parquet file
+duckdb.sql('SELECT * FROM "example.json"')    # directly query a JSON file
+```
 
-DuckDB also supports "registering" a DataFrame or Arrow object as a virtual table, comparable to a SQL `VIEW`. This is useful when querying a DataFrame/Arrow object that is stored in another way (as a class variable, or a value in a dictionary). Below is a Pandas example:
+#### DataFrames
+DuckDB can also directly query Pandas DataFrames, Polars DataFrames and Arrow tables. 
 
-```python
+```py
+import duckdb
+
+# directly query a Pandas DataFrame
 import pandas as pd
-test_df = pd.DataFrame.from_dict({"i":[1, 2, 3, 4], "j":["one", "two", "three", "four"]})
-con.execute('SELECT * FROM test_df')
-con.fetchall()
-# [(1, 'one'), (2, 'two'), (3, 'three'), (4, 'four')]
-```
+pandas_df = pd.DataFrame({'a': [42]})
+duckdb.sql('SELECT * FROM pandas_df')
 
-If your Pandas DataFrame is stored in another location, here is an example of manually registering it:
-```python
-import pandas as pd
-my_dictionary = {}
-my_dictionary['test_df'] = pd.DataFrame.from_dict({"i":[1, 2, 3, 4], "j":["one", "two", "three", "four"]})
-con.register('test_df_view', my_dictionary['test_df'])
-con.execute('SELECT * FROM test_df_view')
-con.fetchall()
-# [(1, 'one'), (2, 'two'), (3, 'three'), (4, 'four')]
-```
+# directly query a Polars DataFrame
+import polars as pl
+polars_df = pl.DataFrame({'a': [42]})
+duckdb.sql('SELECT * FROM polars_df')
 
-Pyarrow tables work in much the same way:
-```python
+# directly query a pyarrow table
 import pyarrow as pa
-arrow_table = pa.Table.from_pydict({'i':[1,2,3,4], 'j':["one", "two", "three", "four"]})
-con.execute('SELECT * FROM arrow_table')
-con.fetchall()
+arrow_table = pa.Table.from_pydict({'a':[42]})
+duckdb.sql('SELECT * FROM arrow_table')
 ```
 
-You can also create a persistent table in DuckDB from the contents of the DataFrame (or the view):
-```python
-con.execute('CREATE TABLE test_df_table AS SELECT * FROM test_df')
-```
-> DuckDB keeps a reference to the Pandas DataFrame or Arrow object after registration. This prevents them from being garbage-collected by the Python runtime. The reference is cleared when the connection is closed, but can also be cleared manually using the `unregister()` method.
+## Result Conversion
+DuckDB supports converting query results efficiently to a variety of formats. See the [result conversion page](result_conversion) for more information.
 
-When retrieving the data from DuckDB back into Python, the standard method of calling `fetchall()` is inefficient as individual Python objects need to be created for every value in the result set. When retrieving a lot of data, this can become very slow.
-
-DuckDB's Python client provides multiple additional methods that can be used to efficiently retrieve data.
-### NumPy
-* `fetchnumpy()` fetches the data as a dictionary of NumPy arrays
-
-### Pandas
-* `df()` fetches the data as a Pandas DataFrame
-* `fetchdf()` is an alias of `df()`
-* `fetch_df()` is an alias of `df()`
-* `fetch_df_chunk(vector_multiple)` fetches a portion of the results into a DataFrame. The number of rows returned in each chunk is the vector size (1024 by default) * vector_multiple (1 by default).
-
-### Apache Arrow
-* `arrow()` fetches the data as an [Arrow table](https://arrow.apache.org/docs/python/generated/pyarrow.Table.html)
-* `fetch_arrow_table()` is an alias of `arrow()`
-* `fetch_record_batch(chunk_size)` returns an [Arrow record batch reader](https://arrow.apache.org/docs/python/generated/pyarrow.ipc.RecordBatchStreamReader.html) with `chunk_size` rows per batch
-
-
-Below are some examples using this functionality. See the Python [guides](../../guides/index#python-client) for more examples.
-
-```python
-# fetch as Pandas DataFrame
-df = con.execute("SELECT * FROM items").fetchdf()
-print(df)
-#        item   value  count
-# 0     jeans    20.0      1
-# 1    hammer    42.2      2
-# 2    laptop  2000.0      1
-# 3  chainsaw   500.0     10
-# 4    iphone   300.0      2
-
-# fetch as dictionary of numpy arrays
-arr = con.execute("SELECT * FROM items").fetchnumpy()
-print(arr)
-# {'item': masked_array(data=['jeans', 'hammer', 'laptop', 'chainsaw', 'iphone'],
-#              mask=[False, False, False, False, False],
-#        fill_value='?',
-#             dtype=object), 'value': masked_array(data=[20.0, 42.2, 2000.0, 500.0, 300.0],
-#              mask=[False, False, False, False, False],
-#        fill_value=1e+20), 'count': masked_array(data=[1, 2, 1, 10, 2],
-#              mask=[False, False, False, False, False],
-#        fill_value=999999,
-#             dtype=int32)}
-
-# fetch as an Arrow table. Converting to Pandas afterwards just for pretty printing
-tbl = con.execute("SELECT * FROM items").fetch_arrow_table()
-print(tbl.to_pandas())
-#        item    value  count
-# 0     jeans    20.00      1
-# 1    hammer    42.20      2
-# 2    laptop  2000.00      1
-# 3  chainsaw   500.00     10
-# 4    iphone   300.00      2
-
+```py
+import duckdb
+duckdb.sql('SELECT 42').fetchall()   # Python objects
+duckdb.sql('SELECT 42').df()         # Pandas DataFrame
+duckdb.sql('SELECT 42').pl()         # Polars DataFrame
+duckdb.sql('SELECT 42').arrow()      # Arrow Table
+duckdb.sql('SELECT 42').fetchnumpy() # NumPy Arrays
 ```
 
-Also refer to [the data import documentation](../../data/overview) for more options of efficiently importing data.
+## Writing Data To Disk
+DuckDB supports writing Relation objects directly to disk in a variety of formats.
 
+```py
+import duckdb
+duckdb.sql('SELECT 42').write_parquet('out.parquet')   # Write to a Parquet file
+duckdb.sql('SELECT 42').write_csv('out.csv')           # Write to a CSV file
+```
 
-## Relational API
-In addition to the SQL API DuckDB supports a programmatic method to construct queries. See [https://github.com/duckdb/duckdb/blob/master/examples/python/duckdb-python.py](https://github.com/duckdb/duckdb/blob/master/examples/python/duckdb-python.py) for an example.
+## Persistent Storage
+By default DuckDB operates on an **in-memory** database. That means that any tables that are created are not persisted to disk. Using the `.connect` method a connection can be made to a **persistent** database. Any data written to that connection will be persisted, and can be reloaded by re-connecting to the same file. 
+
+```py
+import duckdb
+
+# create a connection to a file called 'file.db'
+con = duckdb.connect('file.db')
+# create a table and load data into it
+con.sql('CREATE TABLE test(i INTEGER)')
+con.sql('INSERT INTO test VALUES (42)')
+# query the table
+con.table('test').show()
+```
+
+The connection object and the `duckdb` module can be used interchangeably - they support the same methods. The only difference is that when using the `duckdb` module a global in-memory database is used.
+
+Note that if you are developing a package designed for others to use using duckdb, it is recommend that you create connection objects instead of using the methods on the `duckdb` module. That is because the `duckdb` module uses a shared global database - which can cause hard to debug issues if used from within multiple different packages. 

--- a/docs/api/python/result_conversion.md
+++ b/docs/api/python/result_conversion.md
@@ -11,7 +11,7 @@ DuckDB's Python client provides multiple additional methods that can be used to 
 * `df()` fetches the data as a Pandas DataFrame
 * `fetchdf()` is an alias of `df()`
 * `fetch_df()` is an alias of `df()`
-* `fetch_df_chunk(vector_multiple)` fetches a portion of the results into a DataFrame. The number of rows returned in each chunk is the vector size (1024 by default) * vector_multiple (1 by default).
+* `fetch_df_chunk(vector_multiple)` fetches a portion of the results into a DataFrame. The number of rows returned in each chunk is the vector size (2048 by default) * vector_multiple (1 by default).
 
 ### Apache Arrow
 * `arrow()` fetches the data as an [Arrow table](https://arrow.apache.org/docs/python/generated/pyarrow.Table.html)

--- a/docs/api/python/result_conversion.md
+++ b/docs/api/python/result_conversion.md
@@ -1,0 +1,59 @@
+---
+layout: docu
+title: Result Conversion
+selected: Client APIs
+---
+DuckDB's Python client provides multiple additional methods that can be used to efficiently retrieve data.
+### NumPy
+* `fetchnumpy()` fetches the data as a dictionary of NumPy arrays
+
+### Pandas
+* `df()` fetches the data as a Pandas DataFrame
+* `fetchdf()` is an alias of `df()`
+* `fetch_df()` is an alias of `df()`
+* `fetch_df_chunk(vector_multiple)` fetches a portion of the results into a DataFrame. The number of rows returned in each chunk is the vector size (1024 by default) * vector_multiple (1 by default).
+
+### Apache Arrow
+* `arrow()` fetches the data as an [Arrow table](https://arrow.apache.org/docs/python/generated/pyarrow.Table.html)
+* `fetch_arrow_table()` is an alias of `arrow()`
+* `fetch_record_batch(chunk_size)` returns an [Arrow record batch reader](https://arrow.apache.org/docs/python/generated/pyarrow.ipc.RecordBatchStreamReader.html) with `chunk_size` rows per batch
+
+### Polars
+* `pl()` fetches the data as a Polars DataFrame
+
+Below are some examples using this functionality. See the Python [guides](../../guides/index#python-client) for more examples.
+
+```python
+# fetch as Pandas DataFrame
+df = con.execute("SELECT * FROM items").fetchdf()
+print(df)
+#        item   value  count
+# 0     jeans    20.0      1
+# 1    hammer    42.2      2
+# 2    laptop  2000.0      1
+# 3  chainsaw   500.0     10
+# 4    iphone   300.0      2
+
+# fetch as dictionary of numpy arrays
+arr = con.execute("SELECT * FROM items").fetchnumpy()
+print(arr)
+# {'item': masked_array(data=['jeans', 'hammer', 'laptop', 'chainsaw', 'iphone'],
+#              mask=[False, False, False, False, False],
+#        fill_value='?',
+#             dtype=object), 'value': masked_array(data=[20.0, 42.2, 2000.0, 500.0, 300.0],
+#              mask=[False, False, False, False, False],
+#        fill_value=1e+20), 'count': masked_array(data=[1, 2, 1, 10, 2],
+#              mask=[False, False, False, False, False],
+#        fill_value=999999,
+#             dtype=int32)}
+
+# fetch as an Arrow table. Converting to Pandas afterwards just for pretty printing
+tbl = con.execute("SELECT * FROM items").fetch_arrow_table()
+print(tbl.to_pandas())
+#        item    value  count
+# 0     jeans    20.00      1
+# 1    hammer    42.20      2
+# 2    laptop  2000.00      1
+# 3  chainsaw   500.00     10
+# 4    iphone   300.00      2
+```

--- a/docs/guides/python/execute_sql.md
+++ b/docs/guides/python/execute_sql.md
@@ -6,23 +6,37 @@ selected: Execute SQL
 
 # How to execute SQL queries
 
-
-First connect to a database using the `connect` command. By default an in-memory database will be opened.
+SQL queries can be executed using the `duckdb.sql` command.
 
 ```py
 import duckdb
-con = duckdb.connect()
+duckdb.sql("SELECT 42").show()
 ```
 
-After connecting, SQL queries can be executed using the `execute` command.
+By default this will create a relation object. The result can be converted to various formats using the result conversion functions. For example, the `fetchall` method can be used to convert the result to Python objects.
 
 ```py
-results = con.execute("SELECT 42").fetchall()
+results = duckdb.sql("SELECT 42").fetchall()
+print(results)
+# [(42,)]
 ```
 
-By default, a list of Python objects is returned. Use `df` if you would like the result to be returned as a Python pandas dataframe instead.
+Several other result objects exist. For example, you can use `df` to convert the result to a Pandas DataFrame.
 
 ```py
-results = con.execute("SELECT 42").df()
+results = duckdb.sql("SELECT 42").df()
+print(results)
+#    42
+# 0  42
 ```
 
+By default, a global in-memory connection will be used. Any data stored in files will be lost after shutting down the program. A connection to a persistent database can be created using the `connect` function.
+
+After connecting, SQL queries can be executed using the `sql` command.
+
+```py
+con = duckdb.connect('file.db')
+con.sql('CREATE TABLE integers(i INTEGER)')
+con.sql('INSERT INTO integers VALUES (42)')
+con.sql('SELECT * FROM integers').show()
+```

--- a/docs/guides/python/export_arrow.md
+++ b/docs/guides/python/export_arrow.md
@@ -12,14 +12,11 @@ All results of a query can be exported to an [Apache Arrow Table](https://arrow.
 import duckdb
 import pyarrow as pa
 
-# connect to an in-memory database
-con = duckdb.connect()
-
 my_arrow_table = pa.Table.from_pydict({'i':[1,2,3,4],
                                        'j':["one", "two", "three", "four"]})
 
 # query the Apache Arrow Table "my_arrow_table" and return as an Arrow Table
-results = con.execute("SELECT * FROM my_arrow_table").arrow()
+results = duckdb.sql("SELECT * FROM my_arrow_table").arrow()
 ```
 
 ## Export as a RecordBatchReader
@@ -27,15 +24,12 @@ results = con.execute("SELECT * FROM my_arrow_table").arrow()
 import duckdb
 import pyarrow as pa
 
-# connect to an in-memory database
-con = duckdb.connect()
-
 my_arrow_table = pa.Table.from_pydict({'i':[1,2,3,4],
                                        'j':["one", "two", "three", "four"]})
                                        
 # query the Apache Arrow Table "my_arrow_table" and return as an Arrow RecordBatchReader
 chunk_size = 1_000_000
-results = con.execute("SELECT * FROM my_arrow_table").fetch_record_batch(chunk_size)
+results = duckdb.sql("SELECT * FROM my_arrow_table").fetch_record_batch(chunk_size)
 
 # Loop through the results. A StopIteration exception is thrown when the RecordBatchReader is empty
 while True:

--- a/docs/guides/python/export_pandas.md
+++ b/docs/guides/python/export_pandas.md
@@ -11,13 +11,7 @@ The result of a query can be converted to a Pandas DataFrame using the `df()` fu
 
 ```py
 import duckdb
-import pandas
-
-# connect to an in-memory database
-con = duckdb.connect()
-
-my_df = pandas.DataFrame.from_dict({'a': [42]})
 
 # read the result of an arbitrary SQL query to a Pandas DataFrame
-results = con.execute("SELECT 42").df()
+results = duckdb.sql("SELECT 42").df()
 ```

--- a/docs/guides/python/filesystems.md
+++ b/docs/guides/python/filesystems.md
@@ -22,12 +22,10 @@ then you can register whichever filesystem you'd like to query
 import duckdb
 from fsspec import filesystem
 
-conn = duckdb.connect()
-conn.register_filesystem(filesystem('gcs'))  # this line will throw an exception if the appropriate filesystem interface is not installed
+# this line will throw an exception if the appropriate filesystem interface is not installed
+duckdb.register_filesystem(filesystem('gcs'))
 
-conn.execute("select * from read_csv_auto('gcs:///bucket/file.csv')")
-
-data = conn.fetchall()
+duckdb.sql("select * from read_csv_auto('gcs:///bucket/file.csv')")
 ```
 
 ### Potential issues

--- a/docs/guides/python/import_arrow.md
+++ b/docs/guides/python/import_arrow.md
@@ -13,14 +13,12 @@ import duckdb
 import pyarrow as pa
 
 # connect to an in-memory database
-con = duckdb.connect()
-
 my_arrow = pa.Table.from_pydict({'a':[42]})
 
 # create the table "my_table" from the DataFrame "my_arrow"
-con.execute("CREATE TABLE my_table AS SELECT * FROM my_arrow")
+duckdb.sql("CREATE TABLE my_table AS SELECT * FROM my_arrow")
 
 # insert into the table "my_table" from the DataFrame "my_arrow"
-con.execute("INSERT INTO my_table SELECT * FROM my_arrow")
+duckdb.sql("INSERT INTO my_table SELECT * FROM my_arrow")
 ```
 

--- a/docs/guides/python/import_pandas.md
+++ b/docs/guides/python/import_pandas.md
@@ -13,31 +13,11 @@ import duckdb
 import pandas
 
 # connect to an in-memory database
-con = duckdb.connect()
-
 my_df = pandas.DataFrame.from_dict({'a': [42]})
 
 # create the table "my_table" from the DataFrame "my_df"
-con.execute("CREATE TABLE my_table AS SELECT * FROM my_df")
+duckdb.sql("CREATE TABLE my_table AS SELECT * FROM my_df")
 
 # insert into the table "my_table" from the DataFrame "my_df"
-con.execute("INSERT INTO my_table SELECT * FROM my_df")
-```
-
-## 'object' columns
-
-pandas.DataFrame columns of an `object` dtype require some special care, since this stores values of arbitrary type.
-
-To convert these columns to DuckDB, we first go through an analyze phase before converting the values.
-
-In this analyze phase a sample of all the rows of the column are analyzed to determine the target type.
-
-This sample size is by default set to 1000.
-
-If the type picked during the analyze step is wrong, this will result in a "Failed to cast value:" error, in which case you will need to increase the sample size.
-
-The sample size can be changed by setting the `pandas_analyze_sample` config option.
-```py
-# example setting the sample size to 100000
-duckdb.default_connection.execute("SET GLOBAL pandas_analyze_sample=100000")
+duckdb.sql("INSERT INTO my_table SELECT * FROM my_df")
 ```

--- a/docs/guides/python/polars.md
+++ b/docs/guides/python/polars.md
@@ -4,12 +4,7 @@ title: DuckDB with Polars
 selected: DuckDB with Polars
 ---
 
-[Polars](https://github.com/pola-rs/polars) is a DataFrames library built in Rust with bindings for Python and Node.js. It uses [Apache Arrow's columnar format](https://arrow.apache.org/docs/format/Columnar.html) as its memory model. 
-Polars can output results as Apache Arrow ([which is often a zero-copy operation](https://pola-rs.github.io/polars/py-polars/html/reference/dataframe/api/polars.DataFrame.to_arrow.html)), and DuckDB can read those results directly. 
-DuckDB can also rapidly [output results to Apache Arrow](/docs/guides/python/export_arrow), which can be easily converted to a Polars DataFrame. 
-Due to the interoperability of Apache Arrow, workflows can alternate between DuckDB and Polars with ease! 
-
-This example workflow is also available as a [Google Collab notebook](https://colab.research.google.com/drive/1gz8YaVdwtoibNzP3gbY4VTdIlv_e02y_?usp=sharing).
+[Polars](https://github.com/pola-rs/polars) is a DataFrames library built in Rust with bindings for Python and Node.js. It uses [Apache Arrow's columnar format](https://arrow.apache.org/docs/format/Columnar.html) as its memory model. DuckDB can read Polars DataFrames and convert query results to Polars DataFrames. It does this internally using the efficient Apache Arrow integration. Note that the `pyarrow` library must be installed for the integration to work.
 
 # Installation
 
@@ -18,19 +13,14 @@ pip install duckdb
 pip install -U 'polars[pyarrow]'
 ```
 
-
 # Polars to DuckDB
-To convert from Polars to DuckDB, first save Polars results into an Arrow table using the `to_arrow` function. Then include that Arrow Table in the `FROM` clause of a DuckDB query. This example was based on the Polars Readme.
+DuckDB can natively query Polars DataFrames by referring to the name of Polars DataFrames as they exist in the current scope.
 
-As a note, Pandas is not required as a first step prior to using Polars, but was helpful for generating example data to reuse in the second example below. 
-
-Import the libraries, create an example Pandas DataFrame, then convert to Polars.
 ```python
 import duckdb
 import polars as pl
-import pandas as pd
 
-df = pd.DataFrame(
+df = pl.DataFrame(
     {
         "A": [1, 2, 3, 4, 5],
         "fruits": ["banana", "banana", "apple", "apple", "banana"],
@@ -38,85 +28,20 @@ df = pd.DataFrame(
         "cars": ["beetle", "audi", "beetle", "beetle", "beetle"],
     }
 )
-
-polars_df = pl.DataFrame(df)
-```
-
-Calculate a new Polars DataFrame and output it to a variable as an Apache Arrow table. 
-
-```python
-polars_to_arrow = (
-    polars_df
-    .sort("fruits")
-    .select(
-        [
-            "fruits",
-            "cars",
-            pl.lit("fruits").alias("literal_string_fruits"),
-            pl.col("B").filter(pl.col("cars") == "beetle").sum(),
-            pl.col("A").filter(pl.col("B") > 2).sum().over("cars").alias("sum_A_by_cars"),     # groups by "cars"
-            pl.col("A").sum().over("fruits").alias("sum_A_by_fruits"),                         # groups by "fruits"
-            pl.col("A").reverse().over("fruits").alias("rev_A_by_fruits"),                     # groups by "fruits
-            pl.col("A").sort_by("B").over("fruits").alias("sort_A_by_B_by_fruits"),            # groups by "fruits"
-        ]
-    )
-    .to_arrow()
-)
-```
-
-Then query the Apache Arrow table using DuckDB, and output the results as another Apache Arrow table for use in a subsequent DuckDB or Polars operation.
-
-```python
-output = duckdb.query("""
-  SELECT 
-    fruits,
-    first(sum_A_by_fruits) as sum_A
-  FROM polars_to_arrow
-  GROUP BY ALL
-  ORDER BY ALL
-""").arrow()
+duckdb.sql('SELECT * FROM df').show()
 ```
 
 # DuckDB to Polars
-DuckDB can output results as Apache Arrow tables, which can be imported into Polars with the Polars DataFrame constructor.  The same approach could be used with Pandas DataFrames, but Arrow is a faster way to pass data between DuckDB and Polars.
-
-This example reuses the original Pandas DataFrame created above as a starting point. As a note, Pandas is not required as a first step, but was only used to generate example data.
-
-After the import statements and example DataFrame creation above, query the Pandas DataFrame using DuckDB and output the results as an Arrow table.
+DuckDB can output results as Polars DataFrames using the `.pl()` result-conversion method.
 
 ```python
-duckdb_to_arrow = duckdb.query("""
-  SELECT
-    fruits,
-    cars,
-    'fruits' as literal_string_fruits,
-    SUM(B) FILTER (cars = 'beetle') OVER () as B,
-    SUM(A) FILTER (B > 2) OVER (PARTITION BY cars) as sum_A_by_cars,
-    SUM(A) OVER (PARTITION BY fruits) as sum_A_by_fruits
-  FROM df
-  ORDER BY
-    fruits,
-    df.B
-""").arrow()
-```
-
-Load the Apache Arrow table into Polars using the Polars DataFrame constructor.
-
-```python
-polars_df_2 = pl.DataFrame(duckdb_to_arrow)
-```
-
-Complete a calculation using Polars, then output the results as another Apache Arrow table for use in a subsequent DuckDB or Polars operation.
-```python
-output = (
-    polars_df_2
-    .groupby('fruits')
-    .agg(
-        pl.col('sum_A_by_fruits')
-        .first()
-        .sort_by('fruits')
-        )
-).to_arrow()
+df = duckdb.sql("""
+SELECT 1 AS id, 'banana' AS fruit
+UNION ALL
+SELECT 2, 'apple'
+UNION ALL
+SELECT 3, 'mango'""").pl()
+print(df)
 ```
 
 To learn more about Polars, feel free to explore their [Python API Reference](https://pola-rs.github.io/polars/py-polars/html/reference/index.html)! 

--- a/docs/guides/python/sql_on_pandas.md
+++ b/docs/guides/python/sql_on_pandas.md
@@ -13,10 +13,8 @@ import duckdb
 import pandas
 
 # connect to an in-memory database
-con = duckdb.connect()
-
 my_df = pandas.DataFrame.from_dict({'a': [42]})
 
 # query the Pandas DataFrame "my_df"
-results = con.execute("SELECT * FROM my_df").df()
+results = duckdb.sql("SELECT * FROM my_df").df()
 ```


### PR DESCRIPTION
This PR improves the Python docs in various aspects:

* Use `duckdb.sql` in examples, instead of creating a connection first
* Greatly simplify the "DuckDB and Polars" guide to make use of the new Polars <> DuckDB integration
* Split the Python API overview into separate pages (overview, data ingestion, result conversion and DB API)
* Add (limited) documentation for the new ingestion functions (`.read_csv`, `.read_json` , `.read_parquet`)

Please take a look, there's a bunch of new text + restructuring here.