### PR TITLE
fix: Don't use private method for polars df init

### DIFF
--- a/_posts/2023-02-13-announcing-duckdb-070.md
+++ b/_posts/2023-02-13-announcing-duckdb-070.md
@@ -240,7 +240,7 @@ In addition, Polars DataFrames can be directly queried using the SQL interface.
 ```py
 import duckdb
 import polars as pl
-df = pl.DataFrame._from_dict({'a': 42})
+df = pl.DataFrame({'a': 42})
 duckdb.sql('select * from df').pl()
 ```
 


### PR DESCRIPTION
`DataFrame._from_dict` is private. Adapted so we use the default constructor.