### PR TITLE
adding data load tool (dlt) - DuckDB destination

### DIFF
--- a/why_duckdb.md
+++ b/why_duckdb.md
@@ -86,6 +86,7 @@ Here are some projects that we know of that use DuckDB. If you would like your p
 * [Elixir driver](https://github.com/mpope9/exduckdb) and [Ecto adapter](https://github.com/mpope9/ecto_duckdb/) for DuckDB
 * [DuckDB backend](https://fugue-tutorials.readthedocs.io/tutorials/integrations/backends/duckdb.html) for [Fugue](https://github.com/fugue-project/fugue)
 * [StabilitySort](https://gitlab.com/baaron/StabilitySort) bioinformatics tool for finding unstable variants from predicted AlphaFold2 structures  
+* [Extract and load data from APIs to DuckDB using data load tool](https://dlthub.com/docs/destinations#duckdb)
 
 ## Testimonials
 See our [DuckDB Testimonial Twitter Wall](/docs/twitter_wall)


### PR DESCRIPTION
I would like to add data load tool (dlt) - DuckDB destination as a project mentioned under [Other Projects](https://duckdb.org/why_duckdb#other-projects). I'm opening a PR since I thought it would be easier for everyone, but I can open an issue if necessary. Thanks!