### PR TITLE
New config to exclude archive for faster dev

### DIFF
--- a/_config_exclude_archive.yml
+++ b/_config_exclude_archive.yml
@@ -1,0 +1,2 @@
+# bundler exec jekyll serve --incremental --config _config.yml,_config_exclude_archive.yml
+exclude: ['docs/archive']


### PR DESCRIPTION
I added another jekyll config file that can be added to the existing config when calling `serve` that avoids building the archive. This takes my build time from 80 seconds to 12. It can be called with:
```
bundler exec jekyll serve --incremental --config _config.yml,_config_exclude_archive.yml
```