### PR TITLE
Fix #469 updating sidebar interaction model

### DIFF
--- a/_data/menu_docs_dev.json
+++ b/_data/menu_docs_dev.json
@@ -9,8 +9,11 @@
       "page": "Guides",
       "open": true,
       "slug": "guides/",
-      "url": "index",
       "mainfolderitems": [
+        {
+          "page": "Overview",
+          "url": "index"
+        },
         {
           "page": "Data Import & Export",
           "slug": "import",
@@ -207,9 +210,12 @@
             },
             {
               "page": "CSV Files",
-              "url": "csv",
               "slug": "csv",
               "subsubfolderitems": [
+                {
+                  "page": "Overview",
+                  "url": "/data/csv"
+                },
                 {
                   "page": "Auto Detection",
                   "url": "auto_detection"

--- a/_data/menu_side.json
+++ b/_data/menu_side.json
@@ -6,9 +6,12 @@
       "mainfolderitems": [
         {
           "page": "Testing",
-          "url": "/dev/testing",
           "slug": "sqllogictest",
           "subfolderitems": [
+            {
+              "page": "Overview",
+              "url": "/dev/testing"
+            },
             {
               "page": "SQLLogicTest",
               "url": "/dev/sqllogictest/intro"
@@ -48,6 +51,10 @@
           "url": "/dev/profiling"
         }
       ]
+    },
+    {
+      "page": "Sitemap",
+      "url": "/docs"
     },
     {
       "page": "Why DuckDB",


### PR DESCRIPTION
As per issue here: https://github.com/duckdb/duckdb-web/issues/469

I think this should improve navigation, adding a reachable Sitemap top-level + having only leaves having content (this is more visible on mobile, whether a click means both open sub-menu AND go to page)

I personally think this makes sense, but would be nice to have someone (@Alex-Monahan, @Mause, ?) taking a proper look at this.