### PR TITLE
Add redirect of old CSV link to new CSV link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,6 +35,7 @@ theme: minima
 plugins:
   - jekyll-feed
   - jekyll-seo-tag
+  - jekyll-redirect-from
 excerpt_separator: <!--more-->
 
 twitter:

--- a/docs/data/csv/overview.md
+++ b/docs/data/csv/overview.md
@@ -1,6 +1,8 @@
 ---
 layout: docu
 title: CSV Loading
+redirect_from:
+  - /docs/data/csv
 ---
 
 ### Examples


### PR DESCRIPTION
This adds the `jekyll-redirect-from` plugin as well, we might need to add that somewhere in the requirements