### PR TITLE
Document hash() SQL function

### DIFF
--- a/docs/sql/functions/char.md
+++ b/docs/sql/functions/char.md
@@ -23,6 +23,7 @@ This section describes functions and operators for examining and manipulating st
 | `contains(`*`string`*`, `*`search_string`*`)` | Return true if *search_string* is found within *string* | `contains('abc','a')` | `true` |
 | `format(`*`format`*`, `*`parameters`*`...)` | Formats a string using fmt syntax | `format('Benchmark "{}" took {} seconds', 'CSV', 42)` | `Benchmark "CSV" took 42 seconds` |
 | `from_base64(`*`string`*`)`| Convert a base64 encoded string to a character string. | `from_base64('QQ==')` | `'A'` |
+| `hash(`*`value`*`)` | Returns an integer with the hash of the _value_ | `hash('🦆')` | `2595805878642663834` |
 | `instr(`*`string`*`, `*`search_string`*`)`| Return location of first occurrence of `search_string` in `string`, counting from 1. Returns 0 if no match found. | `instr('test test','es')` | 2 |
 | `lcase(`*`string`*`)` | Alias of `lower`. Convert *string* to lower case | `lcase('Hello')` | `hello` |
 | `left(`*`string`*`, `*`count`*`)`| Extract the left-most count characters | `left('Hello🦆', 2)` | `He` |

--- a/docs/sql/functions/char.md
+++ b/docs/sql/functions/char.md
@@ -23,7 +23,7 @@ This section describes functions and operators for examining and manipulating st
 | `contains(`*`string`*`, `*`search_string`*`)` | Return true if *search_string* is found within *string* | `contains('abc','a')` | `true` |
 | `format(`*`format`*`, `*`parameters`*`...)` | Formats a string using fmt syntax | `format('Benchmark "{}" took {} seconds', 'CSV', 42)` | `Benchmark "CSV" took 42 seconds` |
 | `from_base64(`*`string`*`)`| Convert a base64 encoded string to a character string. | `from_base64('QQ==')` | `'A'` |
-| `hash(`*`value`*`)` | Returns an integer with the hash of the _value_ | `hash('🦆')` | `2595805878642663834` |
+| `hash(`*`value`*`)` | Returns an integer with the hash of the *value* | `hash('🦆')` | `2595805878642663834` |
 | `instr(`*`string`*`, `*`search_string`*`)`| Return location of first occurrence of `search_string` in `string`, counting from 1. Returns 0 if no match found. | `instr('test test','es')` | 2 |
 | `lcase(`*`string`*`)` | Alias of `lower`. Convert *string* to lower case | `lcase('Hello')` | `hello` |
 | `left(`*`string`*`, `*`count`*`)`| Extract the left-most count characters | `left('Hello🦆', 2)` | `He` |

--- a/docs/sql/functions/utility.md
+++ b/docs/sql/functions/utility.md
@@ -17,6 +17,7 @@ The functions below are difficult to categorize into specific function types and
 | `current_setting('setting_name')` | Return the current value of the configuration setting | `current_setting('access_mode')` | `'automatic'` |
 | `currval('sequence_name')` | Return the current value of the sequence. Note that `nextval` must be called at least once prior to calling `currval`. | `currval('my_sequence_name')` | `1` |
 | `gen_random_uuid()` | Alias of `uuid`. Return a random uuid similar to this: eeccb8c5-9943-b2bb-bb5e-222f4e14b687. | `gen_random_uuid()` | various |
+| `hash(`*`value`*`)` | Returns an integer with the hash of the _value_ | `hash('🦆')` | `2595805878642663834` |
 | `icu_sort_key(string , collator)` | Surrogate key used to sort special characters according to the specific locale. Collator parameter is optional. Valid only when ICU extension is installed. | `icu_sort_key('ö','DE')` | 460145960106 |
 | `md5(string)` | Return an md5 one-way hash of the *string*. | `md5('123')` | `'202cb962ac59075b964b07152d234b70'` |
 | `nextval('sequence_name')` | Return the following value of the sequence. | `nextval('my_sequence_name')` | `2` |

--- a/docs/sql/functions/utility.md
+++ b/docs/sql/functions/utility.md
@@ -17,7 +17,7 @@ The functions below are difficult to categorize into specific function types and
 | `current_setting('setting_name')` | Return the current value of the configuration setting | `current_setting('access_mode')` | `'automatic'` |
 | `currval('sequence_name')` | Return the current value of the sequence. Note that `nextval` must be called at least once prior to calling `currval`. | `currval('my_sequence_name')` | `1` |
 | `gen_random_uuid()` | Alias of `uuid`. Return a random uuid similar to this: eeccb8c5-9943-b2bb-bb5e-222f4e14b687. | `gen_random_uuid()` | various |
-| `hash(`*`value`*`)` | Returns an integer with the hash of the _value_ | `hash('🦆')` | `2595805878642663834` |
+| `hash(`*`value`*`)` | Returns an integer with the hash of the *value* | `hash('🦆')` | `2595805878642663834` |
 | `icu_sort_key(string , collator)` | Surrogate key used to sort special characters according to the specific locale. Collator parameter is optional. Valid only when ICU extension is installed. | `icu_sort_key('ö','DE')` | 460145960106 |
 | `md5(string)` | Return an md5 one-way hash of the *string*. | `md5('123')` | `'202cb962ac59075b964b07152d234b70'` |
 | `nextval('sequence_name')` | Return the following value of the sequence. | `nextval('my_sequence_name')` | `2` |


### PR DESCRIPTION
Looks like `hash` function (https://github.com/duckdb/duckdb/pull/3077) is not documented. I added a short description for it. 

Not sure if it's in the right section (since it doesn't apply just to strings), but concluded that the proximity of `md5` makes it a good fit