### PR TITLE
Use same table name in java code examples

### DIFF
--- a/docs/api/java.md
+++ b/docs/api/java.md
@@ -69,7 +69,7 @@ try (ResultSet rs = stmt.executeQuery("SELECT * FROM items")) {
 DuckDB also supports prepared statements as per the JDBC API:
 
 ```java
-try (PreparedStatement p_stmt = conn.prepareStatement("INSERT INTO test VALUES (?, ?, ?);")) {
+try (PreparedStatement p_stmt = conn.prepareStatement("INSERT INTO items VALUES (?, ?, ?);")) {
     p_stmt.setString(1, "chainsaw");
     p_stmt.setDouble(2, 500.0);
     p_stmt.setInt(3, 42);


### PR DESCRIPTION
In the first example, we have named the table as `items`, in the second code example its name is `test`.  This resolves that, making it frictionless for users (like me) who like to copy-paste the entire code.