### PR TITLE
Update dateformat.md

### DIFF
--- a/docs/sql/functions/dateformat.md
+++ b/docs/sql/functions/dateformat.md
@@ -66,7 +66,7 @@ Below is a full list of all available format specifiers.
 | `%-S` | Second as a decimal number. | 0, 1, ..., 59 |
 | `%g` | Millisecond as a decimal number, zero-padded on the left. | 000 - 999 |
 | `%f` | Microsecond as a decimal number, zero-padded on the left. | 000000 - 999999 |
-| `%z` | UTC offset in the form +HHMM or -HHMM. | -0700 |
+| `%z` | [Time offset from UTC](https://en.wikipedia.org/wiki/ISO_8601#Time_offsets_from_UTC) in the form ±HH:MM, ±HHMM, or ±HH. | -0700 |
 | `%Z` | Time zone name. | Europe/Amsterdam  |
 | `%j` | Day of the year as a zero-padded decimal number. | 001, 002, ..., 366 |
 | `%-j` | Day of the year as a decimal number. | 1, 2, ..., 366 |


### PR DESCRIPTION
Change description of time zone format specifier %z so that it specifies patterns ±HH:MM, ±HHMM, and ±HH and includes a link to section "Time offset from UTC" (https://en.wikipedia.org/wiki/ISO_8601#Time_offsets_from_UTC) of Wikipedia page "ISO 8601" (https://en.wikipedia.org/wiki/ISO_8601).