### PR TITLE
Change FROM menu item to FROM & JOIN

### DIFF
--- a/_data/menu_docs_dev.json
+++ b/_data/menu_docs_dev.json
@@ -498,7 +498,7 @@
                 {
                   "page": "Attach",
                   "url": "attach"
-                },
+                }
               ]
             },
             {
@@ -510,7 +510,7 @@
                   "url": "select"
                 },
                 {
-                  "page": "FROM",
+                  "page": "FROM & JOIN",
                   "url": "from"
                 },
                 {

--- a/docs/sql/query_syntax/from.md
+++ b/docs/sql/query_syntax/from.md
@@ -1,12 +1,12 @@
 ---
 layout: docu
-title: FROM Clause
+title: FROM & JOIN Clauses
 selected: Documentation/SQL/Query Syntax/From
 expanded: SQL
 railroad: query_syntax/from.js
 blurb: The FROM clause can contain a single table, a combination of multiple tables that are joined together, or another SELECT query inside a subquery node.
 ---
-The `FROM` clause specifies the *source* of the data on which the remainder of the query should operate. Logically, the `FROM` clause is where the query starts execution. The `FROM` clause can contain a single table, a combination of multiple tables that are joined together, or another `SELECT` query inside a subquery node.
+The `FROM` clause specifies the *source* of the data on which the remainder of the query should operate. Logically, the `FROM` clause is where the query starts execution. The `FROM` clause can contain a single table, a combination of multiple tables that are joined together using `JOIN` clauses, or another `SELECT` query inside a subquery node.
 
 ### Examples
 


### PR DESCRIPTION
A new user wasn't able to quickly find the info on joins that they were looking for, and I have run into the same thing myself where it takes me an extra bit to remember that the join railroad diagram is in the from page! 