### PR TITLE
:student:  Update CASE statement > Add AS keyword

### DIFF
--- a/docs/sql/expressions/case.md
+++ b/docs/sql/expressions/case.md
@@ -10,7 +10,7 @@ railroad: expressions/case.js
 The `CASE` statement performs a switch based on a condition. The basic form is identical to the ternary condition used in many programming languages (`CASE WHEN cond THEN a ELSE b END` is equivalent to `cond ? a : b`).
 ```sql
 -- integers [1, 2, 3]
-SELECT i, CASE WHEN i>2 THEN 1 ELSE 0 END FROM integers;
+SELECT i, CASE WHEN i>2 THEN 1 ELSE 0 END AS test FROM integers;
 -- 1, 2, 3
 -- 0, 0, 1
 ```
@@ -19,7 +19,7 @@ The `WHEN cond THEN expr` part of the `CASE` statement can be chained, whenever 
 
 ```sql
 -- integers [1, 2, 3]
-SELECT i, CASE WHEN i=1 THEN 10 WHEN i=2 THEN 20 ELSE 0 END FROM integers;
+SELECT i, CASE WHEN i=1 THEN 10 WHEN i=2 THEN 20 ELSE 0 END AS test FROM integers;
 -- 1, 2, 3
 -- 10, 20, 0
 ```
@@ -28,7 +28,7 @@ The `ELSE` part of the `CASE` statement is optional. If no else statement is pro
 
 ```sql
 -- integers [1, 2, 3]
-SELECT i, CASE WHEN i=1 THEN 10 END FROM integers;
+SELECT i, CASE WHEN i=1 THEN 10 END AS test FROM integers;
 -- 1, 2, 3
 -- 10, NULL, NULL
 ```
@@ -37,10 +37,10 @@ After the `CASE` but before the `WHEN` an individual expression can also be prov
 
 ```sql
 -- integers [1, 2, 3]
-SELECT i, CASE i WHEN 1 THEN 10 WHEN 2 THEN 20 WHEN 3 THEN 30 END FROM integers;
+SELECT i, CASE i WHEN 1 THEN 10 WHEN 2 THEN 20 WHEN 3 THEN 30 END AS test FROM integers;
 -- 1, 2, 3
 -- 10, 20, 30
 
 -- this is equivalent to:
-SELECT i, CASE WHEN i=1 THEN 10 WHEN i=2 THEN 20 WHEN i=3 THEN 30 END FROM integers;
+SELECT i, CASE WHEN i=1 THEN 10 WHEN i=2 THEN 20 WHEN i=3 THEN 30 END AS test FROM integers;
 ```


### PR DESCRIPTION
# :grey_question: About

The current documentation for `CASE` statement does not emebed the `AS` alias, which makes queries easier to use by putting alias (to create VIEWs or TABLEs on top of the `case` statement)

# :moneybag: Benefits

Merging this PR would make code sample even easier to use.