### PR TITLE
Add JSON import/export docs/guides

### DIFF
--- a/_data/menu_docs_dev.json
+++ b/_data/menu_docs_dev.json
@@ -51,6 +51,14 @@
               "url": "s3_export"
             },
             {
+              "page": "JSON Import",
+              "url": "json_import"
+            },
+            {
+              "page": "JSON Export",
+              "url": "json_export"
+            },
+            {
               "page": "SQLite Import",
               "url": "query_sqlite"
             },
@@ -241,6 +249,16 @@
                 {
                   "page": "Tips",
                   "url": "tips"
+                }
+              ]
+            },
+            {
+              "page": "JSON Files",
+              "slug": "json",
+              "subsubfolderitems": [
+                {
+                  "page": "Overview",
+                  "url": "overview"
                 }
               ]
             },

--- a/docs/data/json/overview.md
+++ b/docs/data/json/overview.md
@@ -1,0 +1,124 @@
+---
+layout: docu
+title: JSON Loading
+redirect_from:
+  - /docs/data/json
+---
+
+### Examples
+
+```sql
+-- read a JSON file from disk, auto-infer options
+SELECT * FROM 'todos.json';
+-- read_json with custom options
+SELECT *
+FROM read_json('todos.json',
+               json_format='array_of_records',
+               columns={userId: 'UBIGINT',
+                        id: 'UBIGINT',
+                        title: 'VARCHAR',
+                        completed: 'BOOLEAN'});
+-- read a JSON file from stdin, auto-infer options
+cat data/json/todos.json | duckdb -c "select * from read_json_auto('/dev/stdin')"
+
+-- read a JSON file into a table
+CREATE TABLE todos(userId UBIGINT, id UBIGINT, title VARCHAR, completed BOOLEAN);
+COPY todos FROM 'todos.json';
+-- alternatively, create a table without specifying the schema manually
+CREATE TABLE todos AS SELECT * FROM 'todos.json';
+
+-- write the result of a query to a JSON file
+COPY (SELECT * FROM todos) TO 'todos.json';
+```
+
+### JSON Loading
+JSON is an open standard file format and data interchange format that uses human-readable text to store and transmit data objects consisting of attribute–value pairs and arrays (or other serializable values).
+While it is not a very efficient format for tabular data, it is very commonly used, as a data interchange format.
+
+The DuckDB JSON reader can automatically infer which configuration flags to use by analyzing the JSON file. This will work correctly in most situations, and should be the first option attempted. In rare situations where the JSON reader cannot figure out the correct configuration, it is possible to manually configure the JSON reader to correctly parse the JSON file.
+
+Below are parameters that can be passed in to the JSON reader.
+
+# Parameters
+
+| Name | Description | Type | Default |
+|:---|:---|:---|:---|
+| `maximum_object_size` | The maximum size of a JSON object (in bytes) | uinteger | `1048576` |
+| `lines` | When set to `'true` only newline-delimited JSON can be read, which can be read in parallel, When set to `'false'`, pretty-printed JSON can be read. Set to `'auto'` to automatically detect | varchar | `'false'` |
+| `ignore_errors` | Whether to ignore parse errors (only possible when `lines` is `'true'`) | bool | false |
+| `compression` | The compression type for the file. By default this will be detected automatically from the file extension (e.g. **t.json.gz** will use gzip, **t.json** will use none). Options are `'none'`, `'gzip'`, `'zstd'`, and `'auto'`. | varchar | `'auto'` |
+| `columns` | A struct that specifies the key names and value types contained within the JSON file (e.g. `{key1: 'INTEGER', key2: 'VARCHAR'}`). If `auto_detect` is enabled these will be inferred | struct | `(empty)` |
+| `json_format` | Can be one of `['auto', 'records', 'array_of_records', 'values', 'array_of_values']` | varchar | `'records'` |
+| `auto_detect` | Whether to auto-detect detect the names of the keys and data types of the values automatically | bool | `false` |
+| `sample_size` | Option to define number of sample objects for automatic JSON type detection. Set to -1 to scan the entire input file | ubigint | `2048` |
+| `maximum_depth` | Maximum nesting depth to which the automatic schema detection detects types. Set to -1 to fully detect nested JSON types | bigint | `-1` |
+| `dateformat` | Specifies the date format to use when parsing dates. See [Date Format](../sql/functions/dateformat) | varchar | `'iso'` |
+| `timestampformat` | Specifies the date format to use when parsing timestamps. See [Date Format](../sql/functions/dateformat) | varchar | `'iso'`|
+
+When using `read_json_auto`, everything parameter that supports auto-detection is enabled.
+
+### Writing
+
+The contents of tables or the result of queries can be written directly to a JSON file using the `COPY` statement. See the [COPY documentation](../../sql/statements/copy#copy-to) for more information.
+
+# read_json_auto function
+The `read_json_auto` is the simplest method of loading JSON files: it automatically attempts to figure out the correct configuration of the JSON reader. It also automatically deduces types of columns.
+
+```sql
+SELECT * FROM read_json_auto('todos.json') LIMIT 5;
+```
+
+| userId | id |                              title                              | completed |
+|--------|----|-----------------------------------------------------------------|-----------|
+| 1      | 1  | delectus aut autem                                              | false     |
+| 1      | 2  | quis ut nam facilis et officia qui                              | false     |
+| 1      | 3  | fugiat veniam minus                                             | false     |
+| 1      | 4  | et porro tempora                                                | true      |
+| 1      | 5  | laboriosam mollitia et enim quasi adipisci quia provident illum | false     |
+
+The path can either be a relative path (relative to the current working directory) or an absolute path.
+
+We can use `read_json_auto` to create a persistent table as well:
+
+```sql
+CREATE TABLE todos AS SELECT * FROM read_json_auto('todos.json');
+DESCRIBE todos;
+```
+
+| column_name | column_type | null | key | default | extra |
+|-------------|-------------|------|-----|---------|-------|
+| userId      | UBIGINT     | YES  |     |         |       |
+| id          | UBIGINT     | YES  |     |         |       |
+| title       | VARCHAR     | YES  |     |         |       |
+| completed   | BOOLEAN     | YES  |     |         |       |
+
+If we specify the columns, we can bypass the automatic detection. Note that not all columns need to be specified:
+
+```sql
+SELECT *
+FROM read_json_auto('todos.json',
+                    columns={userId: 'UBIGINT',
+                             completed: 'BOOLEAN'});
+```
+
+Multiple files can be read at once by providing a glob or a list of files. Refer to the [multiple files section](../multiple_files/overview) for more information.
+
+
+## COPY Statement
+The `COPY` statement can be used to load data from a JSON file into a table. For the `COPY` statement, we must first create a table with the correct schema to load the data into. We then specify the JSON file to load from plus any configuration options separately.
+
+```sql
+CREATE TABLE todos(userId UBIGINT, id UBIGINT, title VARCHAR, completed BOOLEAN);
+COPY todos FROM 'todos.json';
+SELECT * FROM todos LIMIT 5;
+```
+
+| userId | id |                              title                              | completed |
+|--------|----|-----------------------------------------------------------------|-----------|
+| 1      | 1  | delectus aut autem                                              | false     |
+| 1      | 2  | quis ut nam facilis et officia qui                              | false     |
+| 1      | 3  | fugiat veniam minus                                             | false     |
+| 1      | 4  | et porro tempora                                                | true      |
+| 1      | 5  | laboriosam mollitia et enim quasi adipisci quia provident illum | false     |
+
+More on the copy statement can be found [here](/docs/sql/statements/copy.html).

--- a/docs/data/overview.md
+++ b/docs/data/overview.md
@@ -37,6 +37,15 @@ SELECT * FROM read_parquet('test.parquet');
 
 See [here](../data/parquet) for a detailed description of Parquet loading.
 
+### JSON Loading
+JSON files can be efficiently loaded and queried using the `read_json_auto` function.
+
+```sql
+SELECT * from read_json_auto('test.json');
+```
+
+See [here](../data/json) for a detailed description of JSON loading.
+
 ### Appender (C++ and Java)
 
 In C++ and Java, the appender can be used as an alternative for bulk data loading. This class can be used to efficiently add rows to the database system without needing to use SQL.

--- a/docs/extensions/json.md
+++ b/docs/extensions/json.md
@@ -148,6 +148,8 @@ By reading the first example with `json_format='values'` and the second example 
 | [1, 2, 3] |
 | [4, 5, 6] |
 
+For additional examples reading more complex data, please see the [Shredding Deeply Nested JSON, One Vector at a Time blog post](https://duckdb.org/2023/03/03/json.html).
+
 ## JSON Import/Export
 When the JSON extension is installed, `FORMAT JSON` is supported for `COPY FROM`, `COPY TO`, `EXPORT DATABASE` and `IMPORT DATABASE`. See [Copy](../sql/statements/copy) and [Import/Export](../sql/statements/export).
 

--- a/docs/extensions/json.md
+++ b/docs/extensions/json.md
@@ -16,16 +16,16 @@ The following two table functions are used to read JSON:
 | Function | Description |
 |:---|:---|
 | `read_json_objects(`*`filename`*`)`   | Read 1 JSON objects from **filename**, where **filename** can be list of files, or a glob pattern |
-| `read_ndjson_objects(`*`filename`*`)` | Alias for `read_json_objects` with parameter **format** set to `'newline_delimited'` |
+| `read_ndjson_objects(`*`filename`*`)` | Alias for `read_json_objects` with parameter **lines** set to `'true'` |
 
 These functions have the following parameters:
 
-| Name | Description |
-|:---|:---|
-| `maximum_object_size` | The maximum size of a JSON object (in bytes), defaults to 1MB |
-| `lines` | Defaults to `'false'`, which can read pretty-printed JSON. When set to `'true` only newline-delimited JSON can be read, which can be read in parallel. Set to `'auto'` to automatically detect |
-| `ignore_errors` | Whether to ignore parse errors (only possible when `format` is equal to `'newline_delimited'`) |
-| `compression` | The compression type for the file. By default this will be detected automatically from the file extension (e.g. **t.csv.gz** will use gzip, **t.csv** will use none). Options are `'none'`, `'gzip'`, `'zstd'`, and `'auto'`. |
+| Name | Description | Type | Default
+|:---|:---|:---|:---|
+| `maximum_object_size` | The maximum size of a JSON object (in bytes) | uinteger | `1048576` |
+| `lines` | When set to `'true` only newline-delimited JSON can be read, which can be read in parallel, When set to `'false'`, pretty-printed JSON can be read. Set to `'auto'` to automatically detect | varchar | `'false'` |
+| `ignore_errors` | Whether to ignore parse errors (only possible when `lines` is `'true'`) | bool | false |
+| `compression` | The compression type for the file. By default this will be detected automatically from the file extension (e.g. **t.json.gz** will use gzip, **t.json** will use none). Options are `'none'`, `'gzip'`, `'zstd'`, and `'auto'`. | varchar | `'auto'` |
 
 Examples:
 ```sql
@@ -44,21 +44,21 @@ DuckDB also supports reading JSON as a table, using the following functions:
 | Function | Description |
 |:---|:---|
 | `read_json(`*`filename`*`)`   | Read JSON from **filename**, where **filename** can be list of files, or a glob pattern |
-| `read_ndjson(`*`filename`*`)` | Alias for `read_json` with parameter **format** set to `'newline_delimited'` |
+| `read_ndjson(`*`filename`*`)` | Alias for `read_json` with parameter **lines** set to `'true'` |
 | `read_json_auto(`*`filename`*`)`   | Read 1 json objects from **filename**, where **filename** can be list of files, or a glob pattern |
-| `read_ndjson_auto(`*`filename`*`)` | Alias for `read_json_auto` with parameter **format** set to `'newline_delimited'` |
+| `read_ndjson_auto(`*`filename`*`)` | Alias for `read_json_auto` with parameter **lines** set to `'true'` |
 
-Besides the `maximum_object_size`, `format`, `ignore_errors` and `compression`, these functions have additional parameters:
+Besides the `maximum_object_size`, `lines`, `ignore_errors` and `compression`, these functions have additional parameters:
 
-| Name | Description |
-|:---|:---|
-| `columns` | A struct that specifies the key names and value types contained within the JSON file (e.g. `{'key1': 'INTEGER', 'key2': 'VARCHAR'}`). If `auto_detect` is enabled these will be inferred |
-| `json_format` | Defaults to `'records'`, or to `'auto'` for `read_json_auto`. Can be one of `['auto', 'records', 'array_of_records', 'values', 'array_of_values']` |
-| `auto_detect` | Option for JSON parsing. If `true`, the parser will attempt to detect the names of the keys and data types of the values automatically. `read_json_auto` defaults to `true` for this parameter, `read_json` defaults to `false` |
-| `sample_size` | Option to define number of sample objects for automatic JSON type detection. Set to -1 to scan the entire input file. Defaults to 2048 |
-| `maximum_depth` | Maximum nesting depth to which the automatic schema detection detects types. Defaults to -1 to fully detect nested JSON types |
-| `dateformat` | Specifies the date format to use when parsing dates. See [Date Format](../sql/functions/dateformat) |
-| `timestampformat` | Specifies the date format to use when parsing timestamps. See [Date Format](../sql/functions/dateformat) |
+| Name | Description | Type | Default |
+|:---|:---|:---|:---|
+| `columns` | A struct that specifies the key names and value types contained within the JSON file (e.g. `{key1: 'INTEGER', key2: 'VARCHAR'}`). If `auto_detect` is enabled these will be inferred | struct | `(empty)` |
+| `json_format` | Can be one of `['auto', 'records', 'array_of_records', 'values', 'array_of_values']` | varchar | `'records'` |
+| `auto_detect` | Whether to auto-detect detect the names of the keys and data types of the values automatically | bool | `false` |
+| `sample_size` | Option to define number of sample objects for automatic JSON type detection. Set to -1 to scan the entire input file | ubigint | `2048` |
+| `maximum_depth` | Maximum nesting depth to which the automatic schema detection detects types. Set to -1 to fully detect nested JSON types | bigint | `-1` |
+| `dateformat` | Specifies the date format to use when parsing dates. See [Date Format](../sql/functions/dateformat) | varchar | `'iso'` |
+| `timestampformat` | Specifies the date format to use when parsing timestamps. See [Date Format](../sql/functions/dateformat) | varchar | `'iso'`|
 
 Examples:
 ```sql

--- a/docs/guides/import/json_export.md
+++ b/docs/guides/import/json_export.md
@@ -1,0 +1,21 @@
+---
+layout: docu
+title: JSON Export
+selected: JSON Export
+---
+
+# How to export a table to a JSON file
+
+To export the data from a table to a JSON file, use the `COPY` statement.
+
+```sql
+COPY tbl TO 'output.json' (HEADER, DELIMITER ',');
+```
+
+The result of queries can also be directly exported to a JSON file.
+
+```sql
+COPY (SELECT * FROM tbl) TO 'output.json';
+```
+
+For additional options, see the [COPY statement documentation](../../sql/statements/copy).

--- a/docs/guides/import/json_import.md
+++ b/docs/guides/import/json_import.md
@@ -1,0 +1,32 @@
+---
+layout: docu
+title: JSON Import
+selected: JSON Import
+---
+
+# How to load a JSON file into a table
+
+To read data from a JSON file, use the `read_json_auto` function in the `FROM` clause of a query. 
+
+```sql
+SELECT * FROM read_json_auto('input.json');
+```
+
+To create a new table using the result from a query, use `CREATE TABLE AS` from a `SELECT` statement.
+
+```sql
+CREATE TABLE new_tbl AS SELECT * FROM read_json_auto('input.json');
+```
+To load data into an existing table from a query, use `INSERT INTO` from a `SELECT` statement.
+
+```sql
+INSERT INTO tbl SELECT * FROM read_json_auto('input.json');
+```
+
+Alternatively, the `COPY` statement can also be used to load data from a JSON file into an existing table.
+
+```sql
+COPY tbl FROM 'input.json';
+```
+
+For additional options, see the [JSON Loading reference](../../data/json) and the [COPY statement documentation](../../sql/statements/copy).

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -19,6 +19,11 @@ The guides section contains compact how-to guides that are focused on achieving 
 * [How to export a table to a Parquet file](../guides/import/parquet_export)
 * [How to run a query directly on a Parquet file](../guides/import/query_parquet)
 
+##### JSON Files
+
+* [How to load a JSON file into a table](../guides/import/json_import)
+* [How to export a table to a JSON file](../guides/import/json_export)
+
 ##### HTTP, S3 and GCP
 
 * [How to load a Parquet file directly from HTTP(s)](../guides/import/http_import)


### PR DESCRIPTION
I used the CSV import/export docs as an example. I will revisit this when I do more development on the JSON extension.