### PR TITLE
Add homebrew installation doc

### DIFF
--- a/_includes/installation.html
+++ b/_includes/installation.html
@@ -159,7 +159,8 @@ DBInterface.execute(con, "CREATE TABLE integers(i INTEGER)"){%- endhighlight -%}
 	</div>
 
 	<div class="latest cli binary macos">
-		<a href="https://github.com/duckdb/duckdb/releases/download/v{{ site.currentduckdbversion }}/duckdb_cli-osx-universal.zip" target="_blank">https://github.com/duckdb/duckdb/releases/download/v{{ site.currentduckdbversion }}/duckdb_cli-osx-universal.zip</a>
+		Homebrew: brew install duckdb<br/>
+		GitHub Binary: <a href="https://github.com/duckdb/duckdb/releases/download/v{{ site.currentduckdbversion }}/duckdb_cli-osx-universal.zip" target="_blank">https://github.com/duckdb/duckdb/releases/download/v{{ site.currentduckdbversion }}/duckdb_cli-osx-universal.zip</a>
 	</div>
 
 	<div class="latest cli binary linux">


### PR DESCRIPTION
There is a nice duckdb [homebrew formula](https://formulae.brew.sh/formula/duckdb#default) but it's not referenced anywhere in the documentation.
I believe this could be the default way for any macos user, it's added to the `PATH`, and managing upgrade is straightforward.

Not sure about the location where to put it through, happy to hear your thoughts