### PR TITLE
:tea: tea.xyz/+duckdb.org > Update installation.html > Add tea.xyz to install options

### DIFF
--- a/_includes/installation.html
+++ b/_includes/installation.html
@@ -17,6 +17,7 @@
 		<h3>Environment</h3>
 		<ul class="environment">
 			<li data-id=".cli" class="selected">Command Line</li>
+			<li data-id=".tea">Command Line (tea.xyz)</li>
 			<li data-id=".python">Python</li>
 			<li data-id=".r">R</li>
 			<li data-id=".java">Java</li>
@@ -113,6 +114,10 @@ DBInterface.execute(con, "CREATE TABLE integers(i INTEGER)"){%- endhighlight -%}
 
 	<div class="latest python">
 		{% highlight bash %}pip install duckdb=={{ site.currentduckdbversion }}{% endhighlight %}
+	</div>
+	
+	<div class="latest tea">
+		{% highlight bash %}sh <(curl https://tea.xyz) +duckdb.org{% endhighlight %}
 	</div>
 
 	<div class="latest r">


### PR DESCRIPTION
# :grey_question: About

[`tea.xyz`](https://tea.xyz/) is a great way of : 

- :heavy_check_mark:  install software
- :heavy_check_mark:  using software without installing
- :heavy_check_mark:  keeping up-to-date very easily
- :heavy_check_mark:  Write easy tutorial oneliners to share code around duckdb

`duckdb` has recenlty been deployed into [`tea.xyz/+duckdb.org/`](https://tea.xyz/+duckdb.org/)

:point_right: Now, it just has to be added to install options :smile_cat: 

![image](https://user-images.githubusercontent.com/5235127/225758947-9b88f2f6-d7be-4ae5-8a8c-9be615ea1baa.png)

# :dart:  NB about PR

:point_up_2: I've added some code but due to my lack of Jekyll knowledge, **I was not able to add the following resources :** 

```shell
sh <(curl https://tea.xyz) +duckdb.org duckdb -version
```

```shell
sh <(curl https://tea.xyz) +duckdb.org duckdb -c 'select version()'
``` 

# :bookmark: Related resources

- https://github.com/duckdb/duckdb/discussions/6721
- https://github.com/teaxyz/pantry/issues/787
- https://github.com/teaxyz/pantry/issues/780
- https://tea.xyz/
- https://tea.xyz/+duckdb.org/