### PR TITLE
Add documentation of GCD and LCM functions

### DIFF
--- a/docs/sql/functions/numeric.md
+++ b/docs/sql/functions/numeric.md
@@ -47,10 +47,12 @@ The table below shows the available mathematical functions.
 | `factorial(x)` | See `!` operator. Computes the product of the current integer and all integers below it | `factorial(4)` | 24 |
 | `floor(x)` | rounds the number down | `floor(17.4)` | 17 |
 | `gamma(x)` | interpolation of (x-1) factorial (so decimal inputs are allowed) | `gamma(5.5)` | 52.34277778455352 |
+| `gcd(x, x)` | computes the greatest common divisor of x and y | `gcd(42, 57)` | 3 |
 | `greatest(x1, x2, ...)` | selects the largest value | `greatest(3, 2, 4, 4)` | 4 |
 | `isfinite(x)` | Returns true if the floating point value is finite, false otherwise | `isfinite(5.5)` | true |
 | `isinf(x)` | Returns true if the floating point value is infinite, false otherwise | `isinf('Infinity'::float)` | true |
 | `isnan(x)` | Returns true if the floating point value is not a number, false otherwise | `isnan('NaN'::float)` | true |
+| `lcm(x, y)` | computes the least common multiple of x and y | `lcm(42, 57)` | 798 |
 | `least(x1, x2, ...)` | selects the smallest value | `least(3, 2, 4, 4)` | 2 |
 | `lgamma(x)` | computes the log of the `gamma` function. | `lgamma(2)` | 0 |
 | `ln(x)` | computes the natural logarithm of *x* | `ln(2)` | 0.693 |


### PR DESCRIPTION
The functions GCD and LCM have been added to duckdb. This pr adds them to the documentation as well.