### PR TITLE
stackoverflow bot

### DIFF
--- a/.github/workflows/stackoverflow.yml
+++ b/.github/workflows/stackoverflow.yml
@@ -1,0 +1,27 @@
+name: Discord stackoverflow bot 
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 11 * * *"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: github.repository == 'duckdb/duckdb-web'
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setting up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+          architecture: "x64"
+
+      - name: Trigger StackOverflow Bot
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          pip install duckdb requests
+          python3 ./scripts/stackoverflow_bot.py

--- a/scripts/stackoverflow_bot.py
+++ b/scripts/stackoverflow_bot.py
@@ -1,0 +1,60 @@
+import os
+import duckdb 
+import json
+import requests
+
+DISCORD_WEBHOOK_URL = os.environ.get('DISCORD_WEBHOOK_URL')
+STACK_OVERFLOW_API_URL = 'https://api.stackexchange.com/2.3/questions'
+
+def post_to_discord(title, url, profile_image):
+    payload = {
+        "username": "Stack Overflow",
+        "embeds": [
+            {
+                "title": title,
+                "content": "this is a question",
+                "color": 16023588,
+                "thumbnail": {"url": profile_image},
+                "description": url
+            }
+        ]
+    }
+    with requests.post(DISCORD_WEBHOOK_URL, json=payload) as response:
+        print(response.status_code)
+
+if __name__ == '__main__':
+    params = {
+        'tagged': 'duckdb',
+        'sort': 'creation',
+        'order': 'desc',
+        'site': 'stackoverflow'
+    }
+    response = requests.get(STACK_OVERFLOW_API_URL, params=params)
+
+    if response.status_code == 200:
+        data = response.json()
+        so_duckdb_tag = response.json()['items']
+        with open("so.json", "w") as f:
+            for item in so_duckdb_tag:
+                f.write(json.dumps(item) + '\n')
+
+        duckdb.sql('''
+                CREATE OR REPLACE TABLE SO AS 
+                SELECT * FROM read_ndjson_auto('./so.json')
+                ORDER BY creation_date DESC
+                Limit 30
+        ''')
+
+        new_duckdb_questions = duckdb.sql('''
+            SELECT title, link, owner.profile_image,
+                TO_TIMESTAMP(creation_date::BIGINT) create_time,
+            FROM SO 
+            WHERE create_time > NOW() - INTERVAL 3 DAY
+            LIMIT 5
+        ''').fetchall()
+
+        for q in new_duckdb_questions:
+            post_to_discord(q[0], q[1], q[2])
+    else:
+        print(f'Request failed with status code {response.status_code}')
+

--- a/scripts/stackoverflow_bot.py
+++ b/scripts/stackoverflow_bot.py
@@ -12,7 +12,6 @@ def post_to_discord(title, url, profile_image):
         "embeds": [
             {
                 "title": title,
-                "content": "this is a question",
                 "color": 16023588,
                 "thumbnail": {"url": profile_image},
                 "description": url
@@ -49,12 +48,15 @@ if __name__ == '__main__':
             SELECT title, link, owner.profile_image,
                 TO_TIMESTAMP(creation_date::BIGINT) create_time,
             FROM SO 
-            WHERE create_time > NOW() - INTERVAL 3 DAY
+            WHERE create_time > NOW() - INTERVAL 1 DAY
             LIMIT 5
-        ''').fetchall()
+        ''')
+ 
+        new_duckdb_questions.project('title, create_time').show()
 
-        for q in new_duckdb_questions:
-            post_to_discord(q[0], q[1], q[2])
+        for title, link, image, _ in new_duckdb_questions.fetchall():
+            post_to_discord(title, link, image)
+
     else:
         print(f'Request failed with status code {response.status_code}')
 


### PR DESCRIPTION
   The bot has been designed to find all questions that have been posted within the last 3 days on StackOverflow with the "duckdb" tag. It will then post those questions to a designated discord channel.

 The bot that will trigger every UTC 11:00 using Github Actions, while the time is 13:00 in Amsterdam(?).
  
We can also trigger the bot manually


<img width="1428" alt="image" src="https://user-images.githubusercontent.com/103009868/228123338-66585d26-3b66-42c5-a454-c46553279c4e.png">


   Since we launch the bot daily to search for questions posted within the last 3 days, there may be instances of duplicate questions. However, we can easily address this issue by modifying the search to only include questions posted within the last 24 hours. This can be done by updating the `new_duckdb_questions` variable in the `stackoverflow_bot.py` file to `create_time > NOW() - INTERVAL 1 DAY`.

Thanks, @Alex-Monahan for helping with this
