### PR TITLE
Add a jekyll component: iframe

### DIFF
--- a/_includes/iframe.html
+++ b/_includes/iframe.html
@@ -1,0 +1,3 @@
+<div style="position:relative; padding-bottom:60%; width: 100%">
+    <iframe src="{{ include.src }}" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe>
+</div>

--- a/docs/api/wasm.md
+++ b/docs/api/wasm.md
@@ -5,9 +5,7 @@ selected: Client APIs
 ---
 DuckDB has been compiled to WebAssembly, so it can run inside any browser on any device.
 
-<div style="position:relative; padding-bottom:60%; width: 100%">
-    <iframe src="https://shell.duckdb.org" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe>
-</div>
+{% include iframe.html src="https://shell.duckdb.org" %}
 
 DuckDB-Wasm offers a layered API, it can be embedded as a [JavaScript + WebAssembly library](https://www.npmjs.com/package/@duckdb/duckdb-wasm), as a [Web shell](https://www.npmjs.com/package/@duckdb/duckdb-wasm-shell), or [built from source](https://github.com/duckdb/duckdb-wasm) according to your needs.
 


### PR DESCRIPTION
Use it in docs/api/wasm.md.

Note that I am not able to build docs locally, so while the change seems simple there are non negligible changes of it being borked, if someone touches this try to reproduce locally first.

Moving this to component so can be reused more easily (eg. @Tmonster!).

Currently it's pretty minimal, filling the parent width + having a fixed ratio, but if this work we could add optional parameters as it seems needed.