### PR TITLE
Add CHECKPOINT documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ First, thank you for your contribution!
 
 Each new page requires at least 2 edits:
 * The creation of a new markdown page with the documentation. Please follow the format of another .md file in the docs folder.
-* Add a link to the new page within _data/menu_docs_current.json. This populates the dropdown menus.
+* Add a link to the new page within _data/menu_docs_dev.json. This populates the dropdown menus.
 
 The addition of a new guide requires one additional edit:
 * Add a link to the new page within the Guides landing page: docs/guides/index.md
 
-Each new page must also be added to the Search feature. Either manually edit the file _data/search_data.json or:
+Each new page must also be added to the Search feature. Either manually edit the file data/search_data.json or:
 * Install Python
 * Clone this repo and navigate to it
 * Create a new Python virtual environment

--- a/_data/menu_docs_dev.json
+++ b/_data/menu_docs_dev.json
@@ -520,6 +520,10 @@
                 {
                   "page": "Pivot",
                   "url": "pivot"
+                },
+                {
+                  "page": "Checkpoint",
+                  "url": "checkpoint"
                 }
               ]
             },

--- a/data/search_data.json
+++ b/data/search_data.json
@@ -295,6 +295,13 @@
 			"blurb": "Casting refers to the process of changing the type of a row from one type to another. The standard SQL syntax for..."
 		},
 		{
+			"title": "Checkpoint",
+			"text": "the checkpoint statement synchronizes data in the write-ahead log wal to the database data file for in-memory databases this statement will succeed with no effect examples -- synchronize data in the default database checkpoint -- synchronize data in the specified database checkpoint file_db -- abort any in-progress transactions to synchronize the data force checkpoint syntax transactions the default checkpoint command will fail if there are any running transactions including force will abort any transactions and execute the checkpoint operation",
+			"category": "Statements",
+			"url": "/docs/sql/statements/checkpoint",
+			"blurb": "The CHECKPOINT statement synchronizes data in the write-ahead log (WAL) to the database data file. For in-memory..."
+		},
+		{
 			"title": "Client APIs Overview",
 			"text": "there are various client apis for duckdb duckdb s native api is c with official wrappers available for c python r java node js webassembly wasm odbc api julia and a command line interface cli there are also contributed third-party duckdb wrappers for ruby go c rust and common lisp pages in this section",
 			"category": "Api",

--- a/docs/sql/statements/checkpoint.md
+++ b/docs/sql/statements/checkpoint.md
@@ -1,0 +1,27 @@
+---
+layout: docu
+title: Checkpoint
+selected: Documentation/SQL/Checkpoint
+expanded: SQL
+railroad: statements/checkpoint.js
+---
+
+The `CHECKPOINT` statement synchronizes data in the write-ahead log (WAL) to the database data file. For in-memory
+databases this statement will succeed with no effect.
+
+### Examples
+```sql
+-- Synchronize data in the default database
+CHECKPOINT;
+-- Synchronize data in the specified database
+CHECKPOINT file_db;
+-- Abort any in-progress transactions to synchronize the data
+FORCE CHECKPOINT;
+```
+
+### Syntax
+<div id="rrdiagram1"></div>
+
+### Transactions
+The default `CHECKPOINT` command will fail if there are any running transactions. Including `FORCE` will abort any
+transactions and execute the checkpoint operation.

--- a/js/statements/checkpoint.js
+++ b/js/statements/checkpoint.js
@@ -1,0 +1,24 @@
+function GenerateCheckpoint(options = {}) {
+    return Diagram([
+        AutomaticStack([
+            Optional(Keyword("FORCE"), "skip"),
+            Keyword("CHECKPOINT"),
+            Optional(Sequence([
+                Expression("database")
+            ]))
+        ])
+    ])
+}
+
+function Initialize(options = {}) {
+    document.getElementById("rrdiagram1").classList.add("limit-width");
+    document.getElementById("rrdiagram1").innerHTML = GenerateCheckpoint(options).toString();
+}
+
+function Refresh(node_name, set_node) {
+    options[node_name] = set_node;
+    Initialize(options);
+}
+
+options = {}
+Initialize()


### PR DESCRIPTION
Adds a page for the `CHECKPOINT` statement. I took the basic information from https://github.com/duckdb/duckdb/pull/1356. Please let me know if I missed anything.

I also fixed a few paths in the README file.