### PR TITLE
add date function examples with a variable interval

### DIFF
--- a/docs/sql/functions/date.md
+++ b/docs/sql/functions/date.md
@@ -13,8 +13,10 @@ The table below shows the available mathematical operators for `DATE` types.
 |:---|:---|:---|:---|
 | `+` | addition of days (integers) | `DATE '1992-03-22' + 5` | 1992-03-27 |
 | `+` | addition of an `INTERVAL` | `DATE '1992-03-22' + INTERVAL 5 DAY` | 1992-03-27 |
+| `+` | addition of a variable `INTERVAL` | `SELECT DATE '1992-03-22' + INTERVAL 1 DAY * d.days FROM (VALUES (5), (11)) AS d(days)` |1992-03-27 1992-04-02 |
 | `-` | subtraction of `DATE`s | `DATE '1992-03-27' - DATE '1992-03-22'` | 5 |
 | `-` | subtraction of an `INTERVAL` | `DATE '1992-03-27' - INTERVAL 5 DAY'` | 1992-03-22 |
+| `-` | subtraction of a variable `INTERVAL` | `SELECT DATE '1992-03-27' - INTERVAL 1 DAY * d.days FROM (VALUES (5), (11)) AS d(days)` |1992-03-22 1992-03-16 |
 
 Adding to or subtracting from [infinite values](../../sql/data_types/date#special-values) produces the same infinite value.
 


### PR DESCRIPTION
I noticed it was not possible to simply add or subtract variable intervals from a date. I had imagined something like this:
```
SELECT DATE '1992-03-22' + INTERVAL d.days DAY FROM (VALUES (5), (11)) AS d(days);
```
But this gives me a Parser Error. In the comments of a benchmark query I found something that tipped me off with this workaround:
```
SELECT DATE '1992-03-22' + INTERVAL 1 DAY * d.days FROM (VALUES (5), (11)) AS d(days)
```
I thought it a nice addition to the docs as this workaround was not obvious to me.
