### PR TITLE
add popup for outdated document

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -400,13 +400,35 @@ $(document).ready(function(){
 		}
 	})
 	*/
+
+	var outdatedLinks = [
+		'https://duckdb.org/docs/archive/0.6.1/index',
+		'https://duckdb.org/docs/archive/0.5.1/index',
+		'https://duckdb.org/docs/archive/0.4.0/index',
+		'https://duckdb.org/docs/archive/0.3.4/index',
+		'https://duckdb.org/docs/archive/0.3.3/index',
+		'https://duckdb.org/docs/archive/0.3.2/index',
+		'https://duckdb.org/docs/archive/0.3.1/index',
+		'https://duckdb.org/docs/archive/0.3.0/index',
+		'https://duckdb.org/docs/archive/0.2.9/index',
+		'https://duckdb.org/docs/archive/0.2.8/index'
+	  ];
+	  
+	  if (outdatedLinks.includes(window.location.href)) {
 	
-	// VERSION FIX ON MOBILE
-	$('.headlinebar .version').click(function(){
-		$('.versionsidebar').toggleClass('active');
-	})
+		var popup = document.createElement('div');
+		popup.innerHTML = 'This documentation version is outdated. Please refer to the latest <a href="http://127.0.0.1:4000/docs/archive/0.7.1/index">documentation</a>.';
+		popup.style.backgroundColor = 'yellow';
+		popup.style.padding = '10px';
+		popup.style.textAlign = 'center';
+		popup.style.zIndex = '9999';
+		document.querySelector('.headerline').appendChild(popup);
+	  
 	
-	
+		popup.addEventListener('click', function() {
+		  popup.style.display = 'none';
+		});
+	  }
 	
 	// LOCAL STORAGE
 	function setWithExpiry(key, value, ttl) {

--- a/js/script.js
+++ b/js/script.js
@@ -417,7 +417,7 @@ $(document).ready(function(){
 	  if (outdatedLinks.includes(window.location.href)) {
 	
 		var popup = document.createElement('div');
-		popup.innerHTML = 'This documentation version is outdated. Please refer to the latest <a href="http://127.0.0.1:4000/docs/archive/0.7.1/index">documentation</a>.';
+		popup.innerHTML = 'This documentation version is outdated. Please refer to the latest <a href="https://duckdb.org/docs/archive/0.7.1/index">documentation</a>.';
 		popup.style.backgroundColor = 'yellow';
 		popup.style.padding = '10px';
 		popup.style.textAlign = 'center';


### PR DESCRIPTION
![fotor_2023-4-9_15_50_25](https://user-images.githubusercontent.com/110285294/230767343-eef07d23-916d-4cc1-ad99-81d479c13dd9.png)

1.An array outdatedLinks is created to store the URLs of outdated documentation versions.
2.The window.location.href is checked against the outdatedLinks array using the includes method to determine if the current URL is in the list of outdated links.
3.If the current URL is found in the outdatedLinks array, a new HTML element for the popup is created using document.createElement('div').
4.The content of the popup is set using the innerHTML property, which includes a message about the outdated documentation version and a link to the latest documentation.
5.The styles for the popup, such as background color, padding, text alignment, and z-index, are set using the style property.
6.The popup element is appended to the .headerline element using the appendChild method.
7.An event listener is added to the popup element to close the popup when clicked, using the addEventListener method with a callback function that sets the display property of the popup element to 'none'.


**IMPORTANT NOTE** - one more thing before testing it locally make sure you have updated array links according to your local server link  

closes #675