### PR TITLE
Clarify details about kurtosis calculation

### DIFF
--- a/docs/sql/aggregates.md
+++ b/docs/sql/aggregates.md
@@ -78,7 +78,7 @@ The table below shows the available statistical aggregate functions.
 | `corr(y,x)` | Returns the correlation coefficient for non-null pairs in a group. | `COVAR_POP(y, x) / (STDDEV_POP(x) * STDDEV_POP(y))`| - |
 | `covar_pop(y,x)` | Returns the population covariance of input values. | `(SUM(x*y) - SUM(x) * SUM(y) / COUNT(*)) / COUNT(*) ` | - |
 | `entropy(x)` | Returns the log-2 entropy of count input-values. | - | - |
-| `kurtosis(x)` | Returns the excess kurtosis of all input values. | - | - |
+| `kurtosis(x)` | Returns the excess kurtosis (Fisher's definition) of all input values, with a bias correction according to the sample size. | - | - |
 | `mad(x)` | Returns the median absolute deviation for the values within x. NULL values are ignored. Temporal types return a positive `INTERVAL`. | `MEDIAN(ABS(x-MEDIAN(x)))` | - |
 | `median(x)` | Returns the middle value of the set. NULL values are ignored. For even value counts, quantitiative values are averaged and ordinal values return the lower value. | `QUANTILE_CONT(x, 0.5)` | - |
 | `mode(x)` | Returns the most frequent value for the values within x. NULL values are ignored. | - | - |


### PR DESCRIPTION
The function `kurtosis` applies a bias correction to the calculation according to the sample size similarly to what it does in `var_samp`, which is not obvious from the docs and is not always the default in other software (e.g. in SciPy the default is to not apply this correction).

This PR adds a small clarification about the kurtosis calculation to the docs.