### PR TITLE
Update menu_docs_dev.json

### DIFF
--- a/_data/menu_docs_dev.json
+++ b/_data/menu_docs_dev.json
@@ -445,6 +445,14 @@
               "url": "r"
             },
             {
+              "page": "Rust",
+              "url": "rust"
+            },
+            {
+              "page": "Scala",
+              "url": "scala"
+            },
+            {
               "page": "Wasm",
               "slug": "wasm",
               "subsubfolderitems": [


### PR DESCRIPTION
Rust and Scala were missing from the menu, but exist in the repo.