### PR TITLE
Remove unsupported functions from archived docs

### DIFF
--- a/docs/archive/0.7.1/sql/data_types/bitstring.md
+++ b/docs/archive/0.7.1/sql/data_types/bitstring.md
@@ -20,9 +20,6 @@ Bitstrings can be very large, having the same size restrictions as `BLOB`s.
 ```sql
 -- create a bitstring 
 SELECT '101010'::BIT
--- create a bitstring with predefined length 
--- the resulting bitstring will be left-padded with zeroes. This returns 000000101011
-SELECT bitstring('0101011', 12);
 ```
 
 ## Functions

--- a/docs/archive/0.7.1/sql/functions/bitstring.md
+++ b/docs/archive/0.7.1/sql/functions/bitstring.md
@@ -25,7 +25,6 @@ The table below shows the available scalar functions for `BIT` type.
 
 | Function | Description | Example | Result |
 |:---|:---|:---|:---|
-| `bitstring(`*`bitstring`*`, `*`length`*`)` | Returns a bitstring of determined length. | `bitstring('1010'::BIT, 7)` | `0001010` |
 | `bit_length(`*`bitstring`*`)` | Returns the number of bits in the bitstring. | `bit_length('1101011'::BIT)` | `7` |
 | `length(`*`bitstring`*`)` | Alias for `bit_length`. | `length('1101011'::BIT)` | `7` |
 | `octet_length(`*`bitstring`*`)` | Returns the number of bytes in the bitstring. | `octet_length('1101011'::BIT)` | `1` |
@@ -42,11 +41,3 @@ These aggregate functions are available for `BIT` type.
 | `bit_and(arg)` |Returns the bitwise AND operation performed on all bitstrings in a given expression. | `bit_and(A)` |
 | `bit_or(arg)` |Returns the bitwise OR operation performed on all bitstrings in a given expression.  | `bit_or(A)` |
 | `bit_xor(arg)` |Returns the bitwise XOR operation performed on all bitstrings in a given expression. | `bit_xor(A)` |
-| `bitstring_agg(arg)` |Returns a bitstring with bits set for each distinct value. | `bitstring_agg(A)` |
-| `bitstring_agg(arg, min, max)` |Returns a bitstring with bits set for each distinct value. | `bitstring_agg(A, 1, 42)` |
-
-### Bitstring Aggregation
-The `BITSTRING_AGG` function takes any integer type as input and returns a bitstring with bits set for each distinct value. 
-The left-most bit represents the smallest value in the column and the right-most bit the maximum value. If possible, the min and max are retrieved from the column statistics. Otherwise, it is also possible to provide the min and max values.  
-  
-The combination of `BIT_COUNT` and `BITSTRING_AGG` could be used as an alternative to `COUNT DISTINCT`, with possible performance improvements in cases of low cardinality and dense values.


### PR DESCRIPTION
See duckdb/duckdb#7232

These functions are not supported in v0.7.1, but were only added later. These accidentally got added to the v0.7.1 docs because they were merged into the feature branch prior to the release of v0.7.1 (but not included as part of the release).