### PR TITLE
Fix hasty 1ccf82cda [::marker]

### DIFF
--- a/css/normalize.css
+++ b/css/normalize.css
@@ -17,7 +17,10 @@ footer,
 header,
 hgroup,
 nav,
-section,
+section {
+  display: block;
+}
+
 summary {
   display: list-item;
 }


### PR DESCRIPTION
Pre 1ccf82cd ::markers on summary were non visible, after there was some unneded spacing on titles, both cases on Chrome-based browsers