### PR TITLE
Fix bundler command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Click the green Code button to the top right to open a new codespace with this r
 Navigate to the directory where you have cloned duckdb-web and run
 
 ```sh
-bundler exec jekyll serve --incremental --config _config_exclude_archive.yml --livereload
+bundler exec jekyll serve --incremental --config _config.yml,_config_exclude_archive.yml --livereload
 ```
 
 The website can then be browsed by going to `localhost:4000` in your browser.


### PR DESCRIPTION
The current bundler command doesn't include the main `_config.yml` file (only the `_config_exclude_archive.yml` file).

This prevents jekyll from starting properly.

The previous command (`bundler exec jekyll serve`) included `_config.yml` by default.