### PR TITLE
Improve Python docs for Connection

### DIFF
--- a/docs/api/python/dbapi.md
+++ b/docs/api/python/dbapi.md
@@ -9,7 +9,7 @@ The standard DuckDB Python API provides a SQL interface compliant with the [DB-A
 ### Connection
 
 To use the module, you must first create a `DuckDBPyConnection` object that represents the database.
- The connection object takes as parameter the database file to read and write from. If the database file does not exist, it will be created (the file extension may be `.db`, `.duckdb`, or anything else). The special value `:memory:` (the default) can be used to create an **in-memory database**. Note that for an in-memory database no data is persisted to disk (i.e. all data is lost when you exit the Python process). If you would like to connect to an existing database in read-only mode, you can set the `read_only` flag to `True`. Read-only mode is required if multiple Python processes want to access the same database file at the same time.
+ The connection object takes as a parameter the database file to read and write from. If the database file does not exist, it will be created (the file extension may be `.db`, `.duckdb`, or anything else). The special value `:memory:` (the default) can be used to create an **in-memory database**. Note that for an in-memory database no data is persisted to disk (i.e. all data is lost when you exit the Python process). If you would like to connect to an existing database in read-only mode, you can set the `read_only` flag to `True`. Read-only mode is required if multiple Python processes want to access the same database file at the same time.
 
 By default we create an **in-memory-database** that lives inside the `duckdb` module.
 Every method of `DuckDBPyConnection` is also available on the `duckdb` module, this connection is what's used by these methods. 

--- a/docs/api/python/dbapi.md
+++ b/docs/api/python/dbapi.md
@@ -6,8 +6,27 @@ selected: Client APIs
 
 The standard DuckDB Python API provides a SQL interface compliant with the [DB-API 2.0 specification described by PEP 249](https://www.python.org/dev/peps/pep-0249/) similar to the [SQLite Python API](https://docs.python.org/3.7/library/sqlite3.html).
 
-### Startup & Shutdown
-To use the module, you must first create a `Connection` object that represents the database. The connection object takes as parameter the database file to read and write from. If the database file does not exist, it will be created (the file extension may be `.db`, `.duckdb`, or anything else). The special value `:memory:` (the default) can be used to create an **in-memory database**. Note that for an in-memory database no data is persisted to disk (i.e. all data is lost when you exit the Python process). If you would like to connect to an existing database in read-only mode, you can set the `read_only` flag to `True`. Read-only mode is required if multiple Python processes want to access the same database file at the same time.
+### Connection
+
+To use the module, you must first create a `DuckDBPyConnection` object that represents the database.
+ The connection object takes as parameter the database file to read and write from. If the database file does not exist, it will be created (the file extension may be `.db`, `.duckdb`, or anything else). The special value `:memory:` (the default) can be used to create an **in-memory database**. Note that for an in-memory database no data is persisted to disk (i.e. all data is lost when you exit the Python process). If you would like to connect to an existing database in read-only mode, you can set the `read_only` flag to `True`. Read-only mode is required if multiple Python processes want to access the same database file at the same time.
+
+By default we create an **in-memory-database** that lives inside the `duckdb` module.
+Every method of `DuckDBPyConnection` is also available on the `duckdb` module, this connection is what's used by these methods. 
+You can also get a reference to this connection by providing the special value `:default:` to `connect`.
+```python
+import duckdb
+
+duckdb.execute('create table tbl as select 42 a')
+con = duckdb.connect(':default:')
+con.sql('select * from tbl')
+# ┌───────┐
+# │   a   │
+# │ int32 │
+# ├───────┤
+# │    42 │
+# └───────┘
+```
 
 ```python
 import duckdb
@@ -17,6 +36,8 @@ con = duckdb.connect(database=':memory:')
 con = duckdb.connect(database='my-db.duckdb', read_only=False)
 # to use a database file (shared between processes)
 con = duckdb.connect(database='my-db.duckdb', read_only=True)
+# to explicitly get the default connection
+con = duckdb.connect(database=':default:')
 ```
 If you want to create a second connection to an existing database, you can use the `cursor()` method. This might be useful for example to allow parallel threads running queries independently. A single connection is thread-safe but is locked for the duration of the queries, effectively serializing database access in this case.
 

--- a/docs/guides/python/jupyter.md
+++ b/docs/guides/python/jupyter.md
@@ -45,6 +45,7 @@ pip install matplotlib
 
 ## Library Import and Configuration
 Next, open a Jupyter Notebook and import the relevant libraries. 
+It's possible to have `%sql` commands and `duckdb.sql` share the same [default connection](dbapi.md) by providing `duckdb:///:default:` as the SQLAlchemy connection string.
 ```python
 import duckdb
 import pandas as pd
@@ -63,9 +64,10 @@ Set configrations on jupysql to directly output data to Pandas and to simplify t
 ```
 
 Connect jupysql to DuckDB using a SQLAlchemy-style connection string. 
-Either connect to an in memory DuckDB, or a file backed db.
+Either connect to a new in-memory DuckDB, the default connection or a file backed db.
 ```python
-%sql duckdb:///:memory:
+%sql duckdb:///:default:
+# %sql duckdb:///:memory:
 # %sql duckdb:///path/to/file.db
 ```
 

--- a/docs/guides/python/jupyter.md
+++ b/docs/guides/python/jupyter.md
@@ -45,7 +45,8 @@ pip install matplotlib
 
 ## Library Import and Configuration
 Next, open a Jupyter Notebook and import the relevant libraries. 
-It's possible to have `%sql` commands and `duckdb.sql` share the same [default connection](dbapi.md) by providing `duckdb:///:default:` as the SQLAlchemy connection string.
+It's possible to have `%sql` commands and `duckdb.sql` share the same [default connection](dbapi) by providing `duckdb:///:default:` as the SQLAlchemy connection string.
+
 ```python
 import duckdb
 import pandas as pd


### PR DESCRIPTION
This PR fixes #643 

Mention `':default:'` and mention that the methods on `duckdb` use this connection by default.