### PR TITLE
currentduckdbversion: 0.8.0

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,7 +22,7 @@ url: "https://duckdb.org" # the base hostname & protocol for your site, e.g. htt
 # Set current Version of duckDB
 currentduckdbversion: 0.8.0
 currentjavaversion: 0.8.0
-nextjavaversion: 0.8.1  # for java snapshots
+nextjavaversion: 0.9.0  # for java snapshots
 livereload: true
 highlighter: rouge
 incremental: false

--- a/_config.yml
+++ b/_config.yml
@@ -20,9 +20,9 @@ description: >- # this means to ignore newlines until "baseurl:"
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://duckdb.org" # the base hostname & protocol for your site, e.g. http://example.com
 # Set current Version of duckDB
-currentduckdbversion: 0.7.1
-currentjavaversion: 0.7.1
-nextjavaversion: 0.8.0  # for java snapshots
+currentduckdbversion: 0.8.0
+currentjavaversion: 0.8.0
+nextjavaversion: 0.8.1  # for java snapshots
 livereload: true
 highlighter: rouge
 incremental: false

--- a/internals/storage.md
+++ b/internals/storage.md
@@ -54,6 +54,13 @@ To see the commits that changed each storage version, see the [commit log](https
 
 | Storage version | DuckDB versions                                             |
 |-----------------|-------------------------------------------------------------|
+| 51              | v0.8.0                                                      |
+| 50              | [#7270](https://github.com/duckdb/duckdb/pull/7270) onwards |
+| 49              | [#6841](https://github.com/duckdb/duckdb/pull/6841) onwards |
+| 48              | [#6715](https://github.com/duckdb/duckdb/pull/6715) onwards |
+| 47              |                                                             |
+| 46              | [#6621](https://github.com/duckdb/duckdb/pull/6621) onwards |
+| 45              | [#6560](https://github.com/duckdb/duckdb/pull/6560) onwards |
 | 44              | [#6499](https://github.com/duckdb/duckdb/pull/6499) onwards |
 | 43              | v0.7.0, v0.7.1                                              |
 | 42              | [#5544](https://github.com/duckdb/duckdb/pull/5544) onwards |


### PR DESCRIPTION
Happy if someone take it further, because probably there are also other places that needs to be updated.

One open thing is if we want to take a snapshot of docs and put that on v0.8.0 folder, or given that v0.8.1 will have basically the same features and there is work in progress in the docs, we just wait and fork them in a few weeks.