### PR TITLE
Add con.close() to Persistent Storage example in Python Overview

### DIFF
--- a/docs/api/python/overview.md
+++ b/docs/api/python/overview.md
@@ -95,6 +95,9 @@ con.sql('CREATE TABLE test(i INTEGER)')
 con.sql('INSERT INTO test VALUES (42)')
 # query the table
 con.table('test').show()
+# explicitly close the connection
+con.close()
+# Note: connections also closed implicitly when they go out of scope
 ```
 
 The connection object and the `duckdb` module can be used interchangeably - they support the same methods. The only difference is that when using the `duckdb` module a global in-memory database is used.


### PR DESCRIPTION
This adds an explicit `con.close()` to the Persistent Storage example in the Python API Overview page.

As described in #808, readers may come away not being aware that an explicit connection close is required in some situations. A notable context is in a Jupyter notebook, where it is common for everything to be in the global scope, so no implicit close will occur (as was my context when it took me some time to work out why expected tables weren't available in my previously saved database).