### PR TITLE
Replace "high" with "low" in claim about ENUM data types and string column cardinality.

### DIFF
--- a/docs/sql/data_types/enum.md
+++ b/docs/sql/data_types/enum.md
@@ -11,7 +11,7 @@ blurb: The ENUM type represents a dictionary data structure with all possible un
 
 ## Enums
 
-The `ENUM` type represents a dictionary data structure with all possible unique values of a column. For example, a column storing the days of the week can be an Enum holding all possible days. Enums are particularly interesting for string columns with high cardinality. This is because the column only stores a numerical reference to the string in the Enum dictionary, resulting in immense savings in disk storage and faster query performance.
+The `ENUM` type represents a dictionary data structure with all possible unique values of a column. For example, a column storing the days of the week can be an Enum holding all possible days. Enums are particularly interesting for string columns with low cardinality (i.e., fewer distinct values). This is because the column only stores a numerical reference to the string in the Enum dictionary, resulting in immense savings in disk storage and faster query performance.
 
 
 ### Enum Definition


### PR DESCRIPTION
Hello,

I am submitting what I believe to be a valid correction to the section of your docs describing the `ENUM` data type.

I also confess I may not completely understand your intended meaning and how it relates to the distinction between high- and low-cardinality I found in [Wikipedia](https://en.wikipedia.org/wiki/Cardinality_(SQL_statements)#Values_of_cardinality).

Thank you for your amazing project. I use DuckDb everyday and evangelize about it whenever I have the opportunity.