### PR TITLE
Add warning about altering table dependency error

### DIFF
--- a/docs/sql/statements/alter_table.md
+++ b/docs/sql/statements/alter_table.md
@@ -5,9 +5,11 @@ selected: Documentation/SQL/Alter Table
 expanded: SQL
 railroad: statements/alter.js
 ---
+
 The `ALTER TABLE` statement changes the schema of an existing table in the catalog.
 
 ### Examples
+
 ```sql
 -- add a new column with name "k" to the table "integers", it will be filled with the default value NULL
 ALTER TABLE integers ADD COLUMN k INTEGER;
@@ -35,11 +37,13 @@ ALTER TABLE integers RENAME i TO j;
 ```
 
 ### Syntax
+
 <div id="rrdiagram"></div>
 
 `ALTER TABLE` changes the schema of an existing table. All the changes made by `ALTER TABLE` fully respect the transactional semantics - that is - they will not be visible to other transactions until committed, and can be fully reverted through a rollback.
 
 ### RENAME TABLE
+
 ```sql
 -- rename a table
 ALTER TABLE integers RENAME TO integers_old;
@@ -48,6 +52,7 @@ ALTER TABLE integers RENAME TO integers_old;
 The `RENAME TO` clause renames an entire table, changing its name in the schema. Note that any views that rely on the table are **not** automatically updated.
 
 ### RENAME COLUMN
+
 ```sql
 -- rename a column of a table
 ALTER TABLE integers RENAME i TO j;
@@ -57,6 +62,7 @@ ALTER TABLE integers RENAME COLUMN j TO k;
 The `RENAME COLUMN` clause renames a single column within a table. Any constraints that rely on this name (e.g. `CHECK` constraints) are automatically updated. However, note that any views that rely on this column name are **not** automatically updated.
 
 ### ADD COLUMN
+
 ```sql
 -- add a new column with name "k" to the table "integers", it will be filled with the default value NULL
 ALTER TABLE integers ADD COLUMN k INTEGER;
@@ -67,6 +73,7 @@ ALTER TABLE integers ADD COLUMN l INTEGER DEFAULT 10;
 The `ADD COLUMN` clause can be used to add a new column of a specified type to a table. The new column will be filled with the specified default value, or `NULL` if none is specified.
 
 ### DROP COLUMN
+
 ```sql
 -- drop the column "k" from the table integers
 ALTER TABLE integers DROP k;
@@ -75,6 +82,7 @@ ALTER TABLE integers DROP k;
 The `DROP COLUMN` clause can be used to remove a column from a table. Note that columns can only be removed if they do not have any indexes that rely on them. This includes any indexes created as part of a `PRIMARY KEY` or `UNIQUE` constraint. Columns that are part of multi-column check constraints cannot be dropped either.
 
 ### ALTER TYPE
+
 ```sql
 -- change the type of the column "i" to the type "VARCHAR" using a standard cast
 ALTER TABLE integers ALTER i TYPE VARCHAR;
@@ -85,6 +93,7 @@ ALTER TABLE integers ALTER i SET DATA TYPE VARCHAR USING CONCAT(i, '_', j);
 The `SET DATA TYPE` clause changes the type of a column in a table. Any data present in the column is converted according to the provided expression in the `USING` clause, or, if the `USING` clause is absent, cast to the new data type. Note that columns can only have their type changed if they do not have any indexes that rely on them and are not part of any `CHECK` constraints.
 
 ### SET/DROP DEFAULT
+
 ```sql
 -- set the default value of a column
 ALTER TABLE integers ALTER COLUMN i SET DEFAULT 10;
@@ -93,3 +102,7 @@ ALTER TABLE integers ALTER COLUMN i DROP DEFAULT;
 ```
 
 The `SET/DROP DEFAULT` clause modifies the `DEFAULT` value of an existing column. Note that this does not modify any existing data in the column. Dropping the default is equivalent to setting the default value to NULL.
+
+### NOTES
+
+At the moment DuckDB will not allow you to alter a table if there are any dependencies. That means that if you have an index on a column you will first need to drop the index, alter the table, and then recreate the index. Otherwise you will get a "Dependency Error."


### PR DESCRIPTION
I can remove the whitespace fixes that my editor added but wrote a quick note based on the commentary in https://github.com/duckdb/duckdb/discussions/4639 since it took me some time to figure this out.