### PR TITLE
Fix qstudio URL - link was broken

### DIFF
--- a/_data/menu_docs_dev.json
+++ b/_data/menu_docs_dev.json
@@ -204,7 +204,7 @@
             },
             {
               "page": "qStudio SQL IDE",
-              "url": "qStudio"
+              "url": "qstudio"
             },
             {
               "page": "Rill Data Developer",


### PR DESCRIPTION
I was testing the PR that merged: https://github.com/duckdb/duckdb-web/pull/838/
and found I had accidentally added a capital letter which broke the link.
