### PR TITLE
update intervale docs for rounding decimals instead of truncating them.

### DIFF
--- a/docs/sql/data_types/interval.md
+++ b/docs/sql/data_types/interval.md
@@ -28,12 +28,12 @@ SELECT INTERVAL (i) YEAR FROM range(1, 5) t(i);
 -- construct an interval with mixed units
 SELECT INTERVAL '1 month 1 day';
 
--- WARNING: If a decimal value is specified, it will be automatically truncated to an integer
+-- WARNING: If a decimal value is specified, it will be automatically rounded to an integer
 -- To use more precise values, simply use a more granular date part 
 -- (In this example use 18 MONTHS instead of 1.5 YEARS)
 -- The statement below is equivalent to to_years(CAST(1.5 AS INTEGER))
--- 1 year
-SELECT INTERVAL '1.5' YEARS; --WARNING! This returns 1 year!
+-- 2 years
+SELECT INTERVAL '1.5' YEARS; --WARNING! This returns 2 years!
 ```
 
 ## Details


### PR DESCRIPTION
Rounding is expected for the cast of decimal to int. [5288](https://github.com/duckdb/duckdb/issues/5288)

According to the [interval docs](https://duckdb.org/docs/sql/data_types/interval), casting 1.5 to an integer is expected to truncate.

Documentation:

```
-- WARNING: If a decimal value is specified, it will be automatically truncated to an integer
-- To use more precise values, simply use a more granular date part 
-- (In this example use 18 MONTHS instead of 1.5 YEARS)
-- The statement below is equivalent to to_years(CAST(1.5 AS INTEGER))
-- 1 year
SELECT INTERVAL '1.5' YEARS; --WARNING! This returns 1 year!
```

Actual Results duckdb 0.8.1:

```
D SELECT INTERVAL '1.5' YEARS;
┌──────────────────────────────────┐
│ to_years(CAST('1.5' AS INTEGER)) │
│             interval             │
├──────────────────────────────────┤
│ 2 years                          │
└──────────────────────────────────┘
```