### PR TITLE
docs(r): add an example of use read_parquet function with dplyr

### DIFF
--- a/docs/api/r.md
+++ b/docs/api/r.md
@@ -115,7 +115,7 @@ tbl(con, "mtcars.csv") |>
 ```R
 dbExecute(con, "COPY flights TO 'dataset' (FORMAT PARQUET, PARTITION_BY (year, month))")
 
-tbl(con, "read_parquet('dataset/*/*/*.parquet', hive_partitioning=1)") |>
+tbl(con, "read_parquet('dataset/**/*.parquet', hive_partitioning=1)") |>
   filter(month == "3") |>
   summarise(delay = mean(dep_time, na.rm = TRUE)) |>
   collect()

--- a/docs/api/r.md
+++ b/docs/api/r.md
@@ -111,3 +111,12 @@ tbl(con, "mtcars.csv") |>
   summarise(across(disp:wt, .fns = mean)) |>
   collect()
 ```
+
+```R
+dbExecute(con, "COPY flights TO 'dataset' (FORMAT PARQUET, PARTITION_BY (year, month))")
+
+tbl(con, "read_parquet('dataset/*/*/*.parquet', hive_partitioning=1)") |>
+  filter(month == "3") |>
+  summarise(delay = mean(dep_time, na.rm = TRUE)) |>
+  collect()
+```


### PR DESCRIPTION
Related to duckdb/duckdb#7865
Close #826

Clarify that DuckDB functions (e.g. read_parquet) can be used within the `dplyr::tbl` R function.