### PR TITLE
Fix typo in drop.md

### DIFF
--- a/docs/sql/statements/drop.md
+++ b/docs/sql/statements/drop.md
@@ -27,7 +27,6 @@ CREATE SCHEMA myschema;
 CREATE TABLE myschema.t1(i INTEGER);
 -- ERROR: Cannot drop myschema because the table myschema.t1 depends on it.
 DROP SCHEMA myschema;
--- Cascade drops both myschema and myschema.1
+-- Cascade drops both myschema and myschema.t1
 DROP SCHEMA myschema CASCADE;
 ```
-


### PR DESCRIPTION
In the code example for `CASCADE`, the table name is "t1", not "1".