### PR TITLE
docs: fix signature of `ST_AsGeoJSON`

### DIFF
--- a/docs/extensions/spatial.md
+++ b/docs/extensions/spatial.md
@@ -32,14 +32,14 @@ The currently implemented spatial functions can roughly be categorized into the 
 ### Geometry Conversion
 Convert between geometries and other formats. 
 
-| Scalar functions                  | GEOMETRY | POINT_2D | LINESTRING_2D | POLYGON_2D | BOX_2D         |
-| --------------------------------- | -------- | -------- | ------------- | ---------- | -------------- |
-| VARCHAR ST_AsHEXWKB(GEOMETRY)     | 🦆        | 🦆        | 🦆             | 🦆          | 🦆              |
-| VARCHAR ST_AsText(GEOMETRY)       | 🧭        | 🦆        | 🦆             | 🦆          | 🔄 (as POLYGON) |
-| WKB_BLOB ST_AsWKB(GEOMETRY)       | 🦆        | 🦆        | 🦆             | 🦆          | 🦆              |
-| GEOMETRY ST_GeomFromText(VARCHAR) | 🧭        | 🔄        | 🔄             | 🔄          | 🔄 (as POLYGON) |
-| GEOMETRY ST_GeomFromWKB(BLOB)     | 🦆        | 🦆        | 🦆             | 🦆          | 🔄 (as POLYGON) |
-| VARCHAR ST_AsGeoJSON(VARCHAR)     | 🦆        | 🦆        | 🦆             | 🦆          | 🔄 (as POLYGON) |
+| Scalar functions                  | GEOMETRY | POINT_2D | LINESTRING_2D | POLYGON_2D | BOX_2D          |
+|-----------------------------------|----------|----------|---------------|------------|-----------------|
+| VARCHAR ST_AsGeoJSON(GEOMETRY)    | 🦆       | 🦆       | 🦆           | 🦆         | 🔄 (as POLYGON) |
+| VARCHAR ST_AsHEXWKB(GEOMETRY)     | 🦆       | 🦆       | 🦆           | 🦆         | 🦆              |
+| VARCHAR ST_AsText(GEOMETRY)       | 🧭       | 🦆       | 🦆           | 🦆         | 🔄 (as POLYGON) |
+| WKB_BLOB ST_AsWKB(GEOMETRY)       | 🦆       | 🦆       | 🦆           | 🦆         | 🦆              |
+| GEOMETRY ST_GeomFromText(VARCHAR) | 🧭       | 🔄       | 🔄           | 🔄         | 🔄 (as POLYGON) |
+| GEOMETRY ST_GeomFromWKB(BLOB)     | 🦆       | 🦆       | 🦆           | 🦆         | 🔄 (as POLYGON) |
 
 ### Geometry Construction
 Construct new geometries from other geometries or other data.


### PR DESCRIPTION
Update docs to properly describe the signature of the `ST_AsGeoJSON(GEOMETRY) -> VARCHAR` function. 
It should reflect that a `GEOMETRY` input yields a `VARCHAR` output, instead of the current `VARCHAR -> VARCHAR`.

Also sorts `ST_AsGeoJSON` alphabetically along with the other `ST_As....` functions and formats the table.