### PR TITLE
Change documentation link to point to the stable version's documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@ body_class: landing nowrap
 		<div class="mainlinks">
 			<ul>
 				<a href="#quickinstall"><li class="highlighted">Installation <span class="duckdbsymbol">&#x2193;</span> </li></a>
-				<a href="docs/"><li>Documentation</li></a>
+				<a href="/docs/archive/{{ site.currentduckdbversion }}"><li>Documentation</li></a>
 				<a href="https://shell.duckdb.org"><li>Live Demo</li></a>
 			</ul>
 		</div>


### PR DESCRIPTION
This PR changes the main site's "Documentation" link to point to the stable version's documentation.

![Screenshot 2023-08-02 at 17 01 21](https://github.com/duckdb/duckdb-web/assets/1402801/63c70a6c-2952-485d-a5bf-6c2b8ea20ee7)

This helps avoid confusion with newly introduced features that are only available in the `dev` build, e.g. https://github.com/duckdb/duckdb-web/issues/360#issuecomment-1661395421