### PR TITLE
nit: Use uppercase keywords

### DIFF
--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -429,7 +429,7 @@ Note that the duck head is built with unicode characters and does not always wor
 -- Duck head prompt
 .prompt '⚫◗ '
 -- Example SQL statement
-select 'Begin quacking!' as "Ready, Set, ..."
+SELECT 'Begin quacking!' as "Ready, Set, ..."
 ```
 
 To invoke that file on initialization, use this command:

--- a/docs/data/overview.md
+++ b/docs/data/overview.md
@@ -41,7 +41,7 @@ See [here](../data/parquet) for a detailed description of Parquet loading.
 JSON files can be efficiently loaded and queried using the `read_json_auto` function.
 
 ```sql
-SELECT * from read_json_auto('test.json');
+SELECT * FROM read_json_auto('test.json');
 ```
 
 See [here](../data/json) for a detailed description of JSON loading.

--- a/docs/extensions/httpfs.md
+++ b/docs/extensions/httpfs.md
@@ -140,7 +140,7 @@ File globbing is implemented using the ListObjectV2 API call and allows to use f
 multiple files, for example:
 
 ```sql
-SELECT * from read_parquet('s3://bucket/*.parquet')
+SELECT * FROM read_parquet('s3://bucket/*.parquet')
 ```
 
 This query matches all files in the root of the bucket with the parquet extension.

--- a/docs/extensions/json.md
+++ b/docs/extensions/json.md
@@ -22,7 +22,7 @@ SELECT {duck: 42}::JSON;
 
 This works for our nested types as shown in the example, but also for non-nested types:
 ```sql
-select '2023-05-12'::DATE::JSON;
+SELECT '2023-05-12'::DATE::JSON;
 -- "2023-05-12"
 ```
 

--- a/docs/extensions/overview.md
+++ b/docs/extensions/overview.md
@@ -94,8 +94,8 @@ with gzip.open('httpfs.duckdb_extension.gz','rb') as f_in:
 After unzipping, the install and load commands can be used with the path to the .duckdb_extension file. 
 For example, if the file was unzipped into the same directory as where DuckDB is being executed:
 ```sql
-install 'httpfs.duckdb_extension';
-load 'httpfs.duckdb_extension';
+INSTALL 'httpfs.duckdb_extension';
+LOAD 'httpfs.duckdb_extension';
 ```
 
 

--- a/docs/extensions/overview.md
+++ b/docs/extensions/overview.md
@@ -24,7 +24,7 @@ To load unsigned extensions using the CLI, you'll need to pass the `-unsigned` f
 
 You can check the list of core and installed extensions with the following query:
 ```sql
-SELECT * from duckdb_extensions();
+SELECT * FROM duckdb_extensions();
 ```
 
 ## All available extensions

--- a/docs/extensions/overview.md
+++ b/docs/extensions/overview.md
@@ -24,7 +24,7 @@ To load unsigned extensions using the CLI, you'll need to pass the `-unsigned` f
 
 You can check the list of core and installed extensions with the following query:
 ```sql
-select * from duckdb_extensions();
+SELECT * from duckdb_extensions();
 ```
 
 ## All available extensions

--- a/docs/guides/import/excel_export.md
+++ b/docs/guides/import/excel_export.md
@@ -7,8 +7,8 @@ To export the data from a table to an Excel file, install and load the spatial e
 The file will contain one worksheet with the same name as the file, but without the .xlsx extension.
 
 ```sql
-install spatial; -- Only needed once per DuckDB connection
-load spatial; -- Only needed once per DuckDB connection
+INSTALL spatial; -- Only needed once per DuckDB connection
+LOAD spatial; -- Only needed once per DuckDB connection
 
 COPY tbl TO 'output.xlsx' WITH (FORMAT GDAL, DRIVER 'xlsx');
 ```
@@ -16,8 +16,8 @@ COPY tbl TO 'output.xlsx' WITH (FORMAT GDAL, DRIVER 'xlsx');
 The result of queries can also be directly exported to an Excel file.
 
 ```sql
-install spatial; -- Only needed once per DuckDB connection
-load spatial; -- Only needed once per DuckDB connection
+INSTALL spatial; -- Only needed once per DuckDB connection
+LOAD spatial; -- Only needed once per DuckDB connection
 
 COPY (SELECT * FROM tbl) TO 'output.xlsx' WITH (FORMAT GDAL, DRIVER 'xlsx');
 ```

--- a/docs/guides/import/excel_import.md
+++ b/docs/guides/import/excel_import.md
@@ -7,8 +7,8 @@ To read data from an Excel file, install and load the spatial extension, then us
 Use the `layer` parameter to specify the Excel worksheet name.
 
 ```sql
-install spatial; -- Only needed once per DuckDB connection
-load spatial; -- Only needed once per DuckDB connection
+INSTALL spatial; -- Only needed once per DuckDB connection
+LOAD spatial; -- Only needed once per DuckDB connection
 
 SELECT * FROM st_read('test_excel.xlsx', layer='Sheet1');
 ```
@@ -16,8 +16,8 @@ SELECT * FROM st_read('test_excel.xlsx', layer='Sheet1');
 To create a new table using the result from a query, use `CREATE TABLE AS` from a `SELECT` statement.
 
 ```sql
-install spatial; -- Only needed once per DuckDB connection
-load spatial; -- Only needed once per DuckDB connection
+INSTALL spatial; -- Only needed once per DuckDB connection
+LOAD spatial; -- Only needed once per DuckDB connection
 
 CREATE TABLE new_tbl AS 
 SELECT * FROM st_read('test_excel.xlsx', layer='Sheet1');
@@ -25,8 +25,8 @@ SELECT * FROM st_read('test_excel.xlsx', layer='Sheet1');
 To load data into an existing table from a query, use `INSERT INTO` from a `SELECT` statement.
 
 ```sql
-install spatial; -- Only needed once per DuckDB connection
-load spatial; -- Only needed once per DuckDB connection
+INSTALL spatial; -- Only needed once per DuckDB connection
+LOAD spatial; -- Only needed once per DuckDB connection
 
 INSERT INTO tbl
 SELECT * FROM st_read('test_excel.xlsx', layer='Sheet1');

--- a/docs/sql/data_types/map.md
+++ b/docs/sql/data_types/map.md
@@ -16,14 +16,14 @@ To construct a `MAP`, use the bracket syntax preceded by the `MAP` keyword.
 ### Creating Maps
 ```sql
 -- A map with varchar keys and integer values. This returns {key1=1, key2=5}
-select map { 'key1': 1, 'key2': 5 };
+SELECT map { 'key1': 1, 'key2': 5 };
 -- Alternatively use the map_from_entries function. This returns {key1=1, key2=5}
-select map_from_entries([(key1, 1), (key2, 5)]);
+SELECT map_from_entries([(key1, 1), (key2, 5)]);
 -- A map with integer keys and numeric values. This returns {1=42.001, 5=-32.100} 
-select map { 1: 42.001, 5: -32.1 };
+SELECT map { 1: 42.001, 5: -32.1 };
 -- Keys and/or values can also be nested types.
 -- This returns {[a, b]=[1.1, 2.2], [c, d]=[3.3, 4.4]}
-select map { ['a', 'b']: [1.1, 2.2], ['c', 'd']: [3.3, 4.4] };
+SELECT map { ['a', 'b']: [1.1, 2.2], ['c', 'd']: [3.3, 4.4] };
 -- Create a table with a map column that has integer keys and double values
 CREATE TABLE map_table (map_col MAP(INT, DOUBLE));
 ```

--- a/docs/sql/expressions/star.md
+++ b/docs/sql/expressions/star.md
@@ -54,7 +54,7 @@ The `COLUMNS` expression can be used to execute the same expression on multiple 
 ```sql
 CREATE TABLE numbers(id int, number int);
 INSERT INTO numbers VALUES (1, 10), (2, 20), (3, NULL);
-SELECT MIN(COLUMNS(*)), COUNT(COLUMNS(*)) from numbers;
+SELECT MIN(COLUMNS(*)), COUNT(COLUMNS(*)) FROM numbers;
 ```
 
 | min(numbers.id) | min(numbers.number) | count(numbers.id) | count(numbers.number) |
@@ -64,7 +64,7 @@ SELECT MIN(COLUMNS(*)), COUNT(COLUMNS(*)) from numbers;
 The `*` expression in the `COLUMNS` statement can also contain `EXCLUDE` or `REPLACE`, similar to regular star expressions.
 
 ```sql
-SELECT MIN(COLUMNS(* REPLACE (number + id AS number))), COUNT(COLUMNS(* EXCLUDE (number))) from numbers;
+SELECT MIN(COLUMNS(* REPLACE (number + id AS number))), COUNT(COLUMNS(* EXCLUDE (number))) FROM numbers;
 ```
 
 | min(numbers.id) | min(number := (number + id)) | count(numbers.id) |

--- a/docs/sql/functions/timestamptz.md
+++ b/docs/sql/functions/timestamptz.md
@@ -37,7 +37,7 @@ This will let you specify an instant correctly without access to time zone infor
 For portability, `TIMESTAMPTZ` values will always be displayed using GMT offsets:
 
 ```sql
-select '2022-10-08 13:13:34-07'::TIMESTAMPTZ'
+SELECT '2022-10-08 13:13:34-07'::TIMESTAMPTZ'
 -- 2022-10-08 20:13:34+00
 ```
 
@@ -45,7 +45,7 @@ If a time zone extension such as ICU is loaded, then a time zone can be parsed f
 and cast to a representation in the local time zone:
 
 ```sql
-select '2022-10-08 13:13:34 Europe/Amsterdam'::TIMESTAMPTZ::VARCHAR;
+SELECT '2022-10-08 13:13:34 Europe/Amsterdam'::TIMESTAMPTZ::VARCHAR;
 -- 2022-10-08 04:13:34-07
 ```
 


### PR DESCRIPTION
It turns out finding instances of lowercase SQL instructions is difficult – SQL is English language after all, and the term `from` appears everywhere in the documentation. So we need to restrict out scope to code blocks.

We can so so using my `agid` (`ag` + `ignore directory` + `docs/`) macro:

```bash
function agid() {
    if [ ${#} -ge 1 ]; then
        ag --ignore-dir=archive/ $@ docs/
    else
        echo "missing search argument"
        return 1
    fi
}

KEYWORD=from
agid --md -s "\`\`\`[a-zA-Z0-9+]+\n.+${KEYWORD}.+\n\`\`\`"
```