### PR TITLE
Add sites to link checker's ignore list

### DIFF
--- a/.github/linkchecker/linkchecker.conf
+++ b/.github/linkchecker/linkchecker.conf
@@ -11,3 +11,4 @@ ignore=
    .*transtats\.bts\.gov.*
    https://maxwohlleber\.de
    https://crates\.io.*
+   http://www.tpc\.org.*


### PR DESCRIPTION
Some sites are frequently unavailable, making the CI to fail. I'll add a couple of them to the link checker's ignore list.