### PR TITLE
CI: Do not fail on Vale errors

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -1,5 +1,5 @@
 name: vale
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
   vale:
@@ -13,5 +13,5 @@ jobs:
       - uses: errata-ai/vale-action@reviewdog
         with:
           files: docs/
-          filter_mode: nofilter
-          fail_on_error: true
+          filter_mode: added
+          fail_on_error: false


### PR DESCRIPTION
I propose to configure CI so that it doesn't fail on Vale errors for the time being. It will take some time to get the `e.g.`s and `i.e.`s fixed in the main repo.