### PR TITLE
Add multi-arch Jekyll Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+Dockerfile
+.git/*
+.github/*
+_site/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM rockstorm/jekyll:pages-v228-minimal
+
+RUN mkdir /app
+
+COPY Gemfile /app
+COPY Gemfile.lock /app
+
+RUN apk add --update gcc g++ make ruby-bundler
+RUN cd /app && bundle install
+
+EXPOSE 4000
+EXPOSE 35729

--- a/README.md
+++ b/README.md
@@ -53,7 +53,33 @@ Navigate to the directory where you have cloned `duckdb-web` and run:
 scripts/serve.sh
 ```
 
+### Run dev server in Docker
+
+Build the container using:
+
+```sh
+scripts/docker-build.sh
+```
+
+Serve the website (latest only, archives excluded) with:
+
+```sh
+scripts/docker-serve.sh
+```
+
 The website can then be browsed by going to `localhost:4000` in your browser.
+
+Serve the full website with:
+
+```sh
+scripts/docker-serve-full.sh
+```
+
+To stop the container, run:
+
+```sh
+scripts/docker-stop.sh
+```
 
 ## Generating code docs
 

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+# navigate to the repository root
+cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/.."
+
+. scripts/docker-vars.sh
+
+docker build . \
+    --tag ${JEKYLL_DOCKER_IMAGE_NAME}

--- a/scripts/docker-serve-full.sh
+++ b/scripts/docker-serve-full.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+# navigate to the repository root
+cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/.."
+
+scripts/docker-stop.sh
+
+. scripts/docker-vars.sh
+
+docker run \
+    --rm \
+    --interactive \
+    --name ${JEKYLL_DOCKER_CONTAINER_NAME} \
+    --volume="${PWD}:/srv/jekyll:Z" \
+    --publish 4000:4000 \
+    --publish 35729:35729 \
+    ${JEKYLL_DOCKER_IMAGE_NAME} \
+    bundle exec jekyll serve --host 0.0.0.0 $@

--- a/scripts/docker-serve.sh
+++ b/scripts/docker-serve.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+# navigate to the repository root
+cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/.."
+
+scripts/docker-serve-full.sh --incremental --config _config.yml,_config_exclude_archive.yml

--- a/scripts/docker-stop.sh
+++ b/scripts/docker-stop.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+# navigate to the repository root
+cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/.."
+
+. scripts/docker-vars.sh
+
+docker rm --force \
+    ${JEKYLL_DOCKER_CONTAINER_NAME=duckdb-jekyll}

--- a/scripts/docker-vars.sh
+++ b/scripts/docker-vars.sh
@@ -1,0 +1,2 @@
+JEKYLL_DOCKER_IMAGE_NAME=duckdb-web-jekyll-img
+JEKYLL_DOCKER_CONTAINER_NAME=duckdb-web-jekyll


### PR DESCRIPTION
This PR add scripts to run run `jekyll serve` through Docker. It's a multi-arch image so it also runs fast on Apple Silicon.

There is no `builder` version (with Linux and Ruby packages pre-baked into the image), and I did not want to roll out a Docker image for this...

So currently the Docker script installs a few packages.

Here are the times required to deploy the `dev` version on my laptop (after a full `git clean -xdf .`):
- native `jekyll`: no setup time + 6.3 s deployment time
- Docker `jekyll`: 13.4 s setup time + 8.0 s deployment time

So the difference is noticeable but the Docker setup is perfectly usable.

Fixes #951