### PR TITLE
Add rlwrap to CLI page

### DIFF
--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -535,3 +535,11 @@ woot
 42
 43
 ```
+
+## Using rlwrap
+
+You can use the [`rlwrap`](https://github.com/hanslub42/rlwrap) readline wrapper as follows:
+
+```bash
+rlwrap --substitute-prompt="> " duckdb -batch
+```


### PR DESCRIPTION
Fixes #597

@Alex-Monahan I added rlwrap to the CLI page.

However, I myself have trouble using it:
1) It doesn't allow navigating up in the command under editing, e.g. in

    ```sql
    SELECT 42
    ORDER BY ...
    ```

    I cannot navigate up from `...` to add an alias.

2) Once I ran a command, and press <kbd>Up</kbd>, it only gives me the last line of the command.

Is this the expected behaviour for `rlwrap`? I'm using MacOS and iTerm2.