### PR TITLE
Close SQL in side menu

### DIFF
--- a/_data/menu_docs_dev.json
+++ b/_data/menu_docs_dev.json
@@ -523,7 +523,6 @@
         },
         {
           "page": "SQL",
-          "open": true,
           "slug": "sql",
           "subfolderitems": [
             {


### PR DESCRIPTION
I noticed that the SQL menu is always open even if we are browsing something different (see secreenshot). I assume this is not on purpose, is it? In any case, this PR fixes it.
 
![Screenshot 2023-08-12 at 16 08 03](https://github.com/duckdb/duckdb-web/assets/1402801/283e881a-668c-416e-8151-7d6a02bb3e93)
