### PR TITLE
Adding initial CLI options, with a link to the CLI Configuration section

### DIFF
--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -19,9 +19,9 @@ The DuckDB CLI is based on the SQLite command line shell, so CLI-client-specific
 Once the CLI executable has been downloaded, unzip it and save it to any directory. Navigate to that directory in a terminal and enter the command `duckdb` to run the executable. If in a PowerShell or POSIX shell environment, use the command `./duckdb` instead.
 
 The executable can be configured in many ways when started. Some common configurations include: 
-- `-csv`, to set the output mode to CSV
-- `-json` to set the output mode to JSON
-- `-readonly` to open the database in read-only mode
+* `-csv`, to set the output mode to CSV
+* `-json` to set the output mode to JSON
+* `-readonly` to open the database in read-only mode
 
 To see additional command line options to use when starting the CLI, use the command `duckdb -help`.
 

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -16,7 +16,17 @@ The DuckDB CLI is based on the SQLite command line shell, so CLI-client-specific
 
 ## Getting Started
 
-Once the CLI executable has been downloaded, unzip it and save it to any directory. Navigate to that directory in a terminal and enter the command `duckdb` to run the executable. If in a PowerShell or POSIX shell environment, use the command `./duckdb` instead. To see additional command line options to use when starting the CLI, use the command `duckdb --help`.
+Once the CLI executable has been downloaded, unzip it and save it to any directory. Navigate to that directory in a terminal and enter the command `duckdb` to run the executable. If in a PowerShell or POSIX shell environment, use the command `./duckdb` instead.
+
+The executable can be configured in many ways when started. Some common configurations include: 
+- `-csv`, to set the output mode to CSV
+- `-json` to set the output mode to JSON
+- `-readonly` to open the database in read-only mode
+
+To see additional command line options to use when starting the CLI, use the command `duckdb -help`.
+
+Frequently-used configurations can be stored in the file `~/.duckdbrc`. See the [Configuring the CLI](#configuring-the-cli) below for further information on these options.
+
 By default, the CLI will open a temporary in-memory database. To open or create a persistent database, simply include a path as a command line argument like `duckdb path/to/my_database.duckdb`. This path can point to an existing database or to a file that does not yet exist and DuckDB will open or create a database at that location as needed. The file may have any arbitrary extension, but `.db` or `.duckdb` are two common choices. You will see a prompt like the below, with a `D` on the final line.
 
 ```text


### PR DESCRIPTION
Making a start on https://github.com/duckdb/duckdb-web/issues/893 to document the CLI options.