### PR TITLE
Update _config_exclude_archive.yml to exclude vendor

### DIFF
--- a/_config_exclude_archive.yml
+++ b/_config_exclude_archive.yml
@@ -1,2 +1,2 @@
 # bundler exec jekyll serve --incremental --config _config.yml,_config_exclude_archive.yml
-exclude: ['docs/archive']
+exclude: ['docs/archive', 'vendor']


### PR DESCRIPTION
Jekyll seems to choke on the files in here sometimes, and this list overrides the main one in _config.yml