### PR TITLE
Noting that default parameters must be named.

### DIFF
--- a/docs/sql/statements/create_macro.md
+++ b/docs/sql/statements/create_macro.md
@@ -60,7 +60,8 @@ SELECT add(1, 2);
 -- 3
 ```
 
-Macro's can have default parameters.  Unlike some languages, default parameters must be named.
+Macro's can have default parameters.  Unlike some languages, default parameters must be named
+when the macro is invoked.
 ```sql
 -- b is a default parameter
 CREATE MACRO add_default(a, b := 5) AS a + b;

--- a/docs/sql/statements/create_macro.md
+++ b/docs/sql/statements/create_macro.md
@@ -60,7 +60,7 @@ SELECT add(1, 2);
 -- 3
 ```
 
-Macro's can have default parameters.
+Macro's can have default parameters.  Unlike some languages, default parameters must be named.
 ```sql
 -- b is a default parameter
 CREATE MACRO add_default(a, b := 5) AS a + b;


### PR DESCRIPTION
Clarifying that default parameters must be named, which is different than some other languages.