### PR TITLE
Document the CSV reader's buffer_size option

### DIFF
--- a/docs/data/csv/overview.md
+++ b/docs/data/csv/overview.md
@@ -43,6 +43,7 @@ Below are parameters that can be passed in to the CSV reader.
 |:--|:-----|:-|:-|
 | `all_varchar` | Option to skip type detection for CSV parsing and assume all columns to be of type VARCHAR. | bool | false |
 | `auto_detect` | Enables [auto detection of parameters](auto_detection) | bool | true |
+| `buffer_size` | The buffer size used by the CSV reader, specified in bytes. By default, it is set to 32MB or the size of the CSV file (if smaller). The buffer size must be at least as large as the longest line in the CSV file. Note: this is an advanced option that has a significant impact on performance and memory usage. | bigint | min(32000000, CSV file size) |
 | `columns` | A struct that specifies the column names and column types contained within the CSV file (e.g., `{'col1': 'INTEGER', 'col2': 'VARCHAR'}`). | `struct` | `(empty)` |
 | `compression` | The compression type for the file. By default this will be detected automatically from the file extension (e.g., `t.csv.gz` will use gzip, `t.csv` will use `none`). Options are `none`, `gzip`, `zstd`. | varchar | auto |
 | `dateformat` | Specifies the date format to use when parsing dates. See [Date Format](../../sql/functions/dateformat) | varchar | `(empty)` |


### PR DESCRIPTION
Fixes #1039

![Screenshot 2023-08-25 at 09 19 28](https://github.com/duckdb/duckdb-web/assets/1402801/66637c4e-788f-4fc7-8931-0e834ed5110d)

Should be merged after - https://github.com/duckdb/duckdb/pull/8253
