### PR TITLE
Minor fixes

### DIFF
--- a/docs/api/adbc.md
+++ b/docs/api/adbc.md
@@ -21,7 +21,7 @@ Set of functions that operate on a database.
 | Function Name | Description | Arguments | Example |
 |:---|:-|:---|:----|
 | `DatabaseNew` | Allocate a new (but uninitialized) database. | `(AdbcDatabase *database, AdbcError *error)` | `AdbcDatabaseNew(&adbc_database, &adbc_error)` |
-| `DatabaseSetOption` | Set a char* option. | `(AdbcDatabase *database, const char *key, const char *value,AdbcError *error)` | `AdbcDatabaseSetOption(&adbc_database, "path", "test.db", &adbc_error)` |
+| `DatabaseSetOption` | Set a char* option. | `(AdbcDatabase *database, const char *key, const char *value, AdbcError *error)` | `AdbcDatabaseSetOption(&adbc_database, "path", "test.db", &adbc_error)` |
 | `DatabaseInit` | Finish setting options and initialize the database. | `(AdbcDatabase *database, AdbcError *error)` | `AdbcDatabaseInit(&adbc_database, &adbc_error)` |
 | `DatabaseRelease` | Destroy the database.| `(AdbcDatabase *database, AdbcError *error)` | `AdbcDatabaseRelease(&adbc_database, &adbc_error)` |
 
@@ -32,7 +32,7 @@ A set of functions that create and destroy a connection to interact with a datab
 | Function Name | Description | Arguments | Example |
 |:---|:-|:---|:----|
 | `ConnectionNew` | Allocate a new (but uninitialized) connection.| `(AdbcConnection*, AdbcError*)` | `AdbcConnectionNew(&adbc_connection, &adbc_error)` |
-| `ConnectionSetOption` | Options may be set before ConnectionInit.| `(AdbcConnection*, const char*, const char*, AdbcError*)` | `AdbcConnectionSetOption(&adbc_connection, ADBC_CONNECTION_OPTION_AUTOCOMMIT,ADBC_OPTION_VALUE_DISABLED, &adbc_error)` |
+| `ConnectionSetOption` | Options may be set before ConnectionInit.| `(AdbcConnection*, const char*, const char*, AdbcError*)` | `AdbcConnectionSetOption(&adbc_connection, ADBC_CONNECTION_OPTION_AUTOCOMMIT, ADBC_OPTION_VALUE_DISABLED, &adbc_error)` |
 | `ConnectionInit` | Finish setting options and initialize the connection. | `(AdbcConnection*, AdbcDatabase*, AdbcError*)` | `AdbcConnectionInit(&adbc_connection, &adbc_database, &adbc_error)` |
 | `ConnectionRelease` | Destroy this connection. | `(AdbcConnection*, AdbcError*)` | `AdbcConnectionRelease(&adbc_connection, &adbc_error)` |
 

--- a/docs/api/c/connect.md
+++ b/docs/api/c/connect.md
@@ -15,10 +15,10 @@ duckdb_database db;
 duckdb_connection con;
 
 if (duckdb_open(NULL, &db) == DuckDBError) {
-	// handle error
+    // handle error
 }
 if (duckdb_connect(db, &con) == DuckDBError) {
-	// handle error
+    // handle error
 }
 
 // run queries...

--- a/docs/api/cpp.md
+++ b/docs/api/cpp.md
@@ -37,7 +37,7 @@ con.Query("INSERT INTO integers VALUES (3, 4), (5, 6), (7, NULL)");
 
 MaterializedQueryResult result = con.Query("SELECT * FROM integers");
 if (!result->success) {
-	cerr << result->error;
+    cerr << result->error;
 }
 ```
 
@@ -110,7 +110,7 @@ An example of use would be:
 
 ```cpp
 int32_t udf_date(int32_t a) {
-	return a;
+    return a;
 }
 
 con.Query("CREATE TABLE dates (d DATE)");
@@ -151,28 +151,28 @@ The `CreateVectorizedFunction()` methods register a vectorized UDF such as:
 */
 template<typename TYPE>
 static void udf_vectorized(DataChunk &args, ExpressionState &state, Vector &result) {
-	// set the result vector type
-	result.vector_type = VectorType::FLAT_VECTOR;
-	// get a raw array from the result
-	auto result_data = FlatVector::GetData<TYPE>(result);
+    // set the result vector type
+    result.vector_type = VectorType::FLAT_VECTOR;
+    // get a raw array from the result
+    auto result_data = FlatVector::GetData<TYPE>(result);
 
-	// get the solely input vector
-	auto &input = args.data[0];
-	// now get an orrified vector
-	VectorData vdata;
-	input.Orrify(args.size(), vdata);
+    // get the solely input vector
+    auto &input = args.data[0];
+    // now get an orrified vector
+    VectorData vdata;
+    input.Orrify(args.size(), vdata);
 
-	// get a raw array from the orrified input
-	auto input_data = (TYPE *)vdata.data;
+    // get a raw array from the orrified input
+    auto input_data = (TYPE *)vdata.data;
 
-	// handling the data
-	for (idx_t i = 0; i < args.size(); i++) {
-		auto idx = vdata.sel->get_index(i);
-		if ((*vdata.nullmask)[idx]) {
-			continue;
-		}
-		result_data[i] = input_data[idx];
-	}
+    // handling the data
+    for (idx_t i = 0; i < args.size(); i++) {
+        auto idx = vdata.sel->get_index(i);
+        if ((*vdata.nullmask)[idx]) {
+            continue;
+        }
+        result_data[i] = input_data[idx];
+    }
 }
 
 con.Query("CREATE TABLE integers (i INTEGER)");

--- a/docs/api/java.md
+++ b/docs/api/java.md
@@ -51,7 +51,7 @@ DuckDB supports the standard JDBC methods to send queries and retrieve result se
 ```java
 // create a table
 Statement stmt = conn.createStatement();
-stmt.execute("CREATE TABLE items (item VARCHAR, value DECIMAL(10,2), count INTEGER)");
+stmt.execute("CREATE TABLE items (item VARCHAR, value DECIMAL(10, 2), count INTEGER)");
 // insert two items into the table
 stmt.execute("INSERT INTO items VALUES ('jeans', 20.0, 1), ('hammer', 42.2, 2)");
 ```

--- a/docs/api/python/dbapi.md
+++ b/docs/api/python/dbapi.md
@@ -48,7 +48,7 @@ SQL queries can be sent to DuckDB using the `execute()` method of connections. O
 
 ```python
 # create a table
-con.execute("CREATE TABLE items(item VARCHAR, value DECIMAL(10,2), count INTEGER)")
+con.execute("CREATE TABLE items(item VARCHAR, value DECIMAL(10, 2), count INTEGER)")
 # insert two items into the table
 con.execute("INSERT INTO items VALUES ('jeans', 20.0, 1), ('hammer', 42.2, 2)")
 

--- a/docs/api/python/function.md
+++ b/docs/api/python/function.md
@@ -13,8 +13,8 @@ from duckdb.typing import *
 from faker import Faker
 
 def random_name():
-	fake = Faker()
-	return fake.name()
+    fake = Faker()
+    return fake.name()
 
 duckdb.create_function('random_name', random_name, [], VARCHAR)
 res = duckdb.sql('select random_name()').fetchall()
@@ -58,7 +58,7 @@ For example:
 import duckdb
 
 def my_function(x: int) -> str:
-	return x
+    return x
 
 duckdb.create_function('my_func', my_function)
 duckdb.sql('select my_func(42)')
@@ -82,11 +82,11 @@ import duckdb
 from duckdb.typing import *
 
 def dont_intercept_null(x):
-	return 5
+    return 5
 
 duckdb.create_function('dont_intercept', dont_intercept_null, [BIGINT], BIGINT)
 res = duckdb.sql("""
-	select dont_intercept(NULL)
+    select dont_intercept(NULL)
 """).fetchall()
 print(res)
 # [(None,)]
@@ -94,7 +94,7 @@ print(res)
 duckdb.remove_function('dont_intercept')
 duckdb.create_function('dont_intercept', dont_intercept_null, [BIGINT], BIGINT, null_handling='special')
 res = duckdb.sql("""
-	select dont_intercept(NULL)
+    select dont_intercept(NULL)
 """).fetchall()
 print(res)
 # [(5,)]
@@ -177,8 +177,8 @@ from duckdb.typing import *
 from faker import Faker
 
 def random_date():
-	fake = Faker()
-	return fake.date_between()
+    fake = Faker()
+    return fake.date_between()
 
 duckdb.create_function('random_date', random_date, [], DATE, type='native')
 res = duckdb.sql('select random_date()').fetchall()

--- a/docs/api/python/reference/index.md
+++ b/docs/api/python/reference/index.md
@@ -925,7 +925,7 @@ title: Python Client API
 <span class="sig-name descname"><span class="pre">describe</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">self</span></span><span class="p"><span class="pre">:</span></span><span class="w"> </span><span class="n"><a class="reference internal" href="#duckdb.DuckDBPyRelation" title="duckdb.duckdb.DuckDBPyRelation"><span class="pre">duckdb.duckdb.DuckDBPyRelation</span></a></span></em><span class="sig-paren">)</span> <span class="sig-return"><span class="sig-return-icon">&#8594;</span> <span class="sig-return-typehint"><a class="reference internal" href="#duckdb.DuckDBPyRelation" title="duckdb.duckdb.DuckDBPyRelation"><span class="pre">duckdb.duckdb.DuckDBPyRelation</span></a></span></span><a class="headerlink" href="#duckdb.DuckDBPyRelation.describe" title="Link to this definition">&#182;</a>
 </dt>
 <dd>
-<p>Gives basic statistics (e.g., min,max) and if null exists for each column of the relation.</p>
+<p>Gives basic statistics (e.g., min, max) and if null exists for each column of the relation.</p>
 </dd>
 </dl>
 

--- a/docs/api/r.md
+++ b/docs/api/r.md
@@ -31,7 +31,7 @@ DuckDB supports the standard DBI methods to send queries and retrieve result set
 
 ```R
 # create a table
-dbExecute(con, "CREATE TABLE items(item VARCHAR, value DECIMAL(10,2), count INTEGER)")
+dbExecute(con, "CREATE TABLE items(item VARCHAR, value DECIMAL(10, 2), count INTEGER)")
 # insert two items into the table
 dbExecute(con, "INSERT INTO items VALUES ('jeans', 20.0, 1), ('hammer', 42.2, 2)")
 

--- a/docs/api/scala.md
+++ b/docs/api/scala.md
@@ -56,8 +56,8 @@ stmt.execute("INSERT INTO items VALUES ('jeans', 20.0, 1), ('hammer', 42.2, 2)")
 ```scala
 val rs = stmt.executeQuery("SELECT * FROM items");
 while (rs.next()) {
-	System.out.println(rs.getString(1));
-	System.out.println(rs.getInt(3));
+    System.out.println(rs.getString(1));
+    System.out.println(rs.getInt(3));
 }
 rs.close()
 // jeans

--- a/docs/api/scala.md
+++ b/docs/api/scala.md
@@ -48,7 +48,7 @@ DuckDB supports the standard JDBC methods to send queries and retrieve result se
 ```scala
 // create a table
 val stmt = conn.createStatement();
-stmt.execute("CREATE TABLE items (item VARCHAR, value DECIMAL(10,2), count INTEGER)");
+stmt.execute("CREATE TABLE items (item VARCHAR, value DECIMAL(10, 2), count INTEGER)");
 // insert two items into the table
 stmt.execute("INSERT INTO items VALUES ('jeans', 20.0, 1), ('hammer', 42.2, 2)");
 ```

--- a/docs/data/multiple_files/overview.md
+++ b/docs/data/multiple_files/overview.md
@@ -30,7 +30,7 @@ SELECT * FROM 'test/*.parquet';
 -- read 3 parquet files and treat them as a single table
 SELECT * FROM read_parquet(['file1.parquet', 'file2.parquet', 'file3.parquet']);
 -- Read all parquet files from 2 specific folders
-SELECT * FROM read_parquet(['folder1/*.parquet','folder2/*.parquet']);
+SELECT * FROM read_parquet(['folder1/*.parquet', 'folder2/*.parquet']);
 -- read all parquet files that match the glob pattern at any depth
 SELECT * FROM read_parquet('dir/**/*.parquet');
 ```
@@ -76,7 +76,7 @@ The glob syntax and the list input parameter can be combined to scan files that 
 
 ```sql
 -- Read all parquet files from 2 specific folders
-SELECT * FROM read_parquet(['folder1/*.parquet','folder2/*.parquet']);
+SELECT * FROM read_parquet(['folder1/*.parquet', 'folder2/*.parquet']);
 ```
 
 DuckDB can read multiple CSV files at the same time using either the glob syntax, or by providing a list of files to read.

--- a/docs/data/parquet/overview.md
+++ b/docs/data/parquet/overview.md
@@ -23,7 +23,7 @@ SELECT * FROM 'test/*.parquet';
 -- read all files that match the glob pattern, and include a "filename" column that specifies which file each row came from
 SELECT * FROM read_parquet('test/*.parquet', filename=true);
 -- use a list of globs to read all parquet files from 2 specific folders
-SELECT * FROM read_parquet(['folder1/*.parquet','folder2/*.parquet']);
+SELECT * FROM read_parquet(['folder1/*.parquet', 'folder2/*.parquet']);
 -- query the metadata of a parquet file
 SELECT * FROM parquet_metadata('test.parquet');
 -- query the schema of a parquet file

--- a/docs/data/partitioning/hive_partitioning.md
+++ b/docs/data/partitioning/hive_partitioning.md
@@ -73,7 +73,7 @@ By default the system tries to infer if the provided files are in a hive partiti
 `hive_types` is a way to specify the logical types of the hive partitions in a struct:
 
 ```sql
-FROM read_parquet('dir/**/*.parquet', hive_partitioning=1, hive_types={'release':date,'orders':bigint});
+FROM read_parquet('dir/**/*.parquet', hive_partitioning=1, hive_types={'release': date, 'orders': bigint});
 ```
 
 `hive_types` will be autodetected for the following types: `DATE`, `TIMESTAMP` and `BIGINT`. To switch off the autodetection, the flag `hive_types_autocast=0` can be set.

--- a/docs/extensions/full_text_search.md
+++ b/docs/extensions/full_text_search.md
@@ -53,7 +53,7 @@ When an index is built, this retrieval macro is created that can be used to sear
 |:--|:--|:----------|
 |input_id|`VARCHAR`|Column name of document identifier e.g., `'document_identifier'`|
 |query_string|`VARCHAR`|The string to search the index for|
-|fields|`VARCHAR`|Comma-separarated list of fields to search in e.g., `'text_field_2,text_field_N'`. Defaults to `NULL` to search all indexed fields|
+|fields|`VARCHAR`|Comma-separarated list of fields to search in e.g., `'text_field_2, text_field_N'`. Defaults to `NULL` to search all indexed fields|
 |k|`DOUBLE`|Parameter _k<sub>1</sub>_ in the Okapi BM25 retrieval model. Defaults to `1.2`|
 |b|`DOUBLE`|Parameter _b_ in the Okapi BM25 retrieval model. Defaults to `0.75`|
 |conjunctive|`BOOLEAN`|Whether to make the query conjunctive i.e., all terms in the query string must be present in order for a document to be retrieved|
@@ -77,7 +77,7 @@ Reduces words to their base. Used internally by the extension.
 -- create a table and fill it with text data
 CREATE TABLE documents(document_identifier VARCHAR, text_content VARCHAR, author VARCHAR, doc_version INTEGER);
 INSERT INTO documents
-VALUES ('doc1', 'The mallard is a dabbling duck that breeds throughout the temperate.','Hannes Mühleisen', 3),
+VALUES ('doc1', 'The mallard is a dabbling duck that breeds throughout the temperate.', 'Hannes Mühleisen', 3),
        ('doc2', 'The cat is a domestic species of small carnivorous mammal.', 'Laurens Kuiper', 2);
 -- build the index (make both the 'text_content' and 'author' columns searchable)
 PRAGMA create_fts_index('documents', 'document_identifier', 'text_content', 'author');

--- a/docs/extensions/json.md
+++ b/docs/extensions/json.md
@@ -57,7 +57,7 @@ With `'unstructured'`, the top-level JSON is read, e.g.:
   "duck": 42
 }
 {
-  "goose": [1,2,3]
+  "goose": [1, 2, 3]
 }
 ```
 Will result in two objects being read.
@@ -65,7 +65,7 @@ Will result in two objects being read.
 With `'newline_delimited'`, [NDJSON](http://ndjson.org) is read, where each JSON is separated by a newline (`\n`), e.g.:
 ```json
 {"duck": 42}
-{"goose": [1,2,3]}
+{"goose": [1, 2, 3]}
 ```
 Will also result in two objects being read.
 
@@ -76,7 +76,7 @@ With `'array'`, each array element is read, e.g.:
     "duck": 42
   },
   {
-    "goose": [1,2,3]
+    "goose": [1, 2, 3]
   }
 ]
 ```
@@ -86,7 +86,7 @@ Example usage:
 ```sql
 SELECT * FROM read_json_objects('my_file1.json');
 -- {"duck":42,"goose":[1,2,3]}
-SELECT * FROM read_json_objects(['my_file1.json','my_file2.json']);
+SELECT * FROM read_json_objects(['my_file1.json', 'my_file2.json']);
 -- {"duck":42,"goose":[1,2,3]}
 -- {"duck":43,"goose":[4,5,6],"swan":3.3}
 SELECT * FROM read_ndjson_objects('*.json.gz');
@@ -129,7 +129,7 @@ DuckDB can convert JSON arrays directly to its internal `LIST` type, and missing
 
 ```sql
 SELECT *
-FROM read_json(['my_file1.json','my_file2.json'],
+FROM read_json(['my_file1.json', 'my_file2.json'],
                columns={duck: 'INTEGER', goose: 'INTEGER[]', swan: 'DOUBLE'});
 ```
 
@@ -186,8 +186,8 @@ If your JSON file does not contain 'records', i.e., any other type of JSON than 
 This is specified with the `records` parameter.
 The `records` parameter specifies whether the JSON contains records that should be unpacked into individual columns, i.e., reading the following file with `records`:
 ```json
-{"duck": 42, "goose": [1,2,3]}
-{"duck": 43, "goose": [4,5,6]}
+{"duck": 42, "goose": [1, 2, 3]}
+{"duck": 43, "goose": [4, 5, 6]}
 ```
 Results in two columns:
 
@@ -200,8 +200,8 @@ You can read the same file with `records` set to `'false'`, to get a single colu
 
 | json |
 |:---|
-| {'duck': 42, 'goose': [1, 2, 3]} |
- |{'duck': 43, 'goose': [4, 5, 6]} |
+| {'duck': 42, 'goose': [1,2,3]} |
+| {'duck': 43, 'goose': [4,5,6]} |
 
 For additional examples reading more complex data, please see the [Shredding Deeply Nested JSON, One Vector at a Time blog post](https://duckdb.org/2023/03/03/json.html).
 
@@ -255,25 +255,25 @@ We support two kinds of notations to describe locations within JSON: [JSON Point
 The JSONPointer syntax separates each field with a `/`.
 For example, to extract the first element of the array with key `"duck"`, you can do:
 ```sql
-SELECT json_extract('{"duck":[1,2,3]}', '/duck/0');
+SELECT json_extract('{"duck": [1, 2, 3]}', '/duck/0');
 -- 1
 ```
 
 The JSONPath syntax separates fields with a `.`, and accesses array elements with `[i]`, and always starts with `$`. Using the same example, we can do:
 ```sql
-SELECT json_extract('{"duck":[1,2,3]}', '$.duck[0]');
+SELECT json_extract('{"duck": [1, 2, 3]}', '$.duck[0]');
 -- 1
 ```
 
 JSONPath is more expressive, and can also access from the back of lists:
 ```sql
-SELECT json_extract('{"duck":[1,2,3]}', '$.duck[#-1]');
+SELECT json_extract('{"duck": [1, 2, 3]}', '$.duck[#-1]');
 -- 3
 ```
 
 JSONPath also allows escaping syntax tokens, using double quotes:
 ```sql
-SELECT json_extract('{"duck.goose":[1,2,3]}', '$."duck.goose"[1]');
+SELECT json_extract('{"duck.goose": [1, 2, 3]}', '$."duck.goose"[1]');
 -- 2
 ```
 
@@ -288,7 +288,7 @@ SELECT json_valid(j) FROM example;
 -- true
 SELECT json_valid('{');
 -- false
-SELECT json_array_length('["duck","goose","swan",null]');
+SELECT json_array_length('["duck", "goose", "swan", null]');
 -- 4
 SELECT json_array_length(j, 'species') FROM example;
 -- 4
@@ -449,13 +449,13 @@ CREATE TABLE example (j JSON);
 INSERT INTO example VALUES
   ('{"family": "anatidae", "species": ["duck", "goose"], "coolness": 42.42}'),
   ('{"family": "canidae", "species": ["labrador", "bulldog"], "hair": true}');
-SELECT json_transform(j, '{"family":"VARCHAR","coolness":"DOUBLE"}') FROM example;
+SELECT json_transform(j, '{"family": "VARCHAR", "coolness": "DOUBLE"}') FROM example;
 -- {'family': anatidae, 'coolness': 42.420000}
 -- {'family': canidae, 'coolness': NULL}
-SELECT json_transform(j, '{"family":"TINYINT","coolness":"DECIMAL(4,2)"}') FROM example;
+SELECT json_transform(j, '{"family": "TINYINT", "coolness": "DECIMAL(4, 2)"}') FROM example;
 -- {'family': NULL, 'coolness': 42.42}
 -- {'family': NULL, 'coolness': NULL}
-SELECT json_transform_strict(j, '{"family":"TINYINT","coolness":"DOUBLE"}') FROM example;
+SELECT json_transform_strict(j, '{"family": "TINYINT", "coolness": "DOUBLE"}') FROM example;
 -- Invalid Input Error: Failed to cast value: "anatidae"
 ```
 

--- a/docs/extensions/overview.md
+++ b/docs/extensions/overview.md
@@ -88,7 +88,7 @@ There are many methods to decompress gzip. Here is a Python example:
 import gzip
 import shutil
 
-with gzip.open('httpfs.duckdb_extension.gz','rb') as f_in:
+with gzip.open('httpfs.duckdb_extension.gz', 'rb') as f_in:
    with open('httpfs.duckdb_extension', 'wb') as f_out:
      shutil.copyfileobj(f_in, f_out)
 ```

--- a/docs/guides/python/export_arrow.md
+++ b/docs/guides/python/export_arrow.md
@@ -11,8 +11,8 @@ All results of a query can be exported to an [Apache Arrow Table](https://arrow.
 import duckdb
 import pyarrow as pa
 
-my_arrow_table = pa.Table.from_pydict({'i':[1,2,3,4],
-                                       'j':["one", "two", "three", "four"]})
+my_arrow_table = pa.Table.from_pydict({'i': [1, 2, 3, 4],
+                                       'j': ["one", "two", "three", "four"]})
 
 # query the Apache Arrow Table "my_arrow_table" and return as an Arrow Table
 results = duckdb.sql("SELECT * FROM my_arrow_table").arrow()
@@ -24,8 +24,8 @@ results = duckdb.sql("SELECT * FROM my_arrow_table").arrow()
 import duckdb
 import pyarrow as pa
 
-my_arrow_table = pa.Table.from_pydict({'i':[1,2,3,4],
-                                       'j':["one", "two", "three", "four"]})
+my_arrow_table = pa.Table.from_pydict({'i': [1, 2, 3, 4],
+                                       'j': ["one", "two", "three", "four"]})
                                        
 # query the Apache Arrow Table "my_arrow_table" and return as an Arrow RecordBatchReader
 chunk_size = 1_000_000
@@ -52,7 +52,7 @@ import duckdb
 con = duckdb.connect()
 
 con.execute('CREATE TABLE integers (i integer)')
-con.execute('INSERT INTO integers VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9),(NULL)')
+con.execute('INSERT INTO integers VALUES (0), (1), (2), (3), (4), (5), (6), (7), (8), (9), (NULL)')
 
 # Create a relation from the table and export the entire relation as Arrow
 rel = con.table("integers")

--- a/docs/guides/python/relational_api_pandas.md
+++ b/docs/guides/python/relational_api_pandas.md
@@ -12,8 +12,8 @@ import pandas
 # connect to an in-memory database
 con = duckdb.connect()
 
-input_df = pandas.DataFrame.from_dict({'i':[1,2,3,4],
-                                       'j':["one", "two", "three", "four"]})
+input_df = pandas.DataFrame.from_dict({'i': [1, 2, 3, 4],
+                                       'j': ["one", "two", "three", "four"]})
 
 # create a DuckDB relation from a dataframe
 rel = con.from_df(input_df)

--- a/docs/guides/python/sql_on_arrow.md
+++ b/docs/guides/python/sql_on_arrow.md
@@ -16,8 +16,8 @@ import pyarrow as pa
 # connect to an in-memory database
 con = duckdb.connect()
 
-my_arrow_table = pa.Table.from_pydict({'i':[1,2,3,4],
-                                       'j':["one", "two", "three", "four"]})
+my_arrow_table = pa.Table.from_pydict({'i': [1, 2, 3, 4],
+                                       'j': ["one", "two", "three", "four"]})
 
 # query the Apache Arrow Table "my_arrow_table" and return as an Arrow Table
 results = con.execute("SELECT * FROM my_arrow_table WHERE i = 2").arrow()
@@ -40,8 +40,8 @@ import pyarrow.dataset as ds
 # connect to an in-memory database
 con = duckdb.connect()
 
-my_arrow_table = pa.Table.from_pydict({'i':[1,2,3,4],
-                                       'j':["one", "two", "three", "four"]})
+my_arrow_table = pa.Table.from_pydict({'i': [1, 2, 3, 4],
+                                       'j': ["one", "two", "three", "four"]})
 
 # create example parquet files and save in a folder
 base_path = pathlib.Path(tempfile.gettempdir())
@@ -71,8 +71,8 @@ import pyarrow.compute as pc
 # connect to an in-memory database
 con = duckdb.connect()
 
-my_arrow_table = pa.Table.from_pydict({'i':[1,2,3,4],
-                                       'j':["one", "two", "three", "four"]})
+my_arrow_table = pa.Table.from_pydict({'i': [1, 2, 3, 4],
+                                       'j': ["one", "two", "three", "four"]})
 
 # create example parquet files and save in a folder
 base_path = pathlib.Path(tempfile.gettempdir())
@@ -102,8 +102,8 @@ import pyarrow as pa
 # connect to an in-memory database
 con = duckdb.connect()
 
-my_recordbatch = pa.RecordBatch.from_pydict({'i':[1,2,3,4],
-                                             'j':["one", "two", "three", "four"]})
+my_recordbatch = pa.RecordBatch.from_pydict({'i': [1, 2, 3, 4],
+                                             'j': ["one", "two", "three", "four"]})
 
 my_recordbatchreader = pa.ipc.RecordBatchReader.from_batches(my_recordbatch.schema, [my_recordbatch])
 

--- a/docs/guides/sql_features/asof_join.md
+++ b/docs/guides/sql_features/asof_join.md
@@ -14,7 +14,7 @@ First, we create a price table and sales table.
 CREATE TABLE prices AS (
     SELECT '2001-01-01 00:16:00'::TIMESTAMP + INTERVAL (v) MINUTE AS ticker_time,
         v AS unit_price
-    FROM range(0,5) vals(v)
+    FROM range(0, 5) vals(v)
 );
 
 CREATE TABLE sales(item TEXT, sale_time TIMESTAMP, quantity INT);

--- a/docs/guides/sql_features/full_text_search.md
+++ b/docs/guides/sql_features/full_text_search.md
@@ -49,7 +49,7 @@ What does Shakespeare say about butter?
 
 ```sql
 SELECT fts_main_corpus.match_bm25(line_id, 'butter') AS score,
-    line_id,play_name,speaker,text_entry
+    line_id, play_name, speaker, text_entry
   FROM corpus
   WHERE score IS NOT NULL
   ORDER BY score;

--- a/docs/sql/aggregates.md
+++ b/docs/sql/aggregates.md
@@ -41,8 +41,8 @@ The table below shows the available general aggregate functions.
 | Function | Description | Example | Alias(es) |
 |:--|:---|:--|:--|
 | `any_value(arg)` |Returns the first _non-null_ value from arg. | `any_value(A)` | - |
-| `arg_max(arg,val)` |Finds the row with the maximum `val`. Calculates the `arg` expression at that row. | `arg_max(A,B)` | `argMax(A,B)`, `max_by(A,b)` |
-| `arg_min(arg,val)` |Finds the row with the minimum `val`. Calculates the `arg` expression at that row. | `arg_min(A,B)` | `argMin(A,B)`, `min_by(A,B)` |
+| `arg_max(arg, val)` |Finds the row with the maximum `val`. Calculates the `arg` expression at that row. | `arg_max(A, B)` | `argMax(A, B)`, `max_by(A, b)` |
+| `arg_min(arg, val)` |Finds the row with the minimum `val`. Calculates the `arg` expression at that row. | `arg_min(A, B)` | `argMin(A, B)`, `min_by(A, B)` |
 | `avg(arg)` |Calculates the average value for all tuples in arg. | `avg(A)` | - |
 | `bit_and(arg)` |Returns the bitwise AND of all bits in a given expression . | `bit_and(A)` | - |
 | `bit_or(arg)` |Returns the bitwise OR of all bits in a given expression.  | `bit_or(A)` | - |
@@ -80,30 +80,30 @@ The table below shows the available statistical aggregate functions.
 
 | Function | Description | Formula | Alias |
 |:--|:---|:--|:-|
-| `corr(y,x)` | Returns the correlation coefficient for non-null pairs in a group. | `COVAR_POP(y, x) / (STDDEV_POP(x) * STDDEV_POP(y))`| - |
-| `covar_pop(y,x)` | Returns the population covariance of input values. | `(SUM(x*y) - SUM(x) * SUM(y) / COUNT(*)) / COUNT(*) ` | - |
-| `covar_samp(y,x)` | Returns the sample covariance for non-null pairs in a group. | `(SUM(x*y) - SUM(x) * SUM(y) / COUNT(*)) / (COUNT(*) - 1)` | - |
+| `corr(y, x)` | Returns the correlation coefficient for non-null pairs in a group. | `COVAR_POP(y, x) / (STDDEV_POP(x) * STDDEV_POP(y))`| - |
+| `covar_pop(y, x)` | Returns the population covariance of input values. | `(SUM(x*y) - SUM(x) * SUM(y) / COUNT(*)) / COUNT(*) ` | - |
+| `covar_samp(y, x)` | Returns the sample covariance for non-null pairs in a group. | `(SUM(x*y) - SUM(x) * SUM(y) / COUNT(*)) / (COUNT(*) - 1)` | - |
 | `entropy(x)` | Returns the log-2 entropy of count input-values. | - | - |
 | `kurtosis(x)` | Returns the excess kurtosis (Fisher's definition) of all input values, with a bias correction according to the sample size. | - | - |
 | `mad(x)` | Returns the median absolute deviation for the values within x. NULL values are ignored. Temporal types return a positive `INTERVAL`. | `MEDIAN(ABS(x-MEDIAN(x)))` | - |
 | `median(x)` | Returns the middle value of the set. NULL values are ignored. For even value counts, quantitative values are averaged and ordinal values return the lower value. | `QUANTILE_CONT(x, 0.5)` | - |
 | `mode(x)` | Returns the most frequent value for the values within x. NULL values are ignored. | - | - |
-| `quantile_cont(x,pos)` | Returns the interpolated quantile number between 0 and 1 . If `pos` is a `LIST` of `FLOAT`s, then the result is a `LIST` of the corresponding interpolated quantiles. | - | - |
-| `quantile_disc(x,pos)` | Returns the exact quantile number between 0 and 1 . If `pos` is a `LIST` of `FLOAT`s, then the result is a `LIST` of the corresponding exact quantiles. | - | `quantile` |
-| `regr_avgx(y,x)` | Returns the average of the independent variable for non-null pairs in a group, where x is the independent variable and y is the dependent variable. | - | - |
-| `regr_avgy(y,x)` | Returns the average of the dependent variable for non-null pairs in a group, where x is the independent variable and y is the dependent variable. | - | - |
-| `regr_count(y,x)` | Returns the number of non-null number pairs in a group. | `(SUM(x*y) - SUM(x) * SUM(y) / COUNT(*)) / COUNT(*)` | - |
-| `regr_intercept(y,x)` | Returns the intercept of the univariate linear regression line for non-null pairs in a group. | `AVG(y)-REGR_SLOPE(y,x)*AVG(x)` | - |
-| `regr_r2(y,x)` | Returns the coefficient of determination for non-null pairs in a group. | - | - |
-| `regr_slope(y,x)` | Returns the slope of the linear regression line for non-null pairs in a group.| `COVAR_POP(x,y) / VAR_POP(x)` | - |
-| `regr_sxx(y,x)` | -  | `REGR_COUNT(y, x) * VAR_POP(x)` | - |
-| `regr_sxy(y,x)` | Returns the population covariance of input values. | `REGR_COUNT(y, x) * COVAR_POP(y, x) ` | - |
-| `regr_syy(y,x)` | - | `REGR_COUNT(y, x) * VAR_POP(y) f` | - |
+| `quantile_cont(x, pos)` | Returns the interpolated quantile number between 0 and 1 . If `pos` is a `LIST` of `FLOAT`s, then the result is a `LIST` of the corresponding interpolated quantiles. | - | - |
+| `quantile_disc(x, pos)` | Returns the exact quantile number between 0 and 1 . If `pos` is a `LIST` of `FLOAT`s, then the result is a `LIST` of the corresponding exact quantiles. | - | `quantile` |
+| `regr_avgx(y, x)` | Returns the average of the independent variable for non-null pairs in a group, where x is the independent variable and y is the dependent variable. | - | - |
+| `regr_avgy(y, x)` | Returns the average of the dependent variable for non-null pairs in a group, where x is the independent variable and y is the dependent variable. | - | - |
+| `regr_count(y, x)` | Returns the number of non-null number pairs in a group. | `(SUM(x*y) - SUM(x) * SUM(y) / COUNT(*)) / COUNT(*)` | - |
+| `regr_intercept(y, x)` | Returns the intercept of the univariate linear regression line for non-null pairs in a group. | `AVG(y)-REGR_SLOPE(y, x)*AVG(x)` | - |
+| `regr_r2(y, x)` | Returns the coefficient of determination for non-null pairs in a group. | - | - |
+| `regr_slope(y, x)` | Returns the slope of the linear regression line for non-null pairs in a group.| `COVAR_POP(x, y) / VAR_POP(x)` | - |
+| `regr_sxx(y, x)` | -  | `REGR_COUNT(y, x) * VAR_POP(x)` | - |
+| `regr_sxy(y, x)` | Returns the population covariance of input values. | `REGR_COUNT(y, x) * COVAR_POP(y, x) ` | - |
+| `regr_syy(y, x)` | - | `REGR_COUNT(y, x) * VAR_POP(y) f` | - |
 | `skewness(x)` | Returns the skewness of all input values. | - | - |
 | `stddev_pop(x)` | Returns the population standard deviation.  | `sqrt(var_pop(x))` | - |
 | `stddev_samp(x)` | Returns the sample standard deviation. | `sqrt(var_samp(x))` | `stddev(x)` |
 | `var_pop(x)` | Returns the population variance. | - | - |
-| `var_samp(x)` | Returns the sample variance of all input values. | `(SUM(x^2) - SUM(x)^2 / COUNT(x)) / (COUNT(x) - 1)` | `variance(arg,val)` |
+| `var_samp(x)` | Returns the sample variance of all input values. | `(SUM(x^2) - SUM(x)^2 / COUNT(x)) / (COUNT(x) - 1)` | `variance(arg, val)` |
 
 ## Ordered Set Aggregate Functions
 

--- a/docs/sql/data_types/enum.md
+++ b/docs/sql/data_types/enum.md
@@ -65,10 +65,10 @@ CREATE TABLE person (
 );
 
 -- Inserts tuples in the person table
-INSERT INTO person VALUES ('Pedro','happy'), ('Mark', NULL), ('Pagliacci', 'sad'), ('Mr. Mackey', 'ok');
+INSERT INTO person VALUES ('Pedro', 'happy'), ('Mark', NULL), ('Pagliacci', 'sad'), ('Mr. Mackey', 'ok');
 
 -- This will fail since the mood type does not have a 'quackity-quack' value.
-INSERT INTO person VALUES ('Hannes','quackity-quack');
+INSERT INTO person VALUES ('Hannes', 'quackity-quack');
 
 -- The string 'sad' is cast to the type Mood, returning a numerical reference value.
 -- This makes the comparison a numerical comparison instead of a string comparison.

--- a/docs/sql/data_types/list.md
+++ b/docs/sql/data_types/list.md
@@ -34,19 +34,19 @@ Retrieving one or more values from a list can be accomplished using brackets and
 ```sql
 -- Note that we wrap the list creation in parenthesis so that it happens first.
 -- This is only needed in our basic examples here, not when working with a list column
--- For example, this can't be parsed: SELECT ['a','b','c'][1]
+-- For example, this can't be parsed: SELECT ['a', 'b', 'c'][1]
 ```
 
-| example                                           | result     |
-|:---------------------------------------------------|:------------|
-| `SELECT (['a','b','c'])[3]`               | 'c'        |
-| `SELECT (['a','b','c'])[-1]`             | 'c'        |
-| `SELECT (['a','b','c'])[2 + 1]`       | 'c'        |
-| `SELECT list_extract(['a','b','c'],3)` | 'c'        |
-| `SELECT (['a','b','c'])[1:2]`                       | ['a', 'b'] |
-| `SELECT (['a','b','c'])[:2]`              | ['a', 'b'] |
-| `SELECT (['a','b','c'])[-2:]`            | ['b', 'c'] |
-| `SELECT list_slice(['a','b','c'],2,3)`              | ['b', 'c'] |
+| example                                    | result     |
+| :----------------------------------------- | :--------- |
+| `SELECT (['a', 'b', 'c'])[3]`              | 'c'        |
+| `SELECT (['a', 'b', 'c'])[-1]`             | 'c'        |
+| `SELECT (['a', 'b', 'c'])[2 + 1]`          | 'c'        |
+| `SELECT list_extract(['a', 'b', 'c'], 3)`  | 'c'        |
+| `SELECT (['a', 'b', 'c'])[1:2]`            | ['a', 'b'] |
+| `SELECT (['a', 'b', 'c'])[:2]`             | ['a', 'b'] |
+| `SELECT (['a', 'b', 'c'])[-2:]`            | ['b', 'c'] |
+| `SELECT list_slice(['a', 'b', 'c'], 2, 3)` | ['b', 'c'] |
 
 ## Ordering
 

--- a/docs/sql/data_types/numeric.md
+++ b/docs/sql/data_types/numeric.md
@@ -25,7 +25,7 @@ The type integer is the common choice, as it offers the best balance between ran
 
 ## Fixed-Point Decimals
 
-The data type `DECIMAL(WIDTH,SCALE)` represents an exact fixed-point decimal value. When creating a value of type `DECIMAL`, the `WIDTH` and `SCALE` can be specified to define which size of decimal values can be held in the field. The `WIDTH` field determines how many digits can be held, and the `scale` determines the amount of digits after the decimal point. For example, the type `DECIMAL(3,2)` can fit the value `1.23`, but cannot fit the value `12.3` or the value `1.234`. The default `WIDTH` and `SCALE` is `DECIMAL(18,3)`, if none are specified.
+The data type `DECIMAL(WIDTH, SCALE)` represents an exact fixed-point decimal value. When creating a value of type `DECIMAL`, the `WIDTH` and `SCALE` can be specified to define which size of decimal values can be held in the field. The `WIDTH` field determines how many digits can be held, and the `scale` determines the amount of digits after the decimal point. For example, the type `DECIMAL(3, 2)` can fit the value `1.23`, but cannot fit the value `12.3` or the value `1.234`. The default `WIDTH` and `SCALE` is `DECIMAL(18, 3)`, if none are specified.
 
 Internally, decimals are represented as integers depending on their specified width.
 

--- a/docs/sql/data_types/overview.md
+++ b/docs/sql/data_types/overview.md
@@ -38,9 +38,9 @@ DuckDB supports four nested data types: `LIST`, `STRUCT`, `MAP` and `UNION`. Eac
 
 | Name | Description | Rules when used in a column | Build from values | Define in DDL/CREATE |
 |:-|:---|:---|:--|:--|
-| [LIST](../../sql/data_types/list) | An ordered sequence of data values of the same type. | Each row must have the same data type within each LIST, but can have any number of elements. | [1, 2, 3] | INT[ ] |
-| [STRUCT](../../sql/data_types/struct) | A dictionary of multiple named values, where each key is a string, but the value can be a different type for each key. | Each row must have the same keys. | {'i': 42, 'j': 'a'} | STRUCT(i INT, j VARCHAR) |
-| [MAP](../../sql/data_types/map) | A dictionary of multiple named values, each key having the same type and each value having the same type. Keys and values can be any type and can be different types from one another. | Rows may have different keys. | map([1,2],['a','b']) | MAP(INT, VARCHAR) |
+| [LIST](../../sql/data_types/list) | An ordered sequence of data values of the same type. | Each row must have the same data type within each LIST, but can have any number of elements. | `[1, 2, 3]` | INT[ ] |
+| [STRUCT](../../sql/data_types/struct) | A dictionary of multiple named values, where each key is a string, but the value can be a different type for each key. | Each row must have the same keys. | `{'i': 42, 'j': 'a'}` | STRUCT(i INT, j VARCHAR) |
+| [MAP](../../sql/data_types/map) | A dictionary of multiple named values, each key having the same type and each value having the same type. Keys and values can be any type and can be different types from one another. | Rows may have different keys. | `map([1, 2], ['a', 'b'])` | MAP(INT, VARCHAR) |
 | [UNION](../../sql/data_types/union) | A union of multiple alternative data types, storing one of them in each value at a time. A union also contains a discriminator "tag" value to inspect and access the currently set member type. | Rows may be set to different member types of the union. | union_value(num := 2) | UNION(num INT, text VARCHAR) |
 
 ## Nesting

--- a/docs/sql/data_types/struct.md
+++ b/docs/sql/data_types/struct.md
@@ -26,7 +26,7 @@ SELECT {'yes': 'duck', 'maybe': 'goose', 'huh': NULL, 'no': 'heron'};
 SELECT {'key1': 'string', 'key2': 1, 'key3': 12.345};
 -- Struct using the struct_pack function. 
 -- Note the lack of single quotes around the keys and the use of the := operator
-SELECT struct_pack(key1 := 'value1',key2 := 42);
+SELECT struct_pack(key1 := 'value1', key2 := 42);
 -- Struct of structs with NULL values
 SELECT {'birds':
             {'yes': 'duck', 'maybe': 'goose', 'huh': NULL, 'no': 'heron'},
@@ -56,17 +56,17 @@ Retrieving a value from a struct can be accomplished using dot notation, bracket
 ```sql
 -- Use dot notation to retrieve the value at a key's location. This returns 1
 -- The subquery generates a struct column "a", which we then query with a.x
-SELECT a.x FROM (SELECT {'x':1, 'y':2, 'z':3} AS a);
+SELECT a.x FROM (SELECT {'x': 1, 'y': 2, 'z': 3} AS a);
 -- If key contains a space, simply wrap it in double quotes. This returns 1
 -- Note: Use double quotes not single quotes 
 -- This is because this action is most similar to selecting a column from within the struct
-SELECT a."x space" FROM (SELECT {'x space':1, 'y':2, 'z':3} AS a);
+SELECT a."x space" FROM (SELECT {'x space': 1, 'y': 2, 'z': 3} AS a);
 -- Bracket notation may also be used. This returns 1
 -- Note: Use single quotes since the goal is to specify a certain string key. 
 -- Only constant expressions may be used inside the brackets (no columns)
-SELECT a['x space'] FROM (SELECT {'x space':1, 'y':2, 'z':3} AS a);
+SELECT a['x space'] FROM (SELECT {'x space': 1, 'y': 2, 'z': 3} AS a);
 -- The struct_extract function is also equivalent. This returns 1
-SELECT struct_extract({'x space': 1, 'y': 2, 'z': 3},'x space');
+SELECT struct_extract({'x space': 1, 'y': 2, 'z': 3}, 'x space');
 ```
 
 #### Struct.*

--- a/docs/sql/data_types/text.md
+++ b/docs/sql/data_types/text.md
@@ -17,7 +17,7 @@ If you wish to restrict the number of characters in a `VARCHAR` column for data 
 
 ```sql
 CREATE TABLE strings(
-	val VARCHAR CHECK(LENGTH(val) <= 10) -- val has a maximum length of 10 characters
+    val VARCHAR CHECK(LENGTH(val) <= 10) -- val has a maximum length of 10 characters
 );
 ```
 

--- a/docs/sql/functions/char.md
+++ b/docs/sql/functions/char.md
@@ -17,7 +17,7 @@ This section describes functions and operators for examining and manipulating st
 | `bit_length(`*`string`*`)`| Number of bits in a string. | `bit_length('abc')` | `24` | |
 | `chr(`*`x`*`)` | returns a character which is corresponding the ASCII code value or Unicode code point | `chr(65)` | A | |
 | `concat(`*`string`*`, ...)` | Concatenate many strings together | `concat('Hello', ' ', 'World')` | `Hello World` | |
-| `concat_ws(`*`separator`*`, `*`string`*`, ...)` | Concatenate strings together separated by the specified separator | `concat_ws(', ', 'Banana', 'Apple', 'Melon')` | `Banana,Apple,Melon` | |
+| `concat_ws(`*`separator`*`, `*`string`*`, ...)` | Concatenate strings together separated by the specified separator | `concat_ws(', ', 'Banana', 'Apple', 'Melon')` | `Banana, Apple, Melon` | |
 | `contains(`*`string`*`, `*`search_string`*`)` | Return true if *search_string* is found within *string* | `contains('abc', 'a')` | `true` | |
 | `ends_with(`*`string`*`, `*`search_string`*`)`| Return true if *string* ends with *search_string* | `ends_with('abc', 'c')` | `true` | `suffix` |
 | `format(`*`format`*`, `*`parameters`*`...)` | Formats a string using fmt syntax | `format('Benchmark "{}" took {} seconds', 'CSV', 42)` | `Benchmark "CSV" took 42 seconds` | |

--- a/docs/sql/functions/nested.md
+++ b/docs/sql/functions/nested.md
@@ -38,7 +38,7 @@ In the descriptions, `l` is the three element list `[4, 5, 6]`.
 | `list_distinct(`*`list`*`)`                                  | `array_distinct`                                  | Removes all duplicates and NULLs from a list. Does not preserve the original order.                                                                                                | `list_distinct([1, 1, NULL, -3, 1, 5])` | `[1, 5, -3]`      |
 | `list_unique(`*`list`*`)`                                    | `array_unique`                                    | Counts the unique elements of a list.                                                                                                                                              | `list_unique([1, 1, NULL, -3, 1, 5])`   | `3`               |
 | `list_any_value(`*`list`*`)`                                 |                                                   | Returns the first non-null value in the list                                                                                                                                       | `list_any_value([NULL, -3])`            | `-3`              |
-| `list_resize(`*`list`*`, `*`size`*`[, `*`value`*`])`         | `array_resize`                                    | Resizes the list to contain `size` elements. Initializes new elements with `value` or `NULL` if `value` is not set.                                                                | `list_resize([1,2,3], 5, 0)`            | `[1, 2, 3, 0, 0]` |
+| `list_resize(`*`list`*`, `*`size`*`[, `*`value`*`])`         | `array_resize`                                    | Resizes the list to contain `size` elements. Initializes new elements with `value` or `NULL` if `value` is not set.                                                                | `list_resize([1, 2, 3], 5, 0)`            | `[1, 2, 3, 0, 0]` |
 
 ## List Operators
 
@@ -46,10 +46,10 @@ The following operators are supported for lists:
 
 | Operator | Description | Example | Result |
 |-|--|---|-|
-| `&&`     | Alias for `list_intersect`                                                                | `[1,2,3,4,5] && [2,5,5,6]` | `[2,5]`         |
-| `@>`     | Alias for `list_has_all`, where the list on the **right** of the operator is the sublist. | `[1,2,3,4] @> [3,4,3]`     | `true`          |
-| `<@`     | Alias for `list_has_all`, where the list on the **left** of the operator is the sublist.  | `[1,4] <@ [1,2,3,4]`       | `true`          |
-| `||`     | Alias for `list_concat`                                                                   | `[1,2,3] || [4,5,6]`       | `[1,2,3,4,5,6]` |
+| `&&`     | Alias for `list_intersect`                                                                | `[1, 2, 3, 4, 5] && [2, 5, 5, 6]` | `[2, 5]`         |
+| `@>`     | Alias for `list_has_all`, where the list on the **right** of the operator is the sublist. | `[1, 2, 3, 4] @> [3, 4, 3]`     | `true`          |
+| `<@`     | Alias for `list_has_all`, where the list on the **left** of the operator is the sublist.  | `[1, 4] <@ [1, 2, 3, 4]`       | `true`          |
+| `||`     | Alias for `list_concat`                                                                   | `[1, 2, 3] || [4, 5, 6]`       | `[1, 2, 3, 4, 5, 6]` |
 
 ## List Comprehension
 
@@ -78,8 +78,8 @@ SELECT [upper(x) for x in strings if len(x)>0] FROM (VALUES (['Hello', '', 'Worl
 | Function | Description | Example | Result |
 |:--|:---|:---|:-|
 | `map[`*`entry`*`]` | Alias for `element_at` | `map([100, 5], ['a', 'b'])[100]` | `[a]` |
-| `element_at(`*`map, key`*`)` | Return a list containing the value for a given key or an empty list if the key is not contained in the map. The type of the key provided in the second parameter must match the type of the map's keys else an error is returned. | `element_at(map([100, 5], [42, 43]),100);` | `[42]` |
-| `map_extract(`*`map, key`*`)` | Alias of `element_at`. Return a list containing the value for a given key or an empty list if the key is not contained in the map. The type of the key provided in the second parameter must match the type of the map's keys else an error is returned. | `map_extract(map([100, 5], [42, 43]),100);` | `[42]` |
+| `element_at(`*`map, key`*`)` | Return a list containing the value for a given key or an empty list if the key is not contained in the map. The type of the key provided in the second parameter must match the type of the map's keys else an error is returned. | `element_at(map([100, 5], [42, 43]), 100);` | `[42]` |
+| `map_extract(`*`map, key`*`)` | Alias of `element_at`. Return a list containing the value for a given key or an empty list if the key is not contained in the map. The type of the key provided in the second parameter must match the type of the map's keys else an error is returned. | `map_extract(map([100, 5], [42, 43]), 100);` | `[42]` |
 | `cardinality(`*`map`*`)` | Return the size of the map (or the number of entries in the map). | `cardinality( map([4, 2], ['a', 'b']) );` | `2` |
 | `map_from_entries(`*`STRUCT(k, v)[]`*`)` | Returns a map created from the entries of the array | `map_from_entries([{k: 5, v: 'val1'}, {k: 3, v: 'val2'}]);` | `{5=val1, 3=val2}` |
 | `map()` | Returns an empty map. | `map()` | `{}` |
@@ -426,7 +426,7 @@ SELECT flatten([[NULL],[NULL]]);
 The `generate_subscript(`*`arr`*`, `*`dim`*`)` function generates indexes along the `dim`th dimension of array `arr`.
 
 ```sql
-SELECT generate_subscripts([4,5,6], 1) AS i;
+SELECT generate_subscripts([4, 5, 6], 1) AS i;
 ```
 
 ```text

--- a/docs/sql/functions/utility.md
+++ b/docs/sql/functions/utility.md
@@ -11,8 +11,8 @@ The functions below are difficult to categorize into specific function types and
 |:--|:--|:---|:--|
 | `alias(`*`column`*`)` | Return the name of the column| `alias(column1)` | `'column1'` |
 | `checkpoint(`*`database`*`)`| Synchronize WAL with file for (optional) database without interrupting transactions. | `checkpoint(my_db)`| success boolean |
-| `coalesce(`*`expr`*`, `*`...`*`)` | Return the first expression that evaluates to a non-`NULL` value. Accepts 1 or more parameters. Each expression can be a column, literal value, function result, or many others. | `coalesce(NULL,NULL,'default_string')` | `'default_string'`|
-| `ifnull(`*`expr`*`, `*`other`*`)` | A two-argument version of coalesce | `ifnull(NULL,'default_string')` | `'default_string'`|
+| `coalesce(`*`expr`*`, `*`...`*`)` | Return the first expression that evaluates to a non-`NULL` value. Accepts 1 or more parameters. Each expression can be a column, literal value, function result, or many others. | `coalesce(NULL, NULL, 'default_string')` | `'default_string'`|
+| `ifnull(`*`expr`*`, `*`other`*`)` | A two-argument version of coalesce | `ifnull(NULL, 'default_string')` | `'default_string'`|
 | `nullif(`*`a`*`, `*`b`*`)` | Return null if a = b, else return a. Equivalent to `CASE WHEN a=b THEN NULL ELSE a END`. | `nullif(1+1, 2)` | `NULL`|
 | `current_schema()`| Return the name of the currently active schema. Default is main. | `current_schema()` | `'main'`|
 | `current_schemas(`*`boolean`*`)`| Return list of schemas. Pass a parameter of `True` to include implicit schemas.| `current_schemas(true)`| `['temp', 'main', 'pg_catalog']`|
@@ -21,7 +21,7 @@ The functions below are difficult to categorize into specific function types and
 | `force_checkpoint(`*`database`*`)`| Synchronize WAL with file for (optional) database interrupting transactions. | `force_checkpoint(my_db)`| success boolean |
 | `gen_random_uuid()` | Alias of `uuid`. Return a random uuid similar to this: eeccb8c5-9943-b2bb-bb5e-222f4e14b687. | `gen_random_uuid()`| various |
 | `hash(`*`value`*`)` | Returns an integer with the hash of the *value*| `hash('🦆')` | `2595805878642663834` |
-| `icu_sort_key(`*`string`*`, `*`collator`*`)` | Surrogate key used to sort special characters according to the specific locale. Collator parameter is optional. Valid only when ICU extension is installed.| `icu_sort_key('ö','DE')` | 460145960106|
+| `icu_sort_key(`*`string`*`, `*`collator`*`)` | Surrogate key used to sort special characters according to the specific locale. Collator parameter is optional. Valid only when ICU extension is installed.| `icu_sort_key('ö', 'DE')` | 460145960106|
 | `md5(`*`string`*`)` | Return an md5 one-way hash of the *string*.| `md5('123')` | `'202cb962ac59075b964b07152d234b70'`|
 | `nextval(`*`'sequence_name'`*`)`| Return the following value of the sequence.| `nextval('my_sequence_name')`| `2` |
 | `pg_typeof(`*`expression`*`)` | Returns the lower case name of the data type of the result of the expression. For PostgreSQL compatibility.| `pg_typeof('abc')` | `'varchar'` |

--- a/docs/sql/information_schema.md
+++ b/docs/sql/information_schema.md
@@ -50,7 +50,7 @@ The view that describes the catalog information for columns is `information_sche
 | `ordinal_position` |Ordinal position of the column within the table (count starts at 1). | `INTEGER` | `5` |
 | `column_default` |Default expression of the column.|`VARCHAR`| `1.99` |
 | `is_nullable` |`YES` if the column is possibly nullable, `NO` if it is known not nullable.|`VARCHAR`| `'YES'` |
-| `data_type` |Data type of the column.|`VARCHAR`| `'DECIMAL(18,2)'` |
+| `data_type` |Data type of the column.|`VARCHAR`| `'DECIMAL(18, 2)'` |
 | `character_maximum_length` |If `data_type` identifies a character or bit string type, the declared maximum length; null for all other data types or if no maximum length was declared.|`INTEGER`| `255` |
 | `character_octet_length` |If data_type identifies a character type, the maximum possible length in octets (bytes) of a datum; null for all other data types. The maximum octet length depends on the declared character maximum length (see above) and the character encoding.|`INTEGER`| `1073741824` |
 | `numeric_precision` |If data_type identifies a numeric type, this column contains the (declared or implicit) precision of the type for this column. The precision indicates the number of significant digits. For all other data types, this column is null.|`INTEGER`| `18` |

--- a/docs/sql/introduction.md
+++ b/docs/sql/introduction.md
@@ -7,7 +7,7 @@ Here we provide an overview of how to perform simple operations in SQL. This tut
 In the examples that follow, we assume that you have installed the DuckDB Command Line Interface (CLI) shell. See the [installation page](../installation?environment=cli) for information on how to install the CLI. If you build from the source tree, you can launch the CLI from the build directory ``build/release/duckdb``. Launching the shell should give you the following prompt:
 
 ```text
-DuckDB 5fb6fe57ab
+v0.8.1 6536a77232
 Enter ".help" for usage hints.
 Connected to a transient in-memory database.
 Use ".open FILENAME" to reopen on a persistent database.

--- a/docs/sql/introduction.md
+++ b/docs/sql/introduction.md
@@ -4,7 +4,7 @@ title: SQL Introduction
 ---
 Here we provide an overview of how to perform simple operations in SQL. This tutorial is only intended to give you an introduction and is in no way a complete tutorial on SQL. This tutorial is adapted from the [PostgreSQL tutorial](https://www.postgresql.org/docs/11/tutorial-sql-intro.html).
 
-In the examples that follow, we assume that you have installed the DuckDB Command Line Interface (CLI) shell. See the [installation page](../installation?environment=cli) for information on how to install the CLI. If you build from the source tree, you can launch the CLI from the build directory ``build/release/duckdb``. Launching the shell should give you the following prompt:
+In the examples that follow, we assume that you have installed the DuckDB Command Line Interface (CLI) shell. See the [installation page](../installation?environment=cli) for information on how to install the CLI. Launching the shell should give you the following prompt:
 
 ```text
 v0.8.1 6536a77232

--- a/docs/sql/query_syntax/filter.md
+++ b/docs/sql/query_syntax/filter.md
@@ -19,7 +19,7 @@ SELECT
     count(*) as total_rows,
     count(*) FILTER (WHERE i <= 5) as lte_five,
     count(*) FILTER (WHERE i % 2 = 1) as odds
-FROM generate_series(1,10) tbl(i);
+FROM generate_series(1, 10) tbl(i);
 ```
 
 | total_rows | lte_five | odds |
@@ -34,7 +34,7 @@ SELECT
     sum(i) FILTER (WHERE i <= 5) as lte_five_sum,
     median(i) FILTER (WHERE i % 2 = 1) as odds_median,
     median(i) FILTER (WHERE i % 2 = 1 AND i <= 5) as odds_lte_five_median
-FROM generate_series(1,10) tbl(i);
+FROM generate_series(1, 10) tbl(i);
 ```
 
 | lte_five_sum | odds_median | odds_lte_five_median |
@@ -58,7 +58,7 @@ CREATE TEMP TABLE stacked_data as
         SELECT 
             i, 
             count(*) over () as rows 
-        FROM generate_series(1,100000000) tbl(i)
+        FROM generate_series(1, 100000000) tbl(i)
     ) tbl;
 
 --"Pivot" the data out by year (move each year out to a separate column)

--- a/docs/sql/statements/create_macro.md
+++ b/docs/sql/statements/create_macro.md
@@ -33,10 +33,10 @@ CREATE MACRO arr_append(l, e) AS list_concat(l, list_value(e));
 -- create a table macro without parameters
 CREATE MACRO static_table() AS TABLE SELECT 'Hello' AS column1, 'World' AS column2;
 -- create a table macro with parameters (that can be of any type)
-CREATE MACRO dynamic_table(col1_value,col2_value) AS TABLE SELECT col1_value AS column1, col2_value AS column2;
+CREATE MACRO dynamic_table(col1_value, col2_value) AS TABLE SELECT col1_value AS column1, col2_value AS column2;
 -- create a table macro that returns multiple rows. 
 -- It will be replaced if it already exists, and it is temporary (will be automatically deleted when the connection ends)
-CREATE OR REPLACE TEMP MACRO dynamic_table(col1_value,col2_value) AS TABLE 
+CREATE OR REPLACE TEMP MACRO dynamic_table(col1_value, col2_value) AS TABLE 
     SELECT col1_value AS column1, col2_value AS column2 
     UNION ALL 
     SELECT 'Hello' AS col1_value, 456 AS col2_value;
@@ -52,7 +52,7 @@ Macros allow you to create shortcuts for combinations of expressions.
 -- failure! cannot find column "b"
 CREATE MACRO add(a) AS a + b;
 -- this works
-CREATE MACRO add(a,b) AS a + b;
+CREATE MACRO add(a, b) AS a + b;
 -- error! cannot bind +(VARCHAR, INTEGER)
 SELECT add('hello', 3);
 -- success!

--- a/docs/sql/statements/create_type.md
+++ b/docs/sql/statements/create_type.md
@@ -26,4 +26,4 @@ CREATE TYPE x_index AS INTEGER;
 types can then be inspected in the `duckdb_types` table.
 
 Extending these custom types to support custom operators (such as the PostgreSQL `&&` operator)
-would require C++ development. But that can be done in an extension!
+would require C++ development. To do this, create an [extension](../extensions/overview).

--- a/docs/sql/statements/unpivot.md
+++ b/docs/sql/statements/unpivot.md
@@ -211,8 +211,8 @@ is translated into:
 SELECT 
     empid,
     dept,
-    UNNEST(['jan','feb','mar','apr','may','jun']) as "month",
-    UNNEST(["jan","feb","mar","apr","may","jun"]) as "sales"
+    UNNEST(['jan', 'feb', 'mar', 'apr', 'may', 'jun']) as "month",
+    UNNEST(["jan", "feb", "mar", "apr", "may", "jun"]) as "sales"
 FROM monthly_sales;
 ```
 

--- a/docs/sql/statements/unpivot.md
+++ b/docs/sql/statements/unpivot.md
@@ -19,8 +19,8 @@ The full syntax diagram is below, but the simplified `UNPIVOT` syntax can be sum
 UNPIVOT [dataset]
 ON [column(s)]
 INTO 
-	NAME [name-column-name]
-	VALUE [value-column-name(s)]
+    NAME [name-column-name]
+    VALUE [value-column-name(s)]
 ORDER BY [column(s)-with-order-direction(s)]
 LIMIT [number-of-rows];
 ```
@@ -256,8 +256,8 @@ The full syntax diagram is below, but the SQL Standard `UNPIVOT` syntax can be s
 ```sql
 FROM [dataset]
 UNPIVOT [INCLUDE NULLS] (
-	[value-column-name(s)]
-	FOR [name-column-name] IN [column(s)]
+    [value-column-name(s)]
+    FOR [name-column-name] IN [column(s)]
 );
 ```
 

--- a/internals/vector.md
+++ b/internals/vector.md
@@ -12,7 +12,7 @@ DuckDB uses a vectorized query execution model.
 All operators in DuckDB are optimized to work on Vectors of a fixed size.  
 
 This fixed size is commonly referred to in the code as `STANDARD_VECTOR_SIZE`.  
-The default STANDARD_VECTOR_SIZE is 2048 tuples.
+The default `STANDARD_VECTOR_SIZE` is 2048 tuples.
 
 ## Vector Format
 


### PR DESCRIPTION
I added the version number to the CLI output in the SQL introduction and removed this part:
>  If you build from the source tree, you can launch the CLI from the build directory build/release/duckdb.
The SQL introduction page should be about SQL. I think 99% of its readers will use a pre-built DuckDB binary / a notebook / etc.

Some minor fixes are also in this PR.