### PR TITLE
Add Apache Arrow example to overview.md for Node.js

### DIFF
--- a/docs/api/nodejs/overview.md
+++ b/docs/api/nodejs/overview.md
@@ -102,3 +102,33 @@ var stmt = con.prepare('select ?::INTEGER as fortytwo', function(err, stmt) {
   });
 });
 ```
+
+[Apache Arrow](https://duckdb.org/docs/guides/python/sql_on_arrow) can be used to insert data into DuckDB without making a copy:
+
+```js
+const arrow = require('apache-arrow');
+const db = new duckdb.Database(':memory:');
+
+const jsonData = [
+  {"userId":1,"id":1,"title":"delectus aut autem","completed":false},
+  {"userId":1,"id":2,"title":"quis ut nam facilis et officia qui","completed":false}
+];
+
+// note; doesn't work on Windows yet
+db.exec(`INSTALL arrow; LOAD arrow;`, (err) => {
+    if (err) {
+        throw err;
+    }
+
+    const arrowTable = arrow.tableFromJSON(jsonData);
+    db.register_buffer("jsonDataTable", [arrow.tableToIPC(arrowTable)], true, (err, res) => {
+        if (err) {
+            throw err;
+        }
+
+        // `SELECT * FROM jsonDataTable` would return the entries in `jsonData`
+    });
+});
+
+```
+


### PR DESCRIPTION
Added simplified example of how to use Apache Arrow together with the Node.js API to get data into DuckDB efficiently without copying it to a file first, or using INSERT statements.

I saw that https://github.com/duckdb/duckdb-web/blob/5cc1993f870a9d38a00bb0d748b68a5b00422f31/CONTRIBUTING.md states not to include guides on how to use external tools, but i think Apache Arrow is now so close to DuckDB that it would fit here.

Also, the existing Node.js API is not clear on how `register_buffer` method should/can be used.
This example makes that clear.

This PR is based on development i did for https://github.com/duckdb/duckdb/discussions/8466.