### PR TITLE
Rename SQLType to LogicalType in C++ API documentation

### DIFF
--- a/docs/api/cpp.md
+++ b/docs/api/cpp.md
@@ -41,7 +41,7 @@ if (!result->success) {
 }
 ```
 
-The `MaterializedQueryResult` instance contains firstly two fields that indicate whether the query was successful. `Query` will not throw exceptions under normal circumstances. Instead, invalid queries or other issues will lead to the `success` boolean field in the query result instance to be set to `false`. In this case an error message may be available in `error` as a string. If successful, other fields are set: the type of statement that was just executed (e.g., `StatementType::INSERT_STATEMENT`) is contained in `statement_type`. The high-level ("SQL type") types of the result set columns are in `sql_types` and the low-level data representation types are in `types`. The names of the result columns are in the `names` string vector. In case multiple result sets are returned, for example because the result set contained multiple statements, the result set can be chained using the `next` field.
+The `MaterializedQueryResult` instance contains firstly two fields that indicate whether the query was successful. `Query` will not throw exceptions under normal circumstances. Instead, invalid queries or other issues will lead to the `success` boolean field in the query result instance to be set to `false`. In this case an error message may be available in `error` as a string. If successful, other fields are set: the type of statement that was just executed (e.g., `StatementType::INSERT_STATEMENT`) is contained in `statement_type`. The high-level ("Logical type"/"SQL type") types of the result set columns are in `types`. The names of the result columns are in the `names` string vector. In case multiple result sets are returned, for example because the result set contained multiple statements, the result set can be chained using the `next` field.
 
 DuckDB also supports prepared statements in the C++ API with the `Prepare()` method. This returns an instance of `PreparedStatement`. This instance can be used to execute the prepared statement with parameters. Below is an example:
 
@@ -86,24 +86,24 @@ void CreateScalarFunction(string name, TR (*udf_func)(Args…))
 - **name**: is the name to register the UDF function;
 - **udf_func**: is a pointer to the UDF function.
 
-This method automatically discovers from the template typenames the corresponding SQLTypes:
+This method automatically discovers from the template typenames the corresponding LogicalTypes:
 
-- `bool` → `SQLType::BOOLEAN`
-- `int8_t` → `SQLType::TINYINT`
-- `int16_t` → `SQLType::SMALLINT`
-- `int32_t` → `SQLType::INTEGER`
-- `int64_t`  →` SQLType::BIGINT`
-- `float` → `SQLType::FLOAT`
-- `double` → `SQLType::DOUBLE`
-- `string_t` → `SQLType::VARCHAR`
+- `bool` → `LogicalType::BOOLEAN`
+- `int8_t` → `LogicalType::TINYINT`
+- `int16_t` → `LogicalType::SMALLINT`
+- `int32_t` → `LogicalType::INTEGER`
+- `int64_t`  →` LogicalType::BIGINT`
+- `float` → `LogicalType::FLOAT`
+- `double` → `LogicalType::DOUBLE`
+- `string_t` → `LogicalType::VARCHAR`
 
-*In DuckDB some primitive types, e.g., _int32_t_, are mapped to the same SQLType: `INTEGER`, `TIME` and `DATE`, then for disambiguation the users can use the following overloaded method.
+*In DuckDB some primitive types, e.g., _int32_t_, are mapped to the same LogicalType: `INTEGER`, `TIME` and `DATE`, then for disambiguation the users can use the following overloaded method.
 
 **2.**
 
 ```cpp
 template<typename TR, typename... Args>
-void CreateScalarFunction(string name, vector<SQLType> args, SQLType ret_type, TR (*udf_func)(Args…))
+void CreateScalarFunction(string name, vector<LogicalType> args, LogicalType ret_type, TR (*udf_func)(Args…))
 ```
 
 An example of use would be:
@@ -116,7 +116,7 @@ int32_t udf_date(int32_t a) {
 con.Query("CREATE TABLE dates (d DATE)");
 con.Query("INSERT INTO dates VALUES ('1992-01-01')");
 
-con.CreateScalarFunction<int32_t, int32_t>("udf_date", {SQLType::DATE}, SQLType::DATE, &udf_date);
+con.CreateScalarFunction<int32_t, int32_t>("udf_date", {LogicalType::DATE}, LogicalType::DATE, &udf_date);
 
 con.Query("SELECT udf_date(d) FROM dates")->Print();
 
@@ -126,20 +126,20 @@ con.Query("SELECT udf_date(d) FROM dates")->Print();
     - **TR** is the return type of the UDF function;
     - **Args** are the arguments up to 3 for the UDF function (this method only supports until ternary functions);
 - **name**: is the name to register the UDF function;
-- **args**: are the SQLType arguments that the function uses, which should match with the template Args types;
-- **ret_type**: is the SQLType of return of the function, which should match with the template TR type;
+- **args**: are the LogicalType arguments that the function uses, which should match with the template Args types;
+- **ret_type**: is the LogicalType of return of the function, which should match with the template TR type;
 - **udf_func**: is a pointer to the UDF function.
 
-This function checks the template types against the SQLTypes passed as arguments and they must match as follow:
+This function checks the template types against the LogicalTypes passed as arguments and they must match as follow:
 
-- SQLTypeId::BOOLEAN → bool
-- SQLTypeId::TINYINT → int8_t
-- SQLTypeId::SMALLINT → int16_t
-- SQLTypeId::DATE, SQLTypeId::TIME, SQLTypeId::INTEGER → int32_t
-- SQLTypeId::BIGINT, SQLTypeId::TIMESTAMP → int64_t
-- SQLTypeId::FLOAT, SQLTypeId::DOUBLE, SQLTypeId::DECIMAL → double
-- SQLTypeId::VARCHAR, SQLTypeId::CHAR, SQLTypeId::BLOB → string_t
-- SQLTypeId::VARBINARY → blob_t
+- LogicalTypeId::BOOLEAN → bool
+- LogicalTypeId::TINYINT → int8_t
+- LogicalTypeId::SMALLINT → int16_t
+- LogicalTypeId::DATE, LogicalTypeId::TIME, LogicalTypeId::INTEGER → int32_t
+- LogicalTypeId::BIGINT, LogicalTypeId::TIMESTAMP → int64_t
+- LogicalTypeId::FLOAT, LogicalTypeId::DOUBLE, LogicalTypeId::DECIMAL → double
+- LogicalTypeId::VARCHAR, LogicalTypeId::CHAR, LogicalTypeId::BLOB → string_t
+- LogicalTypeId::VARBINARY → blob_t
 
 #### CreateVectorizedFunction
 
@@ -209,7 +209,7 @@ The general API of the `CreateVectorizedFunction()` method is as follows:
 
 ```cpp
 template<typename TR, typename... Args>
-void CreateVectorizedFunction(string name, scalar_function_t udf_func, SQLType varargs = SQLType::INVALID)
+void CreateVectorizedFunction(string name, scalar_function_t udf_func, LogicalType varargs = LogicalType::INVALID)
 ```
 
 - template parameters:
@@ -217,22 +217,22 @@ void CreateVectorizedFunction(string name, scalar_function_t udf_func, SQLType v
     - **Args** are the arguments up to 3 for the UDF function.
 - **name** is the name to register the UDF function;
 - **udf_func** is a _vectorized_ UDF function;
-- **varargs** The type of varargs to support, or SQLTypeId::INVALID (default value) if the function does not accept variable length arguments. 
+- **varargs** The type of varargs to support, or LogicalTypeId::INVALID (default value) if the function does not accept variable length arguments. 
 
-This method automatically discovers from the template typenames the corresponding SQLTypes:
+This method automatically discovers from the template typenames the corresponding LogicalTypes:
 
-- bool → SQLType::BOOLEAN;
-- int8_t → SQLType::TINYINT;
-- int16_t → SQLType::SMALLINT
-- int32_t → SQLType::INTEGER
-- int64_t  → SQLType::BIGINT
-- float → SQLType::FLOAT
-- double → SQLType::DOUBLE
-- string_t → SQLType::VARCHAR
+- bool → LogicalType::BOOLEAN;
+- int8_t → LogicalType::TINYINT;
+- int16_t → LogicalType::SMALLINT
+- int32_t → LogicalType::INTEGER
+- int64_t  → LogicalType::BIGINT
+- float → LogicalType::FLOAT
+- double → LogicalType::DOUBLE
+- string_t → LogicalType::VARCHAR
 
 **2.**
 
 ```cpp
 template<typename TR, typename... Args>
-void CreateVectorizedFunction(string name, vector<SQLType> args, SQLType ret_type, scalar_function_t udf_func, SQLType varargs = SQLType::INVALID)
+void CreateVectorizedFunction(string name, vector<LogicalType> args, LogicalType ret_type, scalar_function_t udf_func, LogicalType varargs = LogicalType::INVALID)
 ```


### PR DESCRIPTION
Resolves #1140.

I am not sure whether my change to
> The high-level ("SQL type") types of the result set columns are in `sql_types` and the low-level data representation types are in `types`. 

is sensible.

A quick look at `MaterializedQueryResult` made me assume that the low-level data types are not exposed anymore and the high-level type vector is now called `types` instead.