### PR TITLE
Highlight function names

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,6 +32,8 @@ markdown: kramdown
 kramdown:
   input: GFM
   syntax_highlighter: rouge
+  syntax_highlighter_opts:
+    default_lang: sql
 theme: minima
 plugins:
   - jekyll-feed

--- a/css/docu.scss
+++ b/css/docu.scss
@@ -328,219 +328,219 @@ div.flex{
 
 /** SLATE IMPORT **/
 
-.highlight table td {
+table td {
     padding: 5px;
 }
-.highlight table pre {
+table pre {
     margin: 0;
 }
-.highlight .cm {
+.cm {
     color: #777772;
     font-family: $fontMonoItalic;
 }
-.highlight .cp {
+.cp {
     color: #797676;
     font-family: $fontMonoBold;
 }
-.highlight .c1 {
+.c1 {
     color: #929292;
     font-family: $fontMonoItalic;
 }
-.highlight .cs {
+.cs {
     color: #797676;
     font-family: $fontMonoItalicBold;
 }
-.highlight .c,
-.highlight .cd {
+.c,
+.cd {
     color: #777772;
     font-family: $fontMonoItalic;
 }
-.highlight .err {
+.err {
     /*
     color: #a61717;
     background-color: #e3d2d2;
     */
 }
-.highlight .gd {
+.gd {
     color: #000000;
     background-color: #ffdddd;
 }
-.highlight .ge {
+.ge {
     color: #000000;
     font-family: $fontMonoItalic;
 }
-.highlight .gr {
+.gr {
     color: #aa0000;
 }
-.highlight .gh {
+.gh {
     color: #797676;
 }
-.highlight .gi {
+.gi {
     color: #000000;
     background-color: #ddffdd;
 }
-.highlight .go {
+.go {
     color: #888888;
 }
-.highlight .gp {
+.gp {
     color: #555555;
 }
-.highlight .gs {
+.gs {
     font-family: $fontMonoBold;
 }
-.highlight .gu {
+.gu {
     color: #aaaaaa;
 }
-.highlight .gt {
+.gt {
     color: #aa0000;
 }
-.highlight .kc {
+.kc {
     color: #000000;
     font-family: $fontMonoBold;
 }
-.highlight .kd {
+.kd {
     color: #000000;
     font-family: $fontMonoBold;
 }
-.highlight .kn {
+.kn {
     color: #000000;
     font-family: $fontMonoBold;
 }
-.highlight .kp {
+.kp {
     color: #000000;
     font-family: $fontMonoBold;
 }
-.highlight .kr {
+.kr {
     color: #000000;
     font-family: $fontMonoBold;
 }
-.highlight .kt {
+.kt {
     color: #445588;
     font-family: $fontMonoBold;
 }
-.highlight .k,
-.highlight .kv {
+.k,
+.kv {
     color: #000000;
     font-family: $fontMonoBold;
 }
-.highlight .mf {
+.mf {
     color: #009999;
 }
-.highlight .mh {
+.mh {
     color: #009999;
 }
-.highlight .il {
+.il {
     color: #009999;
 }
-.highlight .mi {
+.mi {
     color: #32cd32;
 }
-.highlight .mo {
+.mo {
     color: #009999;
 }
-.highlight .m,
-.highlight .mb,
-.highlight .mx {
+.m,
+.mb,
+.mx {
     color: #009999;
 }
-.highlight .sb {
+.sb {
     color: rgb(255,0,0);
 }
-.highlight .sc {
+.sc {
     color: #d14;
 }
-.highlight .sd {
+.sd {
     color: #d14;
 }
-.highlight .s2 {
+.s2 {
     color: rgb(255,0,0);
 }
-.highlight .se {
+.se {
     color: #d14;
 }
-.highlight .sh {
+.sh {
     color: #d14;
 }
-.highlight .si {
+.si {
     color: #d14;
 }
-.highlight .sx {
+.sx {
     color: #d14;
 }
-.highlight .sr {
+.sr {
     color: #009926;
 }
-.highlight .s1 {
+.s1 {
     color: rgb(255,0,0);
 }
-.highlight .ss {
+.ss {
     color: #990073;
 }
-.highlight .s {
+.s {
     color: rgb(255,0,0);
 }
-.highlight .na {
+.na {
     color: #008080;
 }
-.highlight .bp {
+.bp {
     color: #797676;
 }
-.highlight .nb {
+.nb {
     color: rgb(0,0,255);
 }
-.highlight .nc {
+.nc {
     color: #445588;
     font-family: $fontMonoBold;
 }
-.highlight .no {
+.no {
     color: #008080;
 }
-.highlight .nd {
+.nd {
     color: #3c5d5d;
     font-family: $fontMonoBold;
 }
-.highlight .ni {
+.ni {
     color: #800080;
 }
-.highlight .ne {
+.ne {
     color: #990000;
     font-family: $fontMonoBold;
 }
-.highlight .nf {
-    color: black;
+.nf {
+    color: #a1045a;
     font-family: $fontMonoBold;
 }
-.highlight .nl {
+.nl {
     color: #990000;
     font-family: $fontMonoBold;
 }
-.highlight .nn {
+.nn {
     color: #555555;
 }
-.highlight .nt {
+.nt {
     color: #000080;
 }
-.highlight .vc {
+.vc {
     color: #008080;
 }
-.highlight .vg {
+.vg {
     color: #008080;
 }
-.highlight .vi {
+.vi {
     color: #008080;
 }
-.highlight .nv {
+.nv {
     color: #008080;
 }
-.highlight .ow {
+.ow {
     color: #000000;
     font-family: $fontMonoBold;
 }
-.highlight .o {
+.o {
     color: #000000;
     font-family: $fontMonoBold;
 }
-.highlight .w {
+.w {
     color: #bbbbbb;
 }
 .highlight {


### PR DESCRIPTION
This PR makes two changes.

# (1) Highlighting function names in code blocks

Using the customized [Rouge syntax highlighter](https://github.com/duckdb/rouge/tree/duckdb) allows highlighting function names (e.g. `enum_code(...)`) in code blocks. This PR adds function names so they are highlighted.

<img width="803" alt="Screenshot 2023-09-19 at 11 34 57" src="https://github.com/duckdb/duckdb-web/assets/1402801/a538bf5a-7156-4632-9205-06b5804baaa2">

# (2) Formatting inline code as SQL by default

This PR sets SQL as the default language for inline code blocks. This is necessary as there is no way to manually change the language for an inline code block. In the docs, this looks as follows:
<img width="1195" alt="Screenshot 2023-09-19 at 11 39 15" src="https://github.com/duckdb/duckdb-web/assets/1402801/445a38c4-a752-4865-ad18-dce003448cbe">

This is a substantial change compared to our current more muted look (see https://duckdb.org/docs/sql/functions/enum):
<img width="1191" alt="Screenshot 2023-09-19 at 11 40 22" src="https://github.com/duckdb/duckdb-web/assets/1402801/de7cc57a-3eef-4b71-b13a-e4f639754265">

I edited the CSS to allow highlighting the code style classes outside of code blocks and adjusted the function (`.nf`) class to have a purple color:
https://github.com/duckdb/duckdb-web/pull/1174/files#diff-5c0b662767b3be5256eeb61ac6ad3a108aed341745d419facb38c30753edab4eL509