### PR TITLE
Adjust headers for consistency: Start from h2

### DIFF
--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -15,4 +15,4 @@ There are also contributed third-party DuckDB wrappers for:
 - [Rust](https://github.com/wangfenjin/duckdb-rs), by [wangfenjin](https://github.com/wangfenjin)
 - [Zig](https://github.com/karlseguin/zuckdb.zig), by [karlseguin](https://github.com/karlseguin)
 
-### Pages in this Section
+## Pages in this Section

--- a/docs/api/python/expression.md
+++ b/docs/api/python/expression.md
@@ -5,14 +5,14 @@ title: Expression API
 
 The `Expression` class represents an instance of an [expression](../../sql/expressions/overview).
 
-### Why would I use the API?
+## Why would I use the API?
 
 Using this API makes it possible to dynamically build up expressions, which are typically created by the parser from the query string.  
 This allows you to skip that and have more fine-grained control over the used expressions.
 
 Below is a list of currently supported expressions that can be created through the API.  
 
-### Column Expression
+## Column Expression
 
 This expression references a column by name.
 
@@ -28,7 +28,7 @@ print(res)
 # [(1,), (2,), (3,), (4,)]
 ```
 
-### Star Expression
+## Star Expression
 
 This expression selects all columns of the input source.  
 
@@ -51,7 +51,7 @@ print(res)
 # [(1, 42), (2, 21), (3, 13), (4, 14)]
 ```
 
-### Constant Expression
+## Constant Expression
 
 This expression contains a single value.  
 
@@ -71,7 +71,7 @@ print(res)
 # [('hello',), ('hello',), ('hello',), ('hello',)]
 ```
 
-### Case Expression
+## Case Expression
 
 This expression contains a CASE WHEN (...) THEN (...) ELSE (...) END expression.  
 By default ELSE is NULL, it can be set using `.else(value=...)`  
@@ -103,7 +103,7 @@ print(res)
 # [('hello',), ('hello',), ('world',), ('hello',)]
 ```
 
-### Function Expression
+## Function Expression
 
 This expression contains a function call.  
 It can be constructed by providing the function name and an arbitrary amount of Expressions as arguments.
@@ -134,7 +134,7 @@ print(res)
 # [(True,), (True,), (False,), (True,)]
 ```
 
-### Common Operations
+## Common Operations
 
 The Expression class also contains many operations that can be applied to any Expression type.  
 
@@ -150,7 +150,7 @@ Create a IN expression against the provided expressions as the list.
 `.isnotin(*exprs: Expression)`  
 Create a NOT IN expression against the provided expressions as the list.
 
-#### Order Operations
+### Order Operations
 
 When expressions are provided to `DuckDBPyRelation.order()` these take effect:
 

--- a/docs/api/python/known_issues.md
+++ b/docs/api/python/known_issues.md
@@ -6,7 +6,7 @@ title: Known Python Issues
 Unfortunately there are some issues that are either beyond our control or are very elusive / hard to track down.  
 Below is a list of these issues that you might have to be aware of, depending on your workflow.  
 
-### Numpy Import Multithreading
+## Numpy Import Multithreading
 
 When making use of multi threading and fetching results either directly as Numpy arrays or indirectly through a Pandas DataFrame, it might be necessary to ensure that `numpy.core.multiarray` is imported.  
 If this module has not been imported from the main thread, and a different thread during execution attempts to import it this causes either a deadlock or a crash.  

--- a/docs/api/wasm/extensions.md
+++ b/docs/api/wasm/extensions.md
@@ -5,7 +5,7 @@ title: Extensions
 
 DuckDB-Wasm's (dynamic) extension loading is modeled after the regular DuckDB's extension loading, with a few relevant differences due to the difference in platform.
 
-### Format
+## Format
 
 Extensions in DuckDB are binaries to be dynamically loaded via `dlopen`. A cryptographical signature is appended to the binary.
 An extension in DuckDB-Wasm is a regular Wasm file to be dynamically loaded via Emscripten's dlopen. A cryptographical signature is appended to the Wasm file as a WebAssembly custom section called `duckdb_signature`.
@@ -13,18 +13,18 @@ This ensures the file remains a valid WebAssembly file.
 
 > Currently we require this custom section to be the last one, but this can be potentially relaxed in the future.
 
-### INSTALL and LOAD
+## INSTALL and LOAD
 
 The `INSTALL` semantic in native embeddings of DuckDB is to fetch, decompress from `gzip` and store data in local disk.
 The `LOAD` semantic in native embeddings of DuckDB is to (optionally) perform signature checks *and* dynamic load the binary with the main DuckDB binary.
 
 In DuckDB-Wasm, `INSTALL` is a no-op given there is no durable cross-session storage. The `LOAD` operation will fetch (and decompress on the fly), perform signature checks *and* dynamically load via the Emscripten implementation of dlopen.
 
-### Autoloading
+## Autoloading
 
 [Autoloading](../../extensions/overview), i.e., the possibility for DuckDB to add extension functionality on-the-fly, is enabled by default in DuckDB-Wasm.
 
-### List of Officially Available Extensions
+## List of Officially Available Extensions
 
 | Extension name | Description | Aliases |
 |---|-----|--|
@@ -43,17 +43,17 @@ In DuckDB-Wasm, `INSTALL` is a no-op given there is no durable cross-session sto
 
 WebAssembly is basically an additional platform, and there might be platform-specific limitations that make some extensions not able to match their native capabilities or to perform them in a different way. We will document here relevant differences for DuckDB-hosted extensions.
 
-#### HTTPFS
+### HTTPFS
 
 The HTTPFS extension is, at the moment, not available in DuckDB-Wasm. Https protocol capabilities needs to go through an additional layer, the browser, which adds both differences and some restrictions to what is doable from native.
 
-### Extension Signing
+## Extension Signing
 
 As with regular DuckDB extensions, DuckDB-Wasm extension are by default checked on `LOAD` to verify the signature confirm the extension has not been tampered with.
 Extension signature verification can be disabled via a configuration option.
 Signing is a property of the binary itself, so copying a DuckDB extension (say to serve it from a different location) will still keep a valid signature (e.g., for local development).
 
-### Fetching DuckDB-Wasm Extensions
+## Fetching DuckDB-Wasm Extensions
 
 Official DuckDB extensions are served at `extensions.duckdb.org`, and this is also the default value for the `default_extension_repository` option.
 When installing extensions, a relevant URL will be built that will look like `extensions.duckdb.org/$duckdb_version_hash/$duckdb_platform/$name.duckdb_extension.gz`.
@@ -64,13 +64,13 @@ Note that an additional `duckdb-wasm` is added to the folder structure, and the 
 
 DuckDB-Wasm extensions are served pre-compressed using Brotli compression. While fetched from a browser, extensions will be transparently uncompressed. If you want to fetch the `duckdb-wasm` extension manually, you can use `curl --compress extensions.duckdb.org/<...>/icu.duckdb_extension.wasm`.
 
-### Serving Extensions from a Third-Party Repository
+## Serving Extensions from a Third-Party Repository
 
 As with regular DuckDB, if you use `SET custom_extension_repository = some.url.com`, subsequent loads will be attempted at `some.url.com/duckdb-wasm/$duckdb_version_hash/$duckdb_platform/$name.duckdb_extension.wasm`.
 
 Note that GET requests on the extensions needs to be [CORS enabled](https://www.w3.org/wiki/CORS_Enabled) for a browser to allow the connection.
 
-### Tooling
+## Tooling
 
 Both DuckDB-Wasm and its extensions have been compiled using latest packaged Emscripten toolchain.
 

--- a/docs/connect.md
+++ b/docs/connect.md
@@ -3,7 +3,7 @@ layout: docu
 title: Connect
 ---
 
-### Connect or Create a Database
+## Connect or Create a Database
 
 To use DuckDB, you must first create a connection to a database. The exact process varies by client. Most clients take a parameter pointing to a database file to read and write from (the file extension may be anything, e.g., `.db`, `.duckdb`, etc.). If the database file does not exist, it will be created. The special value `:memory:` can be used to create an in-memory database where no data is persisted to disk (i.e., all data is lost when you exit the process). 
 

--- a/docs/data/appender.md
+++ b/docs/data/appender.md
@@ -33,7 +33,7 @@ Any values added to the appender are cached prior to being inserted into the dat
 for performance reasons. That means that, while appending, the rows might not be immediately visible in the system. The cache is automatically flushed when the appender goes out of scope or when `appender.Close()` is called. The cache can also be manually flushed using the `appender.Flush()` method. After either `Flush` or `Close` is called, all the data has been written to the database system.
 
 
-### Date, Time and Timestamps
+## Date, Time and Timestamps
 
 While numbers and strings are rather self-explanatory, dates, times and timestamps require some explanation. They can be directly appended using the methods provided by `duckdb::Date`, `duckdb::Time` or `duckdb::Timestamp`. They can also be appended using the internal `duckdb::Value` type, however, this adds some additional overheads and should be avoided if possible.
 

--- a/docs/data/csv/auto_detection.md
+++ b/docs/data/csv/auto_detection.md
@@ -16,7 +16,7 @@ By default the system will try to auto-detect all options. However, options can 
 The detection works by operating on a sample of the file. The size of the sample can be modified by setting the `sample_size` parameter. The default sample size is `20480` rows. Setting the `sample_size` parameter to `-1` means the entire file is read for sampling. The way sampling is performed depends on the type of file. If we are reading from a regular file on disk, we will jump into the file and try to sample from different locations in the file. If we are reading from a file in which we cannot jump - such as a `.gz` compressed CSV file or `stdin` - samples are taken only from the beginning of the file.
 
 
-### Dialect Detection
+## Dialect Detection
 
 Dialect detection works by attempting to parse the samples using the set of considered values. The detected dialect is the dialect that has (1) a consistent number of columns for each row, and (2) the highest number of columns for each row.
 
@@ -48,7 +48,7 @@ In this file, the dialect detection works as follows:
 
 In this example - the system selects the `|` as the delimiter. All rows are split into the same amount of columns, and there is more than one column per row meaning the delimiter was actually found in the CSV file.
 
-### Type Detection
+## Type Detection
 
 After detecting the dialect, the system will attempt to figure out the types of each of the columns. Note that this step is only performed if we are calling `read_csv_auto`. In case of the `COPY` statement the types of the table that we are copying into will be used instead.
 
@@ -70,7 +70,7 @@ The detected types can be individually overridden using the `types` option. This
 
 The type detection can be entirely disabled by using the `all_varchar` option. If this is set all columns will remain as `VARCHAR` (as they originally occur in the CSV file).
 
-### Header Detection
+## Header Detection
 
 Header detection works by checking if the candidate header row deviates from the other rows in the file in terms of types. For example, in `flights.csv`, we can see that the header row consists of only `VARCHAR` columns - whereas the values contain a `DATE` value for the `FlightDate` column. As such - the system defines the first row as the header row and extracts the column names from the header row.
 
@@ -78,7 +78,7 @@ In files that do not have a header row, the column names are generated as `colum
 
 Note that headers cannot be detected correctly if all columns are of type `VARCHAR` - as in this case the system cannot distinguish the header row from the other rows in the file. In this case the system assumes the file has no header. This can be overridden using the `header` option.
 
-### Dates and Timestamps
+## Dates and Timestamps
 
 DuckDB supports the [ISO 8601 format](https://en.wikipedia.org/wiki/ISO_8601) format by default for timestamps, dates and times. Unfortunately, not all dates and times are formatted using this standard. For that reason, the CSV reader also supports the `dateformat` and `timestampformat` options. Using this format the user can specify a [format string](../../sql/functions/dateformat) that specifies how the date or timestamp should be read.
 

--- a/docs/data/multiple_files/combining_schemas.md
+++ b/docs/data/multiple_files/combining_schemas.md
@@ -5,7 +5,7 @@ title: Combining Schemas
 
 <!-- markdownlint-disable MD036 -->
 
-### Examples
+## Examples
 
 ```sql
 -- read a set of CSV files combining columns by position
@@ -14,7 +14,7 @@ SELECT * FROM read_csv_auto('flights*.csv');
 SELECT * FROM read_csv_auto('flights*.csv', union_by_name=True);
 ```
 
-### Combining Schemas
+## Combining Schemas
 
 When reading from multiple files, we have to **combine schemas** from those files. That is because each file has its own schema that can differ from the other files. DuckDB offers two ways of unifying schemas of multiple files: **by column position** and **by column name**.
 
@@ -22,7 +22,7 @@ By default, DuckDB reads the schema of the first file provided, and then unifies
 
 Below is an example of how both methods work.
 
-### Union By Position
+## Union By Position
 
 By default, DuckDB unifies the columns of these different files **by position**. This means that the first column in each file is combined together, as well as the second column in each file, etc. For example, consider the following two files:
 
@@ -51,7 +51,7 @@ Reading the two files at the same time will produce the following result set:
 
 This is equivalent to the SQL construct [`UNION ALL`](../../sql/query_syntax/setops#union-all).
 
-### Union By Name
+## Union By Name
 
 If you are processing multiple files that have different schemas, perhaps because columns have been added or renamed, it might be desirable to unify the columns of different files **by name** instead. This can be done by providing the `union_by_name` option. For example, consider the following two files, where `flights2.csv` has an extra column (`UniqueCarrier`):
 

--- a/docs/data/multiple_files/overview.md
+++ b/docs/data/multiple_files/overview.md
@@ -7,7 +7,7 @@ redirect_from:
 
 DuckDB can read multiple files of different types (CSV, Parquet, JSON files) at the same time using either the glob syntax, or by providing a list of files to read. See the [combining schemas](combining_schemas) page for tips on reading files with different schemas.
 
-### CSV
+## CSV
 
 ```sql
 -- read all files with a name ending in ".csv" in the folder "dir"
@@ -22,7 +22,7 @@ SELECT * FROM read_csv_auto(['flights1.csv', 'flights2.csv']);
 SELECT * FROM read_csv_auto(['flights1.csv', 'flights2.csv'], union_by_name=True, filename=True);
 ```
 
-### Parquet
+## Parquet
 
 ```sql
 -- read all files that match the glob pattern
@@ -36,11 +36,11 @@ SELECT * FROM read_parquet('dir/**/*.parquet');
 ```
 
 
-### Multi-File Reads and Globs
+## Multi-File Reads and Globs
 
 DuckDB can also read a series of Parquet files and treat them as if they were a single table. Note that this only works if the Parquet files have the same schema. You can specify which Parquet files you want to read using a list parameter, glob pattern matching syntax, or a combination of both.
 
-#### List Parameter
+### List Parameter
 
 The read_parquet function can accept a list of filenames as the input parameter.
 
@@ -49,7 +49,7 @@ The read_parquet function can accept a list of filenames as the input parameter.
 SELECT * FROM read_parquet(['file1.parquet', 'file2.parquet', 'file3.parquet']);
 ```
 
-#### Glob Syntax
+### Glob Syntax
 
 Any file name input to the read_parquet function can either be an exact filename, or use a glob syntax to read multiple files that match a pattern.
 
@@ -70,7 +70,7 @@ Here is an example that reads all the files that end with `.parquet` located in 
 SELECT * FROM read_parquet('test/*.parquet');
 ```
 
-#### List of Globs
+### List of Globs
 
 The glob syntax and the list input parameter can be combined to scan files that meet one of multiple patterns.
 
@@ -81,7 +81,7 @@ SELECT * FROM read_parquet(['folder1/*.parquet', 'folder2/*.parquet']);
 
 DuckDB can read multiple CSV files at the same time using either the glob syntax, or by providing a list of files to read.
 
-### Filename
+## Filename
 
 The `filename` argument can be used to add an extra `filename` column to the result that indicates which row came from which file. For example:
 
@@ -96,7 +96,7 @@ SELECT * FROM read_csv_auto(['flights1.csv', 'flights2.csv'], union_by_name=True
 | 1988-01-03 | New York, NY   | Los Angeles, CA | AA            | flights2.csv |
 
 
-### Glob Function to Find Filenames
+## Glob Function to Find Filenames
 
 The glob pattern matching syntax can also be used to search for filenames using the `glob` table function. 
 It accepts one parameter: the path to search (which may include glob patterns). 

--- a/docs/data/overview.md
+++ b/docs/data/overview.md
@@ -5,7 +5,7 @@ title: Importing Data
 
 The first step to using a database system is to insert data into that system. DuckDB provides several data ingestion methods that allow you to easily and efficiently fill up the database. In this section, we provide an overview of these methods so you can select which one is correct for you.
 
-### Insert Statements
+## Insert Statements
 
 Insert statements are the standard way of loading data into a database system. They are suitable for quick prototyping, but should be avoided for bulk loading as they have significant per-row overhead.
 
@@ -15,7 +15,7 @@ INSERT INTO people VALUES (1, 'Mark');
 
 See [here](../data/insert) for a more detailed description of insert statements.
 
-### CSV Loading
+## CSV Loading
 
 Data can be efficiently loaded from CSV files using the `read_csv_auto` function or the `COPY` statement.
 
@@ -31,7 +31,7 @@ SELECT * FROM read_csv_auto('test.csv.gz');
 
 See [here](../data/csv) for a detailed description of CSV loading.
 
-### Parquet Loading
+## Parquet Loading
 
 Parquet files can be efficiently loaded and queried using the `read_parquet` function.
 
@@ -41,7 +41,7 @@ SELECT * FROM read_parquet('test.parquet');
 
 See [here](../data/parquet) for a detailed description of Parquet loading.
 
-### JSON Loading
+## JSON Loading
 
 JSON files can be efficiently loaded and queried using the `read_json_auto` function.
 
@@ -51,7 +51,7 @@ SELECT * FROM read_json_auto('test.json');
 
 See [here](../data/json) for a detailed description of JSON loading.
 
-### Appender (C++ and Java)
+## Appender (C++ and Java)
 
 In C++ and Java, the appender can be used as an alternative for bulk data loading. This class can be used to efficiently add rows to the database system without needing to use SQL.
 

--- a/docs/data/parquet/metadata.md
+++ b/docs/data/parquet/metadata.md
@@ -3,7 +3,7 @@ layout: docu
 title: Querying Parquet Metadata
 ---
 
-### Parquet Metadata
+## Parquet Metadata
 
 The `parquet_metadata` function can be used to query the metadata contained within a Parquet file, which reveals various internal details of the Parquet file such as the statistics of the different columns. This can be useful for figuring out what kind of skipping is possible in Parquet files, or even to obtain a quick overview of what the different columns contain.
 
@@ -40,7 +40,7 @@ Below is a table of the columns returned by `parquet_metadata`.
 | `total_uncompressed_size` | `BIGINT`  |
 
 
-### Parquet Schema
+## Parquet Schema
 
 The `parquet_schema` function can be used to query the internal schema contained within a Parquet file. Note that this is the schema as it is contained within the metadata of the Parquet file. If you want to figure out the column names and types contained within a Parquet file it is easier to use `DESCRIBE`.
 

--- a/docs/data/parquet/tips.md
+++ b/docs/data/parquet/tips.md
@@ -5,9 +5,9 @@ title: Parquet Tips
 
 Below is a collection of tips to help when dealing with Parquet files.
 
-### Tips for reading Parquet files
+## Tips for reading Parquet files
 
-#### Use `union_by_name` when loading files with different schemas
+### Use `union_by_name` when loading files with different schemas
 
 The `union_by_name` option can be used to unify the schema of files that have different or missing columns. For files that do not have certain columns, `NULL` values are filled in.  
 
@@ -15,9 +15,9 @@ The `union_by_name` option can be used to unify the schema of files that have di
 SELECT * FROM read_parquet('flights*.parquet', union_by_name=True);
 ```
 
-### Tips for writing Parquet files
+## Tips for writing Parquet files
 
-#### Enabling `per_thread_output`
+### Enabling `per_thread_output`
 
 If the final number of parquet files is not important, writing one file per thread can significantly improve performance.
 Using a [glob pattern](../multiple_files/overview#glob-syntax) upon read or a [hive partitioning](../partitioning/hive_partitioning) structure are good ways to transparently handle multiple files.
@@ -26,7 +26,7 @@ Using a [glob pattern](../multiple_files/overview#glob-syntax) upon read or a [h
 COPY (FROM generate_series(10000000)) TO 'test.parquet' (FORMAT PARQUET, PER_THREAD_OUTPUT TRUE);
 ```
 
-#### Selecting a `row_group_size`
+### Selecting a `row_group_size`
 
 The `ROW_GROUP_SIZE` parameter specifies the minimum number of rows in a parquet row group, with a minimum value equal to DuckDB's vector size (currently 2048, but adjustable when compiling DuckDB), and a default of 122880.
 A parquet row group is a partition of rows, consisting of a column chunk for each column in the dataset.

--- a/docs/data/partitioning/hive_partitioning.md
+++ b/docs/data/partitioning/hive_partitioning.md
@@ -3,7 +3,7 @@ layout: docu
 title: Hive Partitioning
 ---
 
-### Examples
+## Examples
 
 ```sql
 -- read data from a hive partitioned data set
@@ -14,7 +14,7 @@ SELECT * FROM parquet_scan('orders/*/*/*.parquet', hive_partitioning=1);
 COPY orders TO 'orders' (FORMAT PARQUET, PARTITION_BY (year, month));
 ```
 
-### Hive Partitioning
+## Hive Partitioning
 
 Hive partitioning is a [partitioning strategy](https://en.wikipedia.org/wiki/Partition_(database)) that is used to split a table into multiple files based on **partition keys**. The files are organized into folders. Within each folder, the **partition key** has a value that is determined by the name of the folder.
 
@@ -44,7 +44,7 @@ SELECT * FROM read_parquet('orders/*/*/*.parquet', hive_partitioning=1);
 
 When we specify the `hive_partitioning` flag, the values of the columns will be read from the directories.
 
-#### Filter Pushdown
+### Filter Pushdown
 
 Filters on the partition keys are automatically pushed down into the files. This way the system skips reading files that are not necessary to answer a query. For example, consider the following query on the above dataset:
 
@@ -64,11 +64,11 @@ orders
          └── file5.parquet
 ```
 
-#### Autodetection
+### Autodetection
 
 By default the system tries to infer if the provided files are in a hive partitioned hierarchy. And if so, the `hive_partitioning` flag is enabled automatically. The autodetection will look at the names of the folders and search for a 'key'='value' pattern. This behaviour can be overridden by setting the `hive_partitioning` flag manually.
 
-#### Hive Types
+### Hive Types
 
 `hive_types` is a way to specify the logical types of the hive partitions in a struct:
 
@@ -79,6 +79,6 @@ FROM read_parquet('dir/**/*.parquet', hive_partitioning=1, hive_types={'release'
 `hive_types` will be autodetected for the following types: `DATE`, `TIMESTAMP` and `BIGINT`. To switch off the autodetection, the flag `hive_types_autocast=0` can be set.
 
 
-#### Writing Partitioned Files
+### Writing Partitioned Files
 
 See the [Partitioned Writes](partitioned_writes) section.

--- a/docs/data/partitioning/partitioned_writes.md
+++ b/docs/data/partitioning/partitioned_writes.md
@@ -3,7 +3,7 @@ layout: docu
 title: Partitioned Writes
 ---
 
-### Examples
+## Examples
 
 ```sql
 -- write a table to a hive partitioned data set of parquet files
@@ -12,7 +12,7 @@ COPY orders TO 'orders' (FORMAT PARQUET, PARTITION_BY (year, month));
 COPY orders TO 'orders' (FORMAT CSV, PARTITION_BY (year, month), OVERWRITE_OR_IGNORE 1);
 ```
 
-### Partitioned Writes
+## Partitioned Writes
 
 When the `partition_by` clause is specified for the `COPY` statement, the files are written in a [hive partitioned](hive_partitioning) folder hierarchy. The target is the name of the root directory (in the example above: `orders`). The files are written in-order in the file hierarchy. Currently, one file is written per thread to each directory.
 
@@ -37,11 +37,11 @@ The values of the partitions are automatically extracted from the data. Note tha
 > Writing data into many small partitions is expensive. It is generally recommended to have at least  `100MB` of data per partition. 
 
 
-#### Overwriting
+### Overwriting
 
 By default the partitioned write will not allow overwriting existing directories. Use the `OVERWRITE_OR_IGNORE` option to allow overwriting an existing directory.
 
-#### Filename Pattern
+### Filename Pattern
 
 By default, files will be named `data_0.parquet` or `data_0.csv`. With the flag `FILENAME_PATTERN` a pattern with `{i}` or `{uuid}` can be defined to create specific filenames:
 * `{i}` will be replaced by an index

--- a/docs/sql/constraints.md
+++ b/docs/sql/constraints.md
@@ -6,11 +6,11 @@ railroad: statements/constraints.js
 
 In SQL, constraints can be specified for tables. Constraints enforce certain properties over data that is inserted into a table. Constraints can be specified along with the schema of the table as part of the [`CREATE TABLE` statement](statements/create_table). In certain cases, constraints can also be added to a table using the [`ALTER TABLE` statement](statements/alter_table), but this is not currently supported for all constraints.
 
-### Syntax
+## Syntax
 
 <div id="rrdiagram"></div>
 
-#### Check
+## Check
 
 Check constraints allow you to specify an arbitrary boolean expression. Any columns that *do not* satisfy this expression violate the constraint. For example, we could enforce that the `name` column does not contain spaces using the following `CHECK` constraint.
 
@@ -20,7 +20,7 @@ INSERT INTO students VALUES ('this name contains spaces');
 -- Constraint Error: CHECK constraint failed: students
 ```
 
-#### Not Null
+## Not Null
 
 A not-null constraint specifies that the column cannot contain any `NULL` values. By default, all columns in tables are nullable. Adding `NOT NULL` to a column definition enforces that a column cannot contain `NULL` values.
  
@@ -30,7 +30,7 @@ INSERT INTO students VALUES (NULL);
 -- Constraint Error: NOT NULL constraint failed: students.name
 ```
 
-#### Primary Key/Unique
+## Primary Key/Unique
 
 Primary key or unique constraints define a column, or set of columns, that are a unique identifier for a row in the table. The constraint enforces that the specified columns are *unique* within a table, i.e., that at most one row contains the given values for the set of columns.
 
@@ -50,7 +50,7 @@ Primary key constraints and unique constraints are identical except for two poin
 
 > Indexes have certain limitations that might result in constraints being evaluated too eagerly, see the [indexes section for more details](indexes#index-limitations)
 
-#### Foreign Key
+## Foreign Key
 
 Foreign keys define a column, or set of columns, that refer to a primary key or unique constraint from *another* table. The constraint enforces that the key exists in the other table. 
 

--- a/docs/sql/expressions/collations.md
+++ b/docs/sql/expressions/collations.md
@@ -10,7 +10,7 @@ Collations provide rules for how text should be sorted or compared in the execut
 
 By default, the `BINARY` collation is used. That means that strings are ordered and compared based only on their binary contents. This makes sense for standard ASCII characters (i.e., the letters A-Z and numbers 0-9), but generally does not make much sense for special unicode characters. It is, however, by far the fastest method of performing ordering and comparisons. Hence it is recommended to stick with the `BINARY` collation unless required otherwise.
 
-### Using Collations
+## Using Collations
 
 In the stand-alone installation of DuckDB three collations are included: `NOCASE`, `NOACCENT` and `NFC`. The `NOCASE` collation compares characters as equal regardless of their casing. The `NOACCENT` collation compares characters as equal regardless of their accents. The `NFC` collation performs NFC-normalized comparisons, see [here](https://en.wikipedia.org/wiki/Unicode_equivalence#Normalization) for more information.
 
@@ -37,7 +37,7 @@ SELECT 'hello' COLLATE NOCASE.NOACCENT='hElLÖ';
 -- true
 ```
 
-### Default Collations
+## Default Collations
 
 The collations we have seen so far have all been specified *per expression*. It is also possible to specify a default collator, either on the global database level or on a base table column. The `PRAGMA` `default_collation` can be used to specify the global default collator. This is the collator that will be used if no other one is specified.
 
@@ -75,7 +75,7 @@ SELECT * FROM names, other_names WHERE names.name COLLATE NOACCENT.NOCASE=other_
 -- hännes|HÄNNES
 ```
 
-### ICU Collations
+## ICU Collations
 
 The collations we have seen so far are not region dependent, and do not follow any specific regional rules. If you wish to follow the rules of a specific region or language, you will need to use one of the ICU collations. For that, you need to include the ICU extension. This can be found in the `extension/icu` folder in the project. Using the C++ API, the extension can be loaded as follows:
 

--- a/docs/sql/expressions/overview.md
+++ b/docs/sql/expressions/overview.md
@@ -5,4 +5,4 @@ title: Expressions
 
 An expression is a combination of values, operators and functions. Expressions are highly composable, and range from very simple to arbitrarily complex. They can be found in many different parts of SQL statements. In this section, we provide the different types of operators and functions that can be used within expressions.
 
-### More
+## More

--- a/docs/sql/expressions/star.md
+++ b/docs/sql/expressions/star.md
@@ -4,7 +4,7 @@ title: Star Expression
 railroad: expressions/star.js
 ---
 
-### Examples
+## Examples
 
 ```sql
 -- select all columns present in the FROM clause
@@ -21,11 +21,11 @@ SELECT COLUMNS(c -> c LIKE '%num%') FROM addresses;
 SELECT COLUMNS('number\d+') FROM addresses;
 ```
 
-### Syntax
+## Syntax
 
 <div id="rrdiagram"></div>
 
-### Star Expression
+## Star Expression
 
 The `*` expression can be used in a `SELECT` statement to select all columns that are projected in the `FROM` clause.
 
@@ -35,7 +35,7 @@ SELECT * FROM tbl;
 
 The `*` expression can be modified using the `EXCLUDE` and `REPLACE`.
 
-#### EXCLUDE Clause
+### EXCLUDE Clause
 
 `EXCLUDE` allows us to exclude specific columns from the `*` expression.
 
@@ -43,7 +43,7 @@ The `*` expression can be modified using the `EXCLUDE` and `REPLACE`.
 SELECT * EXCLUDE (col) FROM tbl;
 ```
 
-#### Replace Clause
+### Replace Clause
 
 `REPLACE` allows us to replace specific columns with different expressions.
 
@@ -51,7 +51,7 @@ SELECT * EXCLUDE (col) FROM tbl;
 SELECT * REPLACE (col / 1000 AS col) FROM tbl;
 ```
 
-### COLUMNS
+## COLUMNS
 
 The `COLUMNS` expression can be used to execute the same expression on multiple columns. Like the `*` expression, it can only be used in the `SELECT` clause.
 
@@ -88,7 +88,7 @@ SELECT COLUMNS(*) + COLUMNS(*) FROM numbers;
 | 6                         | NULL                              |
 
 
-### COLUMNS Regular Expression
+## COLUMNS Regular Expression
 
 `COLUMNS` supports passing a regex in as a string constant:
 
@@ -102,7 +102,7 @@ SELECT COLUMNS('(id|numbers?)') FROM numbers;
 | 2  | 20     |
 | 3  | NULL   |
 
-### COLUMNS Lambda Function
+## COLUMNS Lambda Function
 
 `COLUMNS` also supports passing in a lambda function. The lambda function will be evaluated for all columns present in the `FROM` clause, and only columns that match the lambda function will be returned. This allows the execution of arbitrary expressions in order to select columns.
 
@@ -116,7 +116,7 @@ SELECT COLUMNS(c -> c LIKE '%num%') FROM numbers;
 | 20     |
 | NULL   |
 
-### Struct.*
+## Struct.*
 
 The `*` expression can also be used to retrieve all keys from a struct as separate columns.
 This is particularly useful when a prior operation creates a struct of unknown shape, or if a query must handle any potential struct keys.

--- a/docs/sql/query_syntax/from.md
+++ b/docs/sql/query_syntax/from.md
@@ -7,7 +7,7 @@ blurb: The FROM clause can contain a single table, a combination of multiple tab
 
 The `FROM` clause specifies the *source* of the data on which the remainder of the query should operate. Logically, the `FROM` clause is where the query starts execution. The `FROM` clause can contain a single table, a combination of multiple tables that are joined together using `JOIN` clauses, or another `SELECT` query inside a subquery node. DuckDB also has an optional `FROM`-first syntax which enables you to also query without a `SELECT` statement.
 
-### Examples
+## Examples
 
 ```sql
 -- select all columns from the table called "table_name"
@@ -38,7 +38,7 @@ SELECT * FROM table_name TABLESAMPLE 10 ROWS;
 FROM range(100) AS t(i) SELECT sum(t.i) WHERE i % 2 = 0;
 ```
 
-### Joins
+## Joins
 
 Joins are a fundamental relational operation used to connect two tables or relations horizontally.
 The relations are referred to as the _left_ and _right_ sides of the join
@@ -48,7 +48,7 @@ Each result row has the columns from both relations.
 A join uses a rule to match pairs of rows from each relation.
 Often this is a predicate, but there are other implied rules that may be specified.
 
-#### Outer Joins
+### Outer Joins
 
 Rows that do not have any matches can still be returned if an `OUTER` join is specified.
 Outer joins can be one of:
@@ -61,7 +61,7 @@ A join that is not `OUTER` is `INNER` (only rows that get paired are returned).
 
 When an unpaired row is returned, the attributes from the other table are set to `NULL`.
 
-#### Cross Product Joins
+### Cross Product Joins
 
 The simplest type of join is a `CROSS JOIN`. 
 There are no conditions for this type of join, 
@@ -72,7 +72,7 @@ and it just returns all the possible pairs.
 SELECT a.*, b.* FROM a CROSS JOIN b;
 ```
 
-#### Conditional Joins
+### Conditional Joins
 
 Most joins are specified by a predicate that connects 
 attributes from one side to attributes from the other side.
@@ -130,7 +130,7 @@ WHERE s1.time > s2.time
   AND s1.cost < s2.cost;
 ```
 
-#### Semi and Anti Joins
+### Semi and Anti Joins
 
 Semi joins return rows from the left table that have at least one match in the right table. Anti joins return rows from the left table that have _no_ matches in the right table. When using a semi or anti join the result will never have more rows than the left hand side table. Semi and anti joins provide the same logic as [(NOT) IN](../expressions/in) statements.
 
@@ -148,7 +148,7 @@ FROM cars ANTI JOIN safety_data
 ON cars.safety_report_id = safety_data.report_id;
 ```
 
-#### Lateral Joins
+### Lateral Joins
 
 The `LATERAL` keyword allows subqueries in the `FROM` clause to refer to previous subqueries. This feature is also known as a _lateral join_.
 
@@ -207,7 +207,7 @@ SELECT * FROM t1, LATERAL (SELECT i + j) t2(k);
 
 > DuckDB detects when `LATERAL` joins should be used, making the use of the `LATERAL` keyword optional.
 
-#### Positional Joins
+### Positional Joins
 
 When working with data frames or other embedded tables of the same size, 
 the rows may have a natural correspondence based on their physical order.
@@ -232,7 +232,7 @@ FROM df1 POSITIONAL JOIN df2;
 
 Positional joins are always `FULL OUTER` joins.
 
-#### As-Of Joins
+### As-Of Joins
 
 A common operation when working with temporal or similarly-ordered data
 is to find the nearest (first) event in a reference table (such as prices).
@@ -282,6 +282,6 @@ SELECT t.symbol, t.when AS trade_when, p.when AS price_when, price
 FROM trades t ASOF LEFT JOIN prices p USING (symbol, when);
 ```
 
-### Syntax
+## Syntax
 
 <div id="rrdiagram"></div>

--- a/docs/sql/query_syntax/groupby.md
+++ b/docs/sql/query_syntax/groupby.md
@@ -10,19 +10,19 @@ If the `GROUP BY` clause is specified, the query is always an aggregate query, e
 When a `GROUP BY` clause is specified, all tuples that have matching data in the grouping columns (i.e., all tuples that belong to the same group) will be combined.
 The values of the grouping columns themselves are unchanged, and any other columns can be combined using an aggregate function (such as `COUNT`, `SUM`, `AVG`, etc).
 
-### GROUP BY ALL
+## GROUP BY ALL
 
 Use `GROUP BY ALL` to `GROUP BY` all columns in the `SELECT` statement that are not wrapped in aggregate functions. 
 This simplifies the syntax by allowing the columns list to be maintained in a single location, and prevents bugs by keeping the `SELECT` granularity aligned to the `GROUP BY` granularity (Ex: Prevents any duplication).
 See examples below and additional examples in the [Friendlier SQL with DuckDB blog post](/2022/05/04/friendlier-sql.html#group-by-all).
 
-### Multiple Dimensions
+## Multiple Dimensions
 
 Normally, the `GROUP BY` clause groups along a single dimension.
 Using the [GROUPING SETS, CUBE or ROLLUP clauses](../../sql/query_syntax/grouping_sets) it is possible to group along multiple dimensions.
 See the [GROUPING SETS](../../sql/query_syntax/grouping_sets) page for more information.
 
-### Examples
+## Examples
 
 ```sql
 -- count the number of entries in the "addresses" table that belong to each different city
@@ -36,7 +36,7 @@ FROM addresses
 GROUP BY city, street_name;
 ```
 
-#### GROUP BY ALL Examples
+### GROUP BY ALL Examples
 
 ```sql
 -- Group by city and street_name to remove any duplicate values
@@ -56,6 +56,6 @@ GROUP BY ALL;
 
 ```
 
-### Syntax
+## Syntax
 
 <div id="rrdiagram"></div>

--- a/docs/sql/query_syntax/grouping_sets.md
+++ b/docs/sql/query_syntax/grouping_sets.md
@@ -7,7 +7,7 @@ railroad: query_syntax/groupby.js
 `GROUPING SETS`, `ROLLUP` and `CUBE` can be used in the `GROUP BY` clause to perform a grouping over multiple dimensions within the same query. 
 Note that this syntax is not compatible with [`GROUP BY ALL`](groupby#group-by-all).
 
-### Examples
+## Examples
 
 ```sql
 -- compute the average income along the provided four different dimensions
@@ -25,7 +25,7 @@ FROM addresses
 GROUP BY ROLLUP (city, street_name);
 ```
 
-### Description
+## Description
 
 `GROUPING SETS` perform the same aggregate across different `GROUP BY clauses` in a single query.
 
@@ -90,6 +90,6 @@ The `ROLLUP` clause will produce all "sub-groups" of a grouping set, e.g., `ROLL
 
 `GROUPING` (alias `GROUPING_ID`) is a special aggregate function that can be used in combination with grouping sets. The `GROUPING` function takes as parameters a group, and returns 0 if the group is included in the grouping for that row, or 1 otherwise. This is primarily useful because the grouping columns by which we do not aggregate return NULL, which is ambiguous with groups that are actually the value `NULL`. The `GROUPING` (or `GROUPING_ID`) function can be used to distinguish these two cases.
 
-### Syntax
+## Syntax
 
 <div id="rrdiagram"></div>

--- a/docs/sql/query_syntax/having.md
+++ b/docs/sql/query_syntax/having.md
@@ -6,7 +6,7 @@ railroad: query_syntax/groupby.js
 
 The `HAVING` clause can be used after the `GROUP BY` clause to provide filter criteria *after* the grouping has been completed. In terms of syntax the `HAVING` clause is identical to the `WHERE` clause, but while the `WHERE` clause occurs before the grouping, the `HAVING` clause occurs after the grouping.
 
-### Examples
+## Examples
 
 ```sql
 -- count the number of entries in the "addresses" table that belong to each different city
@@ -23,6 +23,6 @@ GROUP BY city, street_name
 HAVING AVG(income) > 2 * MEDIAN(income);
 ```
 
-### Syntax
+## Syntax
 
 <div id="rrdiagram"></div>

--- a/docs/sql/query_syntax/limit.md
+++ b/docs/sql/query_syntax/limit.md
@@ -9,7 +9,7 @@ railroad: query_syntax/orderby.js
 Note that while `LIMIT` can be used without an `ORDER BY` clause, the results might not be deterministic without the `ORDER BY` clause. This can still be useful, however, for example when you want to inspect a quick snapshot of the data.
 
 
-### Examples
+## Examples
 
 ```sql
 -- select the first 5 rows from the addresses table
@@ -29,6 +29,6 @@ ORDER BY population DESC
 LIMIT 5;
 ```
 
-### Syntax
+## Syntax
 
 <div id="rrdiagram"></div>

--- a/docs/sql/query_syntax/orderby.md
+++ b/docs/sql/query_syntax/orderby.md
@@ -13,19 +13,19 @@ An error will be thrown if no expressions are included, since the `ORDER BY` cla
 The expressions may begin with either an arbitrary scalar expression (which could be a column name), a column position number (Ex: `1`. Note that it is 1-indexed), or the keyword `ALL`.
 Each expression can optionally be followed by an order modifier (`ASC` or `DESC`, default is `ASC`), and/or a `NULL` order modifier (`NULLS FIRST` or `NULLS LAST`, default is `NULLS LAST`).
 
-### ORDER BY ALL
+## ORDER BY ALL
 
 The `ALL` keyword indicates that the output should be sorted by every column in order from left to right. 
 The direction of this sort may be modified using either `ORDER BY ALL ASC` or `ORDER BY ALL DESC` and/or `NULLS FIRST` or `NULLS LAST`.
 Note that `ALL` may not be used in combination with other expressions in the `ORDER BY` clause - it must be by itself.
 See examples below.
 
-### NULL Order Modifier
+## NULL Order Modifier
 
 By default if no modifiers are provided, DuckDB sorts `ASC NULLS LAST`, i.e., the values are sorted in ascending order and null values are placed last. 
-This is identical to the default sort order of PostgreSQL. 
-Note that this was a breaking change in version 0.8.0. Prior to 0.8.0, DuckDB sorted using `ASC NULLS FIRST`.
-The default sort order can be changed using the following `PRAGMA` statements.
+This is identical to the default sort order of PostgreSQL. The default sort order can be changed using the following `PRAGMA` statements.
+
+> Using `ASC NULLS LAST` as default the default sorting order was a breaking change in version 0.8.0. Prior to 0.8.0, DuckDB sorted using `ASC NULLS FIRST`.
 
 ```sql
 -- change the default null sorting order to either NULLS FIRST and NULLS LAST
@@ -34,14 +34,14 @@ PRAGMA default_null_order='NULLS FIRST';
 PRAGMA default_order='DESC';
 ```
 
-### Collations
+## Collations
 
 Text is sorted using the binary comparison collation by default, which means values are sorted on their binary UTF8 values.
 While this works well for ASCII text (e.g., for English language data), the sorting order can be incorrect for other languages.
 For this purpose, DuckDB provides collations.
 For more information on collations, see the [Collation page](../../sql/expressions/collations).
 
-### Examples
+## Examples
 
 All examples use this example table:
 ```sql
@@ -75,7 +75,7 @@ FROM addresses
 ORDER BY city COLLATE DE;
 ```
 
-#### ORDER BY ALL Examples
+### ORDER BY ALL Examples
 
 ```sql
 -- Order from left to right (by address, then by city, then by zip) in ascending order
@@ -108,6 +108,6 @@ ORDER BY ALL DESC;
 
 
 
-### Syntax
+## Syntax
 
 <div id="rrdiagram"></div>

--- a/docs/sql/query_syntax/qualify.md
+++ b/docs/sql/query_syntax/qualify.md
@@ -13,7 +13,7 @@ Note that this is filtering based on [`WINDOW` functions](../../sql/window_funct
 
 The position of where to specify a `QUALIFY` clause is following the [`WINDOW` clause](../../sql/query_syntax/window) in a `SELECT` statement (`WINDOW` does not need to be specified), and before the [`ORDER BY`](../../sql/query_syntax/orderby).
 
-### Examples
+## Examples
 
 Each of the following examples produce the same output, located below.
 
@@ -82,6 +82,6 @@ WHERE
 | pg_catalog  | col_description | 1             |
 | pg_catalog  | format_pg_type  | 2             |
 
-### Syntax
+## Syntax
 
 <div id="rrdiagram"></div>

--- a/docs/sql/query_syntax/sample.md
+++ b/docs/sql/query_syntax/sample.md
@@ -6,7 +6,7 @@ railroad: query_syntax/sample.js
 
 `The SAMPLE clause` allows you to run the query on a sample from the base table. This can significantly speed up processing of queries, at the expense of accuracy in the result. Samples can also be used to quickly see a snapshot of the data when exploring a data set. The sample clause is applied right after anything in the `FROM` clause (i.e., after any joins, but before the where clause or any aggregates). See the [sample](../../sql/samples) page for more information.
 
-### Examples
+## Examples
 
 ```sql
 -- select a sample of 1% of the addresses table using default (system) sampling
@@ -23,6 +23,6 @@ FROM (SELECT * FROM addresses)
 USING SAMPLE 10 ROWS;
 ```
 
-### Syntax
+## Syntax
 
 <div id="rrdiagram"></div>

--- a/docs/sql/query_syntax/select.md
+++ b/docs/sql/query_syntax/select.md
@@ -7,7 +7,7 @@ blurb: The SELECT clause specifies the list of columns that will be returned by 
 
 The `SELECT` clause specifies the list of columns that will be returned by the query. While it appears first in the clause, *logically* the expressions here are executed only at the end. The `SELECT` clause can contain arbitrary expressions that transform the output, as well as aggregates and window functions.
 
-### Examples
+## Examples
 
 ```sql
 -- select all columns from the table called "table_name"
@@ -28,15 +28,15 @@ SELECT COLUMNS('number\d+') FROM addresses;
 SELECT MIN(COLUMNS(*)) FROM addresses;
 ```
 
-### Syntax
+## Syntax
 
 <div id="rrdiagram"></div>
 
-### Select List
+## Select List
 
 The `SELECT` clause contains a list of expressions that specify the result of a query. The select list can refer to any columns in the `FROM` clause, and combine them using expressions. As the output of a SQL query is a table - every expression in the `SELECT` clause also has a name. The expressions can be explicitly named using the `AS` clause (e.g., `expr AS name`). If a name is not provided by the user the expressions are named automatically by the system. 
 
-#### Star Expressions
+### Star Expressions
 
 ```sql
 -- select all columns from the table called "table_name"
@@ -47,7 +47,7 @@ SELECT COLUMNS('number\d+') FROM addresses;
 
 The [star expression](../expressions/star) is a special expression that expands to *multiple expressions* based on the contents of the `FROM` clause. In the simplest case, `*` expands to **all** expressions in the `FROM` clause. Columns can also be selected using regular expressions or lambda functions. See the [star expression page](../expressions/star) for more details.
 
-#### Distinct Clause
+### Distinct Clause
 
 ```sql
 -- select all unique cities from the addresses table
@@ -58,7 +58,7 @@ The `DISTINCT` clause can be used to return **only** the unique rows in the resu
 
 > Queries starting with `SELECT DISTINCT` run deduplication, which is an expensive operation. Therefore, only use `DISTINCT` if necessary.
 
-#### Distinct On Clause
+### Distinct On Clause
 
 ```sql
 -- select only the highest population city for each country
@@ -69,7 +69,7 @@ The `DISTINCT ON` clause returns only one row per unique value in the set of exp
 
 > When querying large data sets, using `DISTINCT` on all columns can be expensive. Therefore, consider using `DISTINCT ON` on a column (or a set of columns) which guaranetees a sufficient degree of uniqueness for your results. For example, using `DISTINCT ON` on the key column(s) of a table guarantees full uniqueness.
 
-#### Aggregates
+### Aggregates
 
 ```sql
 -- return the total number of rows in the addresses table
@@ -80,7 +80,7 @@ SELECT city, COUNT(*) FROM addresses GROUP BY city;
 
 [Aggregate functions](../aggregates) are special functions that *combine* multiple rows into a single value. When aggregate functions are present in the `SELECT` clause, the query is turned into an aggregate query. In an aggregate query, **all** expressions must either be part of an aggregate function, or part of a group (as specified by the [`GROUP BY clause`](groupby)).
 
-#### Window Functions
+### Window Functions
 
 ```sql
 -- generate a "row_number" column containing incremental identifiers for each row
@@ -91,7 +91,7 @@ SELECT amount - lag(amount) OVER (ORDER BY time) FROM sales;
 
 [Window functions](../window_functions) are special functions that allow the computation of values relative to *other rows* in a result. Window functions are marked by the `OVER` clause which contains the *window specification*. The window specification defines the frame or context in which the window function is computed. See the [window functions page](../window_functions) for more information.
 
-#### Unnest
+### Unnest
 
 ```sql
 -- unnest an array by one level

--- a/docs/sql/query_syntax/window.md
+++ b/docs/sql/query_syntax/window.md
@@ -6,6 +6,6 @@ railroad: query_syntax/window.js
 
 The `WINDOW` clause allows you to specify named windows that can be used within window functions. These are useful when you have multiple window functions, as they allow you to avoid repeating the same window clause.
 
-### Syntax
+## Syntax
 
 <div id="rrdiagram"></div>

--- a/docs/sql/statements/alter_table.md
+++ b/docs/sql/statements/alter_table.md
@@ -6,7 +6,7 @@ railroad: statements/alter.js
 
 The `ALTER TABLE` statement changes the schema of an existing table in the catalog.
 
-### Examples
+## Examples
 
 ```sql
 -- add a new column with name "k" to the table "integers", it will be filled with the default value NULL
@@ -39,13 +39,13 @@ ALTER TABLE integers RENAME TO integers_old;
 ALTER TABLE integers RENAME i TO j;
 ```
 
-### Syntax
+## Syntax
 
 <div id="rrdiagram"></div>
 
 `ALTER TABLE` changes the schema of an existing table. All the changes made by `ALTER TABLE` fully respect the transactional semantics, i.e., they will not be visible to other transactions until committed, and can be fully reverted through a rollback.
 
-### RENAME TABLE
+## RENAME TABLE
 
 ```sql
 -- rename a table
@@ -54,7 +54,7 @@ ALTER TABLE integers RENAME TO integers_old;
 
 The `RENAME TO` clause renames an entire table, changing its name in the schema. Note that any views that rely on the table are **not** automatically updated.
 
-### RENAME COLUMN
+## RENAME COLUMN
 
 ```sql
 -- rename a column of a table
@@ -64,7 +64,7 @@ ALTER TABLE integers RENAME COLUMN j TO k;
 
 The `RENAME COLUMN` clause renames a single column within a table. Any constraints that rely on this name (e.g., `CHECK` constraints) are automatically updated. However, note that any views that rely on this column name are **not** automatically updated.
 
-### ADD COLUMN
+## ADD COLUMN
 
 ```sql
 -- add a new column with name "k" to the table "integers", it will be filled with the default value NULL
@@ -75,7 +75,7 @@ ALTER TABLE integers ADD COLUMN l INTEGER DEFAULT 10;
 
 The `ADD COLUMN` clause can be used to add a new column of a specified type to a table. The new column will be filled with the specified default value, or `NULL` if none is specified.
 
-### DROP COLUMN
+## DROP COLUMN
 
 ```sql
 -- drop the column "k" from the table integers
@@ -84,7 +84,7 @@ ALTER TABLE integers DROP k;
 
 The `DROP COLUMN` clause can be used to remove a column from a table. Note that columns can only be removed if they do not have any indexes that rely on them. This includes any indexes created as part of a `PRIMARY KEY` or `UNIQUE` constraint. Columns that are part of multi-column check constraints cannot be dropped either.
 
-### ALTER TYPE
+## ALTER TYPE
 
 ```sql
 -- change the type of the column "i" to the type "VARCHAR" using a standard cast
@@ -95,7 +95,7 @@ ALTER TABLE integers ALTER i SET DATA TYPE VARCHAR USING CONCAT(i, '_', j);
 
 The `SET DATA TYPE` clause changes the type of a column in a table. Any data present in the column is converted according to the provided expression in the `USING` clause, or, if the `USING` clause is absent, cast to the new data type. Note that columns can only have their type changed if they do not have any indexes that rely on them and are not part of any `CHECK` constraints.
 
-### SET/DROP DEFAULT
+## SET/DROP DEFAULT
 
 ```sql
 -- set the default value of a column
@@ -108,6 +108,6 @@ The `SET/DROP DEFAULT` clause modifies the `DEFAULT` value of an existing column
 
 > At the moment DuckDB will not allow you to alter a table if there are any dependencies. That means that if you have an index on a column you will first need to drop the index, alter the table, and then recreate the index. Otherwise you will get a "Dependency Error."
 
-### ADD/DROP CONSTRAINT
+## ADD/DROP CONSTRAINT
 
 > The `ADD CONSTRAINT` and `DROP CONSTRAINT` clauses are not yet supported in DuckDB.

--- a/docs/sql/statements/alter_view.md
+++ b/docs/sql/statements/alter_view.md
@@ -5,7 +5,7 @@ title: Alter View
 
 The `ALTER VIEW` statement changes the schema of an existing view in the catalog.
 
-### Examples
+## Examples
 
 ```sql
 -- rename a view

--- a/docs/sql/statements/attach.md
+++ b/docs/sql/statements/attach.md
@@ -6,7 +6,7 @@ railroad: statements/attach.js
 
 The `ATTACH` statement adds a new database file to the catalog that can be read from and written to.
 
-### Examples
+## Examples
 
 ```sql
 -- attach the database "file.db" with the alias inferred from the name ("file")
@@ -27,19 +27,19 @@ SHOW databases;
 USE file;
 ```
 
-### Syntax
+## Syntax
 
 <div id="rrdiagram1"></div>
 
 `ATTACH` allows DuckDB to operate on multiple database files, and allows for transfer of data between different database files. 
 
-### Detach
+## Detach
 
 <div id="rrdiagram2"></div>
 
 The `DETACH` statement allows previously attached database files to be closed and detached, releasing any locks held on the database file.
 
-### Name Qualification
+## Name Qualification
 
 The fully qualified name of catalog objects contains the *catalog*, the *schema* and the *name* of the object. For example:
 
@@ -91,7 +91,7 @@ CREATE TABLE new_db.tbl(i INTEGER);
 -- Error: Binder Error: Ambiguous reference to catalog or schema "new_db" - use a fully qualified path like "memory.new_db"
 ```
 
-### Transactional Semantics
+## Transactional Semantics
 
 When running queries on multiple databases, the system opens separate transactions per database. The transactions are started *lazily* by default - when a given database is referenced for the first time in a query, a transaction for that database will be started. `SET immediate_transaction_mode=true` can be toggled to change this behavior to eagerly start transactions in all attached databases instead.
 

--- a/docs/sql/statements/call.md
+++ b/docs/sql/statements/call.md
@@ -6,7 +6,7 @@ railroad: statements/call.js
 
 The `CALL` statement invokes the given table function and returns the results.
 
-### Examples
+## Examples
 
 ```sql
 -- Invoke the 'duckdb_functions' table function.
@@ -15,6 +15,6 @@ CALL duckdb_functions();
 CALL pragma_table_info('pg_am');
 ```
 
-### Syntax
+## Syntax
 
 <div id="rrdiagram1"></div>

--- a/docs/sql/statements/checkpoint.md
+++ b/docs/sql/statements/checkpoint.md
@@ -7,7 +7,7 @@ railroad: statements/checkpoint.js
 The `CHECKPOINT` statement synchronizes data in the write-ahead log (WAL) to the database data file. For in-memory
 databases this statement will succeed with no effect.
 
-### Examples
+## Examples
 
 ```sql
 -- Synchronize data in the default database
@@ -18,14 +18,14 @@ CHECKPOINT file_db;
 FORCE CHECKPOINT;
 ```
 
-### Syntax
+## Syntax
 
 <div id="rrdiagram1"></div>
 
 Checkpoint operations happen automatically based on the WAL size (see [Configuration](../configuration)). This
 statement is for manual checkpoint actions.
 
-### Behavior
+## Behavior
 
 The default `CHECKPOINT` command will fail if there are any running transactions. Including `FORCE` will abort any
 transactions and execute the checkpoint operation.

--- a/docs/sql/statements/create_macro.md
+++ b/docs/sql/statements/create_macro.md
@@ -11,7 +11,7 @@ For a table macro, the syntax is similar to a scalar macro except `AS` is replac
 
 If a `MACRO` is temporary, it is only usable within the same database connection and is deleted when the connection is closed.
 
-### Examples
+## Examples
 
 ```sql
 -- create a macro that adds two expressions (a and b)
@@ -43,7 +43,7 @@ CREATE OR REPLACE TEMP MACRO dynamic_table(col1_value, col2_value) AS TABLE
     SELECT 'Hello' AS col1_value, 456 AS col2_value;
 ```
 
-### Syntax
+## Syntax
 
 <div id="rrdiagram"></div>
 

--- a/docs/sql/statements/create_schema.md
+++ b/docs/sql/statements/create_schema.md
@@ -6,7 +6,7 @@ railroad: statements/createschema.js
 
 The `CREATE SCHEMA` statement creates a schema in the catalog. The default schema is `main`.
 
-### Examples
+## Examples
 
 ```sql
 -- create a schema
@@ -20,6 +20,6 @@ CREATE TABLE s2.t(id INTEGER PRIMARY KEY, j VARCHAR);
 SELECT * FROM s1.t s1t, s2.t s2t WHERE s1t.other_id = s2t.id;
 ```
 
-### Syntax
+## Syntax
 
 <div id="rrdiagram"></div>

--- a/docs/sql/statements/create_table.md
+++ b/docs/sql/statements/create_table.md
@@ -6,7 +6,7 @@ railroad: statements/createtable.js
 
 The `CREATE TABLE` statement creates a table in the catalog.
 
-### Examples
+## Examples
 
 ```sql
 -- create a table with two integer columns (i and j)
@@ -25,7 +25,7 @@ CREATE TABLE t1 AS SELECT * FROM read_csv_auto ('path/file.csv');
 CREATE TABLE t1 AS FROM read_csv_auto ('path/file.csv');
 ```
 
-### Temporary Tables
+## Temporary Tables
 
 Temporary tables can be created using a `CREATE TEMP TABLE` statement (see diagram below). 
 Temporary tables are session scoped (similar to PostgreSQL for example), meaning that only the specific connection that created them can access them, and once the connection to DuckDB is closed they will be automatically dropped. 
@@ -39,7 +39,7 @@ CREATE TEMP TABLE t1 AS SELECT * FROM read_csv_auto ('path/file.csv');
 SET temp_directory='/path/to/directory/';
 ```
 
-### Create or Replace
+## Create or Replace
 
 The `CREATE OR REPLACE` syntax allows a new table to be created or for an existing table to be overwritten by the new table. This is shorthand for dropping the existing table and then creating the new one.
 
@@ -48,7 +48,7 @@ The `CREATE OR REPLACE` syntax allows a new table to be created or for an existi
 CREATE OR REPLACE TABLE t1(i INTEGER, j INTEGER);
 ```
 
-### If Not Exists
+## If Not Exists
 
 The `IF NOT EXISTS` syntax will only proceed with the creation of the table if it does not already exist. If the table already exists, no action will be taken and the existing table will remain in the database. 
 
@@ -57,7 +57,7 @@ The `IF NOT EXISTS` syntax will only proceed with the creation of the table if i
 CREATE TABLE IF NOT EXISTS t1(i INTEGER, j INTEGER);
 ```
 
-### Check Constraints
+## Check Constraints
 
 A `CHECK` constraint is an expression that must be satisfied by the values of every row in the table.
 
@@ -94,7 +94,7 @@ INSERT INTO t3 VALUES (2, 5, 3);
 -- Error: Constraint Error: CHECK constraint failed: t3
 ```
 
-### Foreign Key Constraints
+## Foreign Key Constraints
 
 A `FOREIGN KEY` is a column (or set of columns) that references another table's primary key. Foreign keys check referential integrity, i.e., the referred primary key must exist in the other table upon insertion.
 
@@ -138,7 +138,7 @@ CREATE TABLE t6(id INTEGER PRIMARY KEY, t5_id INTEGER, FOREIGN KEY (t5_id) REFER
 
 > Foreign keys with cascading deletes (`FOREIGN KEY ... REFERENCES ... ON DELETE CASCADE`) are not supported.
 
-### Generated Columns
+## Generated Columns
 
 The `[type] [GENERATED ALWAYS] AS (expr) [VIRTUAL|STORED]` syntax will create a generated column. The data in this kind of column is generated from its expression, which can reference other (regular or generated) columns of the table. Since they are produced by calculations, these columns can not be inserted into directly.
 
@@ -160,6 +160,6 @@ CREATE TABLE t1(x FLOAT, two_x AS (2 * x));
 CREATE TABLE t1(x FLOAT, two_x FLOAT GENERATED ALWAYS AS (2 * x) VIRTUAL);
 ```
 
-### Syntax
+## Syntax
 
 <div id="rrdiagram"></div>

--- a/docs/sql/statements/create_type.md
+++ b/docs/sql/statements/create_type.md
@@ -6,7 +6,7 @@ railroad: statements/createtype.js
 
 The `CREATE TYPE` statement defines a new type in the catalog.
 
-### Examples
+## Examples
 
 ```sql
 -- create a simple enum type
@@ -19,7 +19,7 @@ CREATE TYPE one_thing AS UNION(number INTEGER, string VARCHAR);
 CREATE TYPE x_index AS INTEGER;
 ```
 
-### Syntax
+## Syntax
 
 <div id="rrdiagram"></div>
 

--- a/docs/sql/statements/create_view.md
+++ b/docs/sql/statements/create_view.md
@@ -6,7 +6,7 @@ railroad: statements/createview.js
 
 The `CREATE VIEW` statement defines a new view in the catalog.
 
-### Examples
+## Examples
 
 ```sql
 -- create a simple view
@@ -17,7 +17,7 @@ CREATE OR REPLACE VIEW v1 AS SELECT 42;
 CREATE VIEW v1(a) AS SELECT 42;
 ```
 
-### Syntax
+## Syntax
 
 <div id="rrdiagram"></div>
 

--- a/docs/sql/statements/delete.md
+++ b/docs/sql/statements/delete.md
@@ -6,7 +6,7 @@ railroad: statements/delete.js
 
 The `DELETE` statement removes rows from the table identified by the table-name.
 
-### Examples
+## Examples
 
 ```sql
 -- remove the rows matching the condition "i=2" from the database
@@ -15,7 +15,7 @@ DELETE FROM tbl WHERE i=2;
 DELETE FROM tbl;
 ```
 
-### Syntax
+## Syntax
 
 <div id="rrdiagram"></div>
 

--- a/docs/sql/statements/drop.md
+++ b/docs/sql/statements/drop.md
@@ -6,7 +6,7 @@ railroad: statements/drop.js
 
 The `DROP` statement removes a catalog entry added previously with the `CREATE` command.
 
-### Examples
+## Examples
 
 ```sql
 -- delete the table with the name "tbl"
@@ -15,7 +15,7 @@ DROP TABLE tbl;
 DROP VIEW IF EXISTS v1;
 ```
 
-### Syntax
+## Syntax
 
 <div id="rrdiagram"></div>
 

--- a/docs/sql/statements/export.md
+++ b/docs/sql/statements/export.md
@@ -6,7 +6,7 @@ railroad: statements/export.js
 
 The `EXPORT DATABASE` command allows you to export the contents of the database to a specific directory. The `IMPORT DATABASE` command allows you to then read the contents again.
 
-### Examples
+## Examples
 
 ```sql
 -- export the database to the target directory
@@ -23,7 +23,7 @@ IMPORT DATABASE 'target_directory';
 
 For details regarding the writing of Parquet files, see the [Parquet Files page in the Data Import section](../../data/parquet/overview#writing-to-parquet-files), and the [Copy Statement page](copy).
 
-### Syntax
+## Syntax
 
 <div id="rrdiagram"></div>
 

--- a/docs/sql/statements/overview.md
+++ b/docs/sql/statements/overview.md
@@ -3,4 +3,4 @@ layout: docu
 title: Statements Overview
 ---
 
-### More
+## More

--- a/docs/sql/statements/set.md
+++ b/docs/sql/statements/set.md
@@ -6,7 +6,7 @@ railroad: statements/set.js
 
 The `SET` statement modifies the provided DuckDB configuration option at the specified scope.
 
-### Examples
+## Examples
 
 ```sql
 -- Update the `memory_limit` configuration value.
@@ -17,19 +17,19 @@ SET threads TO 1;
 RESET threads;
 ```
 
-### Syntax
+## Syntax
 
 <div id="rrdiagram1"></div>
 
 `SET` updates a DuckDB configuration option to the provided value.
 
-### Reset
+## Reset
 
 <div id="rrdiagram2"></div>
 
 The `RESET` statement changes the given DuckDB configuration option to the default value.
 
-### Scopes
+## Scopes
 
 * local - Not yet implemented.
 * session - Configuration value is used (or reset) only for the current session attached to a DuckDB instance.
@@ -37,6 +37,6 @@ The `RESET` statement changes the given DuckDB configuration option to the defau
 
 When not specified, the default scope for the configuration option is used. For most options this is global.
 
-### Configuration
+## Configuration
 
 See the [Configuration](../configuration) page for the full list of configuration options.

--- a/docs/sql/statements/update.md
+++ b/docs/sql/statements/update.md
@@ -6,7 +6,7 @@ railroad: statements/update.js
 
 The `UPDATE` statement modifies the values of rows in a table.
 
-### Examples
+## Examples
 
 ```sql
 -- for every row where "i" is NULL, set the value to 0 instead
@@ -15,13 +15,13 @@ UPDATE tbl SET i=0 WHERE i IS NULL;
 UPDATE tbl SET i=1, j = 2;
 ```
 
-### Syntax
+## Syntax
 
 <div id="rrdiagram"></div>
 
 `UPDATE` changes the values of the specified columns in all rows that satisfy the condition. Only the columns to be modified need be mentioned in the `SET` clause; columns not explicitly modified retain their previous values.
 
-### Update from Other Table
+## Update from Other Table
 
 A table can be updated based upon values from another table. This can be done by specifying a table in a `FROM` clause, or using a sub-select statement. Both approaches have the benefit of completing the `UPDATE` operation in bulk for increased performance.
 
@@ -68,7 +68,7 @@ SELECT * FROM original;
 | 1   | new value   |
 | 2   | new value 2 |
 
-### Update from Same Table
+## Update from Same Table
 
 The only difference between this case and the above is that a different table alias must be specified on both the target table and the source table.
 In this example `as true_original` and `as new` are both required. 
@@ -83,6 +83,6 @@ UPDATE original as true_original
     );
 ```
 
-### Upsert (Insert or Update)
+## Upsert (Insert or Update)
 
 See the [Insert documentation](insert#on-conflict-clause) for details.

--- a/docs/sql/statements/use.md
+++ b/docs/sql/statements/use.md
@@ -6,7 +6,7 @@ railroad: statements/use.js
 
 The `USE` statement selects a database and optional schema to use as the default.
 
-### Examples
+## Examples
 
 ```sql
 --- Sets the 'memory' database as the default
@@ -15,7 +15,7 @@ USE memory;
 USE duck.main;
 ```
 
-### Syntax
+## Syntax
 
 <div id="rrdiagram1"></div>
 

--- a/docs/sql/statements/vacuum.md
+++ b/docs/sql/statements/vacuum.md
@@ -6,7 +6,7 @@ railroad: statements/vacuum.js
 
 The `VACUUM` statement is primarily in place for PostgreSQL compatibility.
 
-### Examples
+## Examples
 
 ```sql
 -- No-op.
@@ -17,7 +17,7 @@ VACUUM ANALYZE;
 VACUUM ANALYZE memory.main.my_table(my_column);
 ```
 
-### Syntax
+## Syntax
 
 <div id="rrdiagram1"></div>
 


### PR DESCRIPTION
I wrote a script to find documents which start their headings from h3 instead of h2 (blasphemy!). Luckily, DuckDB makes this super easy. Just create a list of files with h2 headers and another with h3 headers and perform the substraction (h3\h2).

Shell:
```bash
ag --md --ignore-dir=archive/ --files-with-matches '^### ' docs/ > l3
ag --md --ignore-dir=archive/ --files-with-matches '^## '  docs/ > l2
```

DuckDB:
```sql
create table l3 as from read_csv_auto('l3');
create table l2 as from read_csv_auto('l2');
select * from l3 except from l2;
```