### PR TITLE
Single-PDF document: Use custom syntax highlighter

### DIFF
--- a/single-file-document/pandoc-configuration.yaml
+++ b/single-file-document/pandoc-configuration.yaml
@@ -6,6 +6,7 @@ to: pdf
 metadata-file: metadata.yaml
 template: eisvogel2.tex
 pdf-engine: xelatex
+syntax-definition: sql-duckdb.xml
 table-of-contents: true
 toc-depth: 3
 top-level-division: part

--- a/single-file-document/sql-duckdb.xml
+++ b/single-file-document/sql-duckdb.xml
@@ -1,0 +1,1473 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE language
+[
+
+  <!-- Regular expression matching case-insensitively a single hexadecial digit. -->
+  <!ENTITY hexDigit "[0-9a-fA-F]">
+
+  <!-- Regular expression matching all potential names of PostgresSQL built-in
+  functions and PostGIS functions. -->
+  <!ENTITY functionName "[a-zA-Z][a-zA-Z0-9_]*">
+
+]>
+
+<!-- PostgreSQL SQL, syntax definition based on sql.xml by Yury Lebedev
+     v5 fix comments by Gene Thomas <gene@genethomas.com>
+  -->
+
+<!-- Support for escape characters in strings and identifiers, PostGIS highlighting
+     and better functioni highlighting by Lukas Sommer <sommerluk@gamil.com>. These
+     modifications are under MIT License.
+  -->
+
+<!-- The DuckDB syntax highlighter is based on the PostgreSQL highlighter:
+     https://github.com/KDE/syntax-highlighting/blob/v5.110.0/data/syntax/sql-postgresql.xml
+  -->
+
+<language name="sql"
+          version="16"
+          kateversion="5.44"
+          section="Database"
+          extensions="*.sql;*.SQL;*.ddl;*.DDL"
+          mimetype="text/x-sql"
+          casesensitive="0"
+          author="Shane Wright (me@shanewright.co.uk)"
+          license="">
+  <highlighting>
+    <list name="controlFlow">
+      <item>BEGIN</item>
+      <item>CASE</item>
+      <item>ELSE</item>
+      <item>ELSIF</item>
+      <item>END</item>
+      <item>EXCEPTION</item>
+      <item>FOR</item>
+      <item>IF</item>
+      <item>LOOP</item>
+      <item>RETURN</item>
+      <item>THEN</item>
+      <item>WHEN</item>
+  </list>
+    <list name="operators">
+      <item>AND</item>
+      <item>BETWEEN</item>
+      <item>IN</item>
+      <item>IS</item>
+      <item>LIKE</item>
+      <item>NOT</item>
+      <item>OR</item>
+    </list>
+    <list name="keywords">
+      <item>A</item>
+      <item>ABORT</item>
+      <item>ABSENT</item>
+      <item>ABSOLUTE</item>
+      <item>ACCESS</item>
+      <item>ACCORDING</item>
+      <item>ACTION</item>
+      <item>ADA</item>
+      <item>ADD</item>
+      <item>ADMIN</item>
+      <item>AFTER</item>
+      <item>AGGREGATE</item>
+      <item>ALL</item>
+      <item>ALLOCATE</item>
+      <item>ALSO</item>
+      <item>ALTER</item>
+      <item>ALWAYS</item>
+      <item>ANALYZE</item>
+      <item>ANY</item>
+      <item>ARE</item>
+      <item>ARRAY</item>
+      <item>ARRAY_AGG</item>
+      <item>ARRAY_MAX_CARDINALITY</item>
+      <item>AS</item>
+      <item>ASC</item>
+      <item>ASENSITIVE</item>
+      <item>ASSERTION</item>
+      <item>ASSIGNMENT</item>
+      <item>ASYMMETRIC</item>
+      <item>AT</item>
+      <item>ATOMIC</item>
+      <item>ATTACH</item>
+      <item>ATTRIBUTE</item>
+      <item>ATTRIBUTES</item>
+      <item>AUTHORIZATION</item>
+      <item>BACKWARD</item>
+      <item>BASE64</item>
+      <item>BEFORE</item>
+      <item>BEGIN_FRAME</item>
+      <item>BEGIN_PARTITION</item>
+      <item>BERNOULLI</item>
+      <item>BINARY</item>
+      <item>BLOB</item>
+      <item>BLOCKED</item>
+      <item>BOM</item>
+      <item>BOTH</item>
+      <item>BREADTH</item>
+      <item>BY</item>
+      <item>C</item>
+      <item>CACHE</item>
+      <item>CALL</item>
+      <item>CALLED</item>
+      <item>CARDINALITY</item>
+      <item>CASCADE</item>
+      <item>CASCADED</item>
+      <item>CAST</item>
+      <item>CATALOG</item>
+      <item>CATALOG_NAME</item>
+      <item>CHAIN</item>
+      <item>CHARACTERISTICS</item>
+      <item>CHARACTERS</item>
+      <item>CHARACTER_SET_CATALOG</item>
+      <item>CHARACTER_SET_NAME</item>
+      <item>CHARACTER_SET_SCHEMA</item>
+      <item>CHECK</item>
+      <item>CHECKPOINT</item>
+      <item>CLASS</item>
+      <item>CLASS_ORIGIN</item>
+      <item>CLOB</item>
+      <item>CLOSE</item>
+      <item>CLUSTER</item>
+      <item>COBOL</item>
+      <item>COLLATE</item>
+      <item>COLLATION</item>
+      <item>COLLATION_CATALOG</item>
+      <item>COLLATION_NAME</item>
+      <item>COLLATION_SCHEMA</item>
+      <item>COLLECT</item>
+      <item>COLUMN</item>
+      <item>COLUMNS</item>
+      <item>COLUMN_NAME</item>
+      <item>COMMAND_FUNCTION</item>
+      <item>COMMAND_FUNCTION_CODE</item>
+      <item>COMMENT</item>
+      <item>COMMENTS</item>
+      <item>COMMIT</item>
+      <item>COMMITTED</item>
+      <item>CONCURRENTLY</item>
+      <item>CONDITION</item>
+      <item>CONDITION_NUMBER</item>
+      <item>CONFIGURATION</item>
+      <item>CONFLICT</item>
+      <item>CONNECT</item>
+      <item>CONNECTION</item>
+      <item>CONNECTION_NAME</item>
+      <item>CONSTRAINT</item>
+      <item>CONSTRAINTS</item>
+      <item>CONSTRAINT_CATALOG</item>
+      <item>CONSTRAINT_NAME</item>
+      <item>CONSTRAINT_SCHEMA</item>
+      <item>CONSTRUCTOR</item>
+      <item>CONTAINS</item>
+      <item>CONTENT</item>
+      <item>CONTINUE</item>
+      <item>CONTROL</item>
+      <item>CONVERSION</item>
+      <item>COPY</item>
+      <item>CORR</item>
+      <item>CORRESPONDING</item>
+      <item>COST</item>
+      <item>COVAR_POP</item>
+      <item>COVAR_SAMP</item>
+      <item>CREATE</item>
+      <item>CROSS</item>
+      <item>CSV</item>
+      <item>CUBE</item>
+      <item>CUME_DIST</item>
+      <item>CURRENT</item>
+      <item>CURRENT_CATALOG</item>
+      <item>CURRENT_DATE</item>
+      <item>CURRENT_DEFAULT_TRANSFORM_GROUP</item>
+      <item>CURRENT_PATH</item>
+      <item>CURRENT_ROLE</item>
+      <item>CURRENT_ROW</item>
+      <item>CURRENT_TIME</item>
+      <item>CURRENT_TIMESTAMP</item>
+      <item>CURRENT_TRANSFORM_GROUP_FOR_TYPE</item>
+      <item>CURSOR</item>
+      <item>CURSOR_NAME</item>
+      <item>CYCLE</item>
+      <item>DATA</item>
+      <item>DATABASE</item>
+      <item>DATALINK</item>
+      <item>DATETIME_INTERVAL_CODE</item>
+      <item>DATETIME_INTERVAL_PRECISION</item>
+      <item>DAY</item>
+      <item>DB</item>
+      <item>DEALLOCATE</item>
+      <item>DEC</item>
+      <item>DECLARE</item>
+      <item>DEFAULT</item>
+      <item>DEFAULTS</item>
+      <item>DEFERRABLE</item>
+      <item>DEFERRED</item>
+      <item>DEFINED</item>
+      <item>DEFINER</item>
+      <item>DEGREE</item>
+      <item>DELETE</item>
+      <item>DELIMITER</item>
+      <item>DELIMITERS</item>
+      <item>DENSE_RANK</item>
+      <item>DEPENDS</item>
+      <item>DEPTH</item>
+      <item>DEREF</item>
+      <item>DERIVED</item>
+      <item>DESC</item>
+      <item>DESCRIBE</item>
+      <item>DESCRIPTOR</item>
+      <item>DESTROY</item>
+      <item>DESTRUCTOR</item>
+      <item>DETACH</item>
+      <item>DETERMINISTIC</item>
+      <item>DIAGNOSTICS</item>
+      <item>DICTIONARY</item>
+      <item>DISABLE</item>
+      <item>DISCARD</item>
+      <item>DISCONNECT</item>
+      <item>DISPATCH</item>
+      <item>DISTINCT</item>
+      <item>DLNEWCOPY</item>
+      <item>DLPREVIOUSCOPY</item>
+      <item>DLURLCOMPLETE</item>
+      <item>DLURLCOMPLETEONLY</item>
+      <item>DLURLCOMPLETEWRITE</item>
+      <item>DLURLPATH</item>
+      <item>DLURLPATHONLY</item>
+      <item>DLURLPATHWRITE</item>
+      <item>DLURLSCHEME</item>
+      <item>DLURLSERVER</item>
+      <item>DLVALUE</item>
+      <item>DO</item>
+      <item>DOCUMENT</item>
+      <item>DOMAIN</item>
+      <item>DROP</item>
+      <item>DYNAMIC</item>
+      <item>DYNAMIC_FUNCTION</item>
+      <item>DYNAMIC_FUNCTION_CODE</item>
+      <item>EACH</item>
+      <item>ELEMENT</item>
+      <item>EMPTY</item>
+      <item>ENABLE</item>
+      <item>ENCODING</item>
+      <item>ENCRYPTED</item>
+      <item>END-EXEC</item>
+      <item>END_FRAME</item>
+      <item>END_PARTITION</item>
+      <item>ENFORCED</item>
+      <item>ENUM</item>
+      <item>EQUALS</item>
+      <item>ESCAPE</item>
+      <item>EVENT</item>
+      <item>EXCEPT</item>
+      <item>EXCLUDE</item>
+      <item>EXCLUDING</item>
+      <item>EXCLUSIVE</item>
+      <item>EXEC</item>
+      <item>EXECUTE</item>
+      <item>EXISTS</item>
+      <item>EXPLAIN</item>
+      <item>EXPRESSION</item>
+      <item>EXTENSION</item>
+      <item>EXTERNAL</item>
+      <item>FALSE</item>
+      <item>FETCH</item>
+      <item>FILE</item>
+      <item>FILTER</item>
+      <item>FINAL</item>
+      <item>FIRST</item>
+      <item>FIRST_VALUE</item>
+      <item>FLAG</item>
+      <item>FLOAT</item>
+      <item>FOLLOWING</item>
+      <item>FORCE</item>
+      <item>FOREIGN</item>
+      <item>FORTRAN</item>
+      <item>FORWARD</item>
+      <item>FOUND</item>
+      <item>FRAME_ROW</item>
+      <item>FREE</item>
+      <item>FREEZE</item>
+      <item>FROM</item>
+      <item>FS</item>
+      <item>FULL</item>
+      <item>FUNCTION</item>
+      <item>FUNCTIONS</item>
+      <item>FUSION</item>
+      <item>G</item>
+      <item>GENERAL</item>
+      <item>GENERATED</item>
+      <item>GET</item>
+      <item>GLOBAL</item>
+      <item>GO</item>
+      <item>GOTO</item>
+      <item>GRANT</item>
+      <item>GRANTED</item>
+      <item>GREATEST</item>
+      <item>GROUP</item>
+      <item>GROUPING</item>
+      <item>GROUPS</item>
+      <item>HANDLER</item>
+      <item>HAVING</item>
+      <item>HEADER</item>
+      <item>HEX</item>
+      <item>HIERARCHY</item>
+      <item>HOLD</item>
+      <item>HOUR</item>
+      <item>ID</item>
+      <item>IDENTITY</item>
+      <item>IGNORE</item>
+      <item>ILIKE</item>
+      <item>IMMEDIATE</item>
+      <item>IMMEDIATELY</item>
+      <item>IMMUTABLE</item>
+      <item>IMPLEMENTATION</item>
+      <item>IMPLICIT</item>
+      <item>IMPORT</item>
+      <item>INCLUDING</item>
+      <item>INCREMENT</item>
+      <item>INDENT</item>
+      <item>INDEX</item>
+      <item>INDEXES</item>
+      <item>INDICATOR</item>
+      <item>INHERIT</item>
+      <item>INHERITS</item>
+      <item>INITIALLY</item>
+      <item>INLINE</item>
+      <item>INNER</item>
+      <item>INOUT</item>
+      <item>INPUT</item>
+      <item>INSENSITIVE</item>
+      <item>INSERT</item>
+      <item>INSTANCE</item>
+      <item>INSTANTIABLE</item>
+      <item>INSTEAD</item>
+      <item>INTEGRITY</item>
+      <item>INTERSECT</item>
+      <item>INTERSECTION</item>
+      <item>INTO</item>
+      <item>INVOKER</item>
+      <item>ISNULL</item>
+      <item>ISOLATION</item>
+      <item>JOIN</item>
+      <item>K</item>
+      <item>KEY</item>
+      <item>KEY_MEMBER</item>
+      <item>KEY_TYPE</item>
+      <item>LABEL</item>
+      <item>LAG</item>
+      <item>LANGUAGE</item>
+      <item>LARGE</item>
+      <item>LAST</item>
+      <item>LAST_VALUE</item>
+      <item>LATERAL</item>
+      <item>LEAD</item>
+      <item>LEADING</item>
+      <item>LEAKPROOF</item>
+      <item>LEAST</item>
+      <item>LEFT</item>
+      <item>LEVEL</item>
+      <item>LIBRARY</item>
+      <item>LIKE_REGEX</item>
+      <item>LIMIT</item>
+      <item>LINK</item>
+      <item>LISTEN</item>
+      <item>LOAD</item>
+      <item>LOCAL</item>
+      <item>LOCALTIME</item>
+      <item>LOCALTIMESTAMP</item>
+      <item>LOCATION</item>
+      <item>LOCATOR</item>
+      <item>LOCK</item>
+      <item>LOCKED</item>
+      <item>LOGGED</item>
+      <item>M</item>
+      <item>MAP</item>
+      <item>MAPPING</item>
+      <item>MATCH</item>
+      <item>MATCHED</item>
+      <item>MATERIALIZED</item>
+      <item>MAXVALUE</item>
+      <item>MAX_CARDINALITY</item>
+      <item>MEMBER</item>
+      <item>MERGE</item>
+      <item>MESSAGE_LENGTH</item>
+      <item>MESSAGE_OCTET_LENGTH</item>
+      <item>MESSAGE_TEXT</item>
+      <item>METHOD</item>
+      <item>MINUTE</item>
+      <item>MINVALUE</item>
+      <item>MODE</item>
+      <item>MODIFIES</item>
+      <item>MODULE</item>
+      <item>MONTH</item>
+      <item>MORE</item>
+      <item>MOVE</item>
+      <item>MULTISET</item>
+      <item>MUMPS</item>
+      <item>NAME</item>
+      <item>NAMES</item>
+      <item>NAMESPACE</item>
+      <item>NATIONAL</item>
+      <item>NATURAL</item>
+      <item>NCHAR</item>
+      <item>NCLOB</item>
+      <item>NESTING</item>
+      <item>NEW</item>
+      <item>NEXT</item>
+      <item>NFC</item>
+      <item>NFD</item>
+      <item>NFKC</item>
+      <item>NFKD</item>
+      <item>NIL</item>
+      <item>NO</item>
+      <item>NONE</item>
+      <item>NORMALIZE</item>
+      <item>NORMALIZED</item>
+      <item>NOTHING</item>
+      <item>NOTIFY</item>
+      <item>NOTNULL</item>
+      <item>NOWAIT</item>
+      <item>NTH_VALUE</item>
+      <item>NTILE</item>
+      <item>NULL</item>
+      <item>NULLABLE</item>
+      <item>NULLS</item>
+      <item>NUMBER</item>
+      <item>OBJECT</item>
+      <item>OCCURRENCES_REGEX</item>
+      <item>OCTETS</item>
+      <item>OF</item>
+      <item>OFF</item>
+      <item>OFFSET</item>
+      <item>OIDS</item>
+      <item>OLD</item>
+      <item>ON</item>
+      <item>ONLY</item>
+      <item>OPEN</item>
+      <item>OPERATOR</item>
+      <item>OPTION</item>
+      <item>OPTIONS</item>
+      <item>ORDER</item>
+      <item>ORDERING</item>
+      <item>ORDINALITY</item>
+      <item>OTHERS</item>
+      <item>OUT</item>
+      <item>OUTER</item>
+      <item>OUTPUT</item>
+      <item>OVER</item>
+      <item>OVERLAPS</item>
+      <item>OVERRIDING</item>
+      <item>OWNED</item>
+      <item>OWNER</item>
+      <item>P</item>
+      <item>PAD</item>
+      <item>PARALLEL</item>
+      <item>PARAMETER</item>
+      <item>PARAMETER_MODE</item>
+      <item>PARAMETER_NAME</item>
+      <item>PARAMETER_ORDINAL_POSITION</item>
+      <item>PARAMETER_SPECIFIC_CATALOG</item>
+      <item>PARAMETER_SPECIFIC_NAME</item>
+      <item>PARAMETER_SPECIFIC_SCHEMA</item>
+      <item>PARSER</item>
+      <item>PARTIAL</item>
+      <item>PARTITION</item>
+      <item>PASCAL</item>
+      <item>PASSING</item>
+      <item>PASSTHROUGH</item>
+      <item>PASSWORD</item>
+      <item>PERCENT</item>
+      <item>PERCENTILE_CONT</item>
+      <item>PERCENTILE_DISC</item>
+      <item>PERCENT_RANK</item>
+      <item>PERIOD</item>
+      <item>PERMISSION</item>
+      <item>PLACING</item>
+      <item>PLANS</item>
+      <item>PLI</item>
+      <item>POLICY</item>
+      <item>PORTION</item>
+      <item>POSITION_REGEX</item>
+      <item>PRECEDES</item>
+      <item>PRECEDING</item>
+      <item>PRECISION</item>
+      <item>PREPARE</item>
+      <item>PREPARED</item>
+      <item>PRESERVE</item>
+      <item>PRIMARY</item>
+      <item>PRIOR</item>
+      <item>PRIVILEGES</item>
+      <item>PROCEDURAL</item>
+      <item>PROCEDURE</item>
+      <item>PROGRAM</item>
+      <item>PUBLIC</item>
+      <item>RANGE</item>
+      <item>PUBLICATION</item>
+      <item>QUOTE</item>
+      <item>RANGE</item>
+      <item>RANK</item>
+      <item>READ</item>
+      <item>READS</item>
+      <item>REASSIGN</item>
+      <item>RECHECK</item>
+      <item>RECOVERY</item>
+      <item>RECURSIVE</item>
+      <item>REF</item>
+      <item>REFERENCES</item>
+      <item>REFERENCING</item>
+      <item>REFRESH</item>
+      <item>REGR_AVGX</item>
+      <item>REGR_AVGY</item>
+      <item>REGR_COUNT</item>
+      <item>REGR_INTERCEPT</item>
+      <item>REGR_R2</item>
+      <item>REGR_SLOPE</item>
+      <item>REGR_SXX</item>
+      <item>REGR_SXY</item>
+      <item>REGR_SYY</item>
+      <item>REINDEX</item>
+      <item>RELATIVE</item>
+      <item>RELEASE</item>
+      <item>RENAME</item>
+      <item>REPEATABLE</item>
+      <item>REPLICA</item>
+      <item>REQUIRING</item>
+      <item>RESET</item>
+      <item>RESPECT</item>
+      <item>RESTART</item>
+      <item>RESTORE</item>
+      <item>RESTRICT</item>
+      <item>RESULT</item>
+      <item>RETURNED_CARDINALITY</item>
+      <item>RETURNED_LENGTH</item>
+      <item>RETURNED_OCTET_LENGTH</item>
+      <item>RETURNED_SQLSTATE</item>
+      <item>RETURNING</item>
+      <item>RETURNS</item>
+      <item>REVOKE</item>
+      <item>RIGHT</item>
+      <item>ROLE</item>
+      <item>ROLLBACK</item>
+      <item>ROLLUP</item>
+      <item>ROUTINE</item>
+      <item>ROUTINE_CATALOG</item>
+      <item>ROUTINE_NAME</item>
+      <item>ROUTINE_SCHEMA</item>
+      <item>ROW</item>
+      <item>ROWS</item>
+      <item>ROW_COUNT</item>
+      <item>ROW_NUMBER</item>
+      <item>RULE</item>
+      <item>SAVEPOINT</item>
+      <item>SCALE</item>
+      <item>SCHEMA</item>
+      <item>SCHEMAS</item>
+      <item>SCHEMA_NAME</item>
+      <item>SCOPE</item>
+      <item>SCOPE_CATALOG</item>
+      <item>SCOPE_NAME</item>
+      <item>SCOPE_SCHEMA</item>
+      <item>SCROLL</item>
+      <item>SEARCH</item>
+      <item>SECOND</item>
+      <item>SECTION</item>
+      <item>SECURITY</item>
+      <item>SELECT</item>
+      <item>SELECTIVE</item>
+      <item>SELF</item>
+      <item>SENSITIVE</item>
+      <item>SEQUENCE</item>
+      <item>SEQUENCES</item>
+      <item>SERIALIZABLE</item>
+      <item>SERVER</item>
+      <item>SERVER_NAME</item>
+      <item>SESSION</item>
+      <item>SET</item>
+      <item>SETOF</item>
+      <item>SETS</item>
+      <item>SHARE</item>
+      <item>SHOW</item>
+      <item>SIMILAR</item>
+      <item>SIMPLE</item>
+      <item>SIZE</item>
+      <item>SKIP</item>
+      <item>SNAPSHOT</item>
+      <item>SOME</item>
+      <item>SOURCE</item>
+      <item>SPACE</item>
+      <item>SPECIFIC</item>
+      <item>SPECIFICTYPE</item>
+      <item>SPECIFIC_NAME</item>
+      <item>SQL</item>
+      <item>SQLCODE</item>
+      <item>SQLERROR</item>
+      <item>SQLEXCEPTION</item>
+      <item>SQLSTATE</item>
+      <item>SQLWARNING</item>
+      <item>STABLE</item>
+      <item>STANDALONE</item>
+      <item>START</item>
+      <item>STATE</item>
+      <item>STATEMENT</item>
+      <item>STATIC</item>
+      <item>STATISTICS</item>
+      <item>STDDEV_POP</item>
+      <item>STDDEV_SAMP</item>
+      <item>STDIN</item>
+      <item>STDOUT</item>
+      <item>STORAGE</item>
+      <item>STRICT</item>
+      <item>STRIP</item>
+      <item>STRUCTURE</item>
+      <item>STYLE</item>
+      <item>SUBCLASS_ORIGIN</item>
+      <item>SUBMULTISET</item>
+      <item>SUBSCRIPTION</item>
+      <item>SUBSTRING_REGEX</item>
+      <item>SUCCEEDS</item>
+      <item>SYMMETRIC</item>
+      <item>SYSID</item>
+      <item>SYSTEM</item>
+      <item>SYSTEM_TIME</item>
+      <item>SYSTEM_USER</item>
+      <item>T</item>
+      <item>TABLE</item>
+      <item>TABLES</item>
+      <item>TABLESAMPLE</item>
+      <item>TABLESPACE</item>
+      <item>TABLE_NAME</item>
+      <item>TEMP</item>
+      <item>TEMPLATE</item>
+      <item>TEMPORARY</item>
+      <item>TIES</item>
+      <item>TIMEZONE_HOUR</item>
+      <item>TIMEZONE_MINUTE</item>
+      <item>TO</item>
+      <item>TOKEN</item>
+      <item>TOP_LEVEL_COUNT</item>
+      <item>TRAILING</item>
+      <item>TRANSACTION</item>
+      <item>TRANSACTIONS_COMMITTED</item>
+      <item>TRANSACTIONS_ROLLED_BACK</item>
+      <item>TRANSACTION_ACTIVE</item>
+      <item>TRANSFORM</item>
+      <item>TRANSFORMS</item>
+      <item>TRANSLATE_REGEX</item>
+      <item>TRANSLATION</item>
+      <item>TREAT</item>
+      <item>TRIGGER</item>
+      <item>TRIGGER_CATALOG</item>
+      <item>TRIGGER_NAME</item>
+      <item>TRIGGER_SCHEMA</item>
+      <item>TRIM_ARRAY</item>
+      <item>TRUE</item>
+      <item>TRUNCATE</item>
+      <item>TRUSTED</item>
+      <item>TYPE</item>
+      <item>TYPES</item>
+      <item>UESCAPE</item>
+      <item>UNBOUNDED</item>
+      <item>UNCOMMITTED</item>
+      <item>UNDER</item>
+      <item>UNENCRYPTED</item>
+      <item>UNION</item>
+      <item>UNIQUE</item>
+      <item>UNKNOWN</item>
+      <item>UNLINK</item>
+      <item>UNLISTEN</item>
+      <item>UNLOGGED</item>
+      <item>UNNAMED</item>
+      <item>UNNEST</item>
+      <item>UNTIL</item>
+      <item>UNTYPED</item>
+      <item>UPDATE</item>
+      <item>URI</item>
+      <item>USAGE</item>
+      <item>USER</item>
+      <item>USER_DEFINED_TYPE_CATALOG</item>
+      <item>USER_DEFINED_TYPE_CODE</item>
+      <item>USER_DEFINED_TYPE_NAME</item>
+      <item>USER_DEFINED_TYPE_SCHEMA</item>
+      <item>USING</item>
+      <item>VACUUM</item>
+      <item>VALID</item>
+      <item>VALIDATE</item>
+      <item>VALIDATOR</item>
+      <item>VALUE</item>
+      <item>VALUES</item>
+      <item>VALUE_OF</item>
+      <item>VARBINARY</item>
+      <item>VARIADIC</item>
+      <item>VARYING</item>
+      <item>VAR_POP</item>
+      <item>VAR_SAMP</item>
+      <item>VERBOSE</item>
+      <item>VERSIONING</item>
+      <item>VIEW</item>
+      <item>VIEWS</item>
+      <item>VOLATILE</item>
+      <item>WHENEVER</item>
+      <item>WHERE</item>
+      <item>WHITESPACE</item>
+      <item>WINDOW</item>
+      <item>WITH</item>
+      <item>WITHIN</item>
+      <item>WITHOUT</item>
+      <item>WORK</item>
+      <item>WRAPPER</item>
+      <item>WRITE</item>
+      <item>XMLAGG</item>
+      <item>XMLATTRIBUTES</item>
+      <item>XMLBINARY</item>
+      <item>XMLCAST</item>
+      <item>XMLCOMMENT</item>
+      <item>XMLCONCAT</item>
+      <item>XMLDECLARATION</item>
+      <item>XMLDOCUMENT</item>
+      <item>XMLELEMENT</item>
+      <item>XMLEXISTS</item>
+      <item>XMLFOREST</item>
+      <item>XMLITERATE</item>
+      <item>XMLNAMESPACES</item>
+      <item>XMLPARSE</item>
+      <item>XMLPI</item>
+      <item>XMLQUERY</item>
+      <item>XMLROOT</item>
+      <item>XMLSCHEMA</item>
+      <item>XMLSERIALIZE</item>
+      <item>XMLTABLE</item>
+      <item>XMLTEXT</item>
+      <item>XMLVALIDATE</item>
+      <item>YEAR</item>
+      <item>YES</item>
+      <item>ZONE</item>
+    </list>
+    <list name="functions">
+      <!-- math -->
+      <item>ABS</item>
+      <item>CBRT</item>
+      <item>CEIL</item>
+      <item>CEILING</item>
+      <item>DEGREES</item>
+      <item>EXP</item>
+      <item>FLOOR</item>
+      <item>LN</item>
+      <item>LOG</item>
+      <item>MOD</item>
+      <item>PI</item>
+      <item>POW</item>
+      <item>POWER</item>
+      <item>RADIANS</item>
+      <item>RANDOM</item>
+      <item>ROUND</item>
+      <item>SETSEED</item>
+      <item>SIGN</item>
+      <item>SQRT</item>
+      <item>TRUNC</item>
+      <item>WIDTH_BUCKET</item>
+      <!-- trig -->
+      <item>ACOS</item>
+      <item>ASIN</item>
+      <item>ATAN</item>
+      <item>ATAN2</item>
+      <item>COS</item>
+      <item>COT</item>
+      <item>SIN</item>
+      <item>TAN</item>
+      <!-- string -->
+      <item>BIT_LENGTH</item>
+      <item>CHAR_LENGTH</item>
+      <item>CHARACTER_LENGTH</item>
+      <item>CONCAT</item>
+      <item>CONCAT_WS</item>
+      <item>CONVERT</item>
+      <item>GET_BYTE</item>
+      <item>GET_BIT</item>
+      <item>LOWER</item>
+      <item>OCTET_LENGTH</item>
+      <item>OVERLAY</item>
+      <item>POSITION</item>
+      <item>SET_BIT</item>
+      <item>SUBSTRING</item>
+      <item>TRIM</item>
+      <item>UPPER</item>
+      <!-- other string -->
+      <item>ASCII</item>
+      <item>BTRIM</item>
+      <item>CHR</item>
+      <item>DECODE</item>
+      <item>ENCODE</item>
+      <item>INITCAP</item>
+      <item>LENGTH</item>
+      <item>LPAD</item>
+      <item>LTRIM</item>
+      <item>MD5</item>
+      <item>PG_CLIENT_ENCODING</item>
+      <item>QUOTE_IDENT</item>
+      <item>QUOTE_LITERAL</item>
+      <item>REGEXP_REPLACE</item>
+      <item>REPEAT</item>
+      <item>REPLACE</item>
+      <item>RPAD</item>
+      <item>RTRIM</item>
+      <item>SPLIT_PART</item>
+      <item>STRPOS</item>
+      <item>SUBSTR</item>
+      <item>TO_ASCII</item>
+      <item>TO_HEX</item>
+      <item>TRANSLATE</item>
+      <!-- data type formatting -->
+      <item>TO_CHAR</item>
+      <item>TO_DATE</item>
+      <item>TO_TIMESTAMP</item>
+      <item>TO_NUMBER</item>
+      <!-- date/time -->
+      <item>AGE</item>
+      <item>DATE_PART</item>
+      <item>DATE_TRUNC</item>
+      <item>EXTRACT</item>
+      <item>ISFINITE</item>
+      <item>JUSTIFY_HOURS</item>
+      <item>JUSTIFY_DAYS</item>
+      <item>NOW</item>
+      <item>TIMEOFDAY</item>
+      <item>TIMESTAMP</item>
+      <!-- geometric -->
+      <item>AREA</item>
+      <item>CENTER</item>
+      <item>DIAMETER</item>
+      <item>HEIGHT</item>
+      <item>ISCLOSED</item>
+      <item>ISOPEN</item>
+      <item>NPOINTS</item>
+      <item>PCLOSE</item>
+      <item>POPEN</item>
+      <item>RADIUS</item>
+      <item>WIDTH</item>
+      <!-- geometric type conversion -->
+      <item>BOX</item>
+      <item>CIRCLE</item>
+      <item>LSEG</item>
+      <item>PATH</item>
+      <item>POINT</item>
+      <item>POLYGON</item>
+      <!-- array -->
+      <item>ARRAY_CAT</item>
+      <item>ARRAY_APPEND</item>
+      <item>ARRAY_PREPEND</item>
+      <item>ARRAY_DIMS</item>
+      <item>ARRAY_LOWER</item>
+      <item>ARRAY_UPPER</item>
+      <item>ARRAY_TO_STRING</item>
+      <item>STRING_TO_ARRAY</item>
+      <!-- network address type, TEXT is omitted as it is more commonly a data type -->
+      <item>BROADCAST</item>
+      <item>HOST</item>
+      <item>MASKLEN</item>
+      <item>SET_MASKLEN</item>
+      <item>NETMASK</item>
+      <item>HOSTMASK</item>
+      <item>NETWORK</item>
+      <item>TEXT</item>
+      <item>ABBREV</item>
+      <item>FAMILY</item>
+      <!-- sequence manipulation -->
+      <item>NEXTVAL</item>
+      <item>CURRVAL</item>
+      <item>LASTVAL</item>
+      <item>SETVAL</item>
+      <!-- conditional expressions -->
+      <item>COALESCE</item>
+      <item>NULLIF</item>
+      <!-- aggregate -->
+      <item>AVG</item>
+      <item>BIT_AND</item>
+      <item>BIT_OR</item>
+      <item>BOOL_AND</item>
+      <item>BOOL_OR</item>
+      <item>COUNT</item>
+      <item>EVERY</item>
+      <item>MAX</item>
+      <item>MIN</item>
+      <item>STDDEV</item>
+      <item>SUM</item>
+      <item>VARIANCE</item>
+      <!-- series generating -->
+      <item>GENERATE_SERIES</item>
+      <!-- system information -->
+      <item>CURRENT_DATABASE</item>
+      <item>CURRENT_SCHEMA</item>
+      <item>CURRENT_SCHEMAS</item>
+      <item>CURRENT_USER</item>
+      <item>INET_CLIENT_ADDR</item>
+      <item>INET_CLIENT_PORT</item>
+      <item>INET_SERVER_ADDR</item>
+      <item>INET_SERVER_PORT</item>
+      <item>SESSION_USER</item>
+      <item>PG_POSTMASTER_START_TIME</item>
+      <item>VERSION</item>
+      <!-- access privilege inquiry  -->
+      <item>HAS_TABLE_PRIVILEGE</item>
+      <item>HAS_DATABASE_PRIVILEGE</item>
+      <item>HAS_FUNCTION_PRIVILEGE</item>
+      <item>HAS_LANGUAGE_PRIVILEGE</item>
+      <item>PG_HAS_ROLE</item>
+      <item>HAS_SCHEMA_PRIVILEGE</item>
+      <item>HAS_TABLESPACE_PRIVILEGE</item>
+      <!--  schema visibility inquiry -->
+      <item>PG_TABLE_IS_VISIBLE</item>
+      <item>PG_TYPE_IS_VISIBLE</item>
+      <item>PG_FUNCTION_IS_VISIBLE</item>
+      <item>PG_OPERATOR_IS_VISIBLE</item>
+      <item>PG_OPCLASS_IS_VISIBLE</item>
+      <item>PG_CONVERSION_IS_VISIBLE</item>
+      <!-- system catalog information -->
+      <item>FORMAT_TYPE</item>
+      <item>PG_GET_CONSTRAINTDEF</item>
+      <item>PG_GET_EXPR</item>
+      <item>PG_GET_INDEXDEF</item>
+      <item>PG_GET_RULEDEF</item>
+      <item>PG_GET_SERIAL_SEQUENCE</item>
+      <item>PG_TABLESPACE_DATABASES</item>
+      <item>PG_GET_TRIGGERDEF</item>
+      <item>PG_GET_USERBYID</item>
+      <item>PG_GET_VIEWDEF</item>
+      <!-- comment information -->
+      <item>OBJ_DESCRIPTION</item>
+      <item>COL_DESCRIPTION</item>
+      <!-- configuration settings -->
+      <item>CURRENT_SETTING</item>
+      <item>SET_CONFIG</item>
+      <!-- server signalling -->
+      <item>PG_CANCEL_BACKEND</item>
+      <item>PG_RELOAD_CONF</item>
+      <item>PG_ROTATE_LOGFILE</item>
+      <!-- backup control -->
+      <item>PG_START_BACKUP</item>
+      <item>PG_STOP_BACKUP</item>
+      <!-- database object Sizes-->
+      <item>PG_COLUMN_SIZE</item>
+      <item>PG_TABLESPACE_SIZE</item>
+      <item>PG_DATABASE_SIZE</item>
+      <item>PG_RELATION_SIZE</item>
+      <item>PG_TOTAL_RELATION_SIZE</item>
+      <item>PG_SIZE_PRETTY</item>
+      <!-- generic file access -->
+      <item>PG_LS_DIR</item>
+      <item>PG_READ_FILE</item>
+      <item>PG_STAT_FILE</item>
+    </list>
+    <list name="postgisFunctions">
+      <!-- From https://postgis.net/docs/PostGIS_Special_Functions_Index.html#PostGIS_TypeFunctionMatrix at 2022-09-16 19:15 GMT -->
+      <item>Box2D</item>
+      <item>Box3D</item>
+      <item>GeometryType</item>
+      <item>PostGIS_AddBBox</item>
+      <item>PostGIS_DropBBox</item>
+      <item>PostGIS_Extensions_Upgrade</item>
+      <item>PostGIS_Full_Version</item>
+      <item>PostGIS_GEOS_Version</item>
+      <item>PostGIS_HasBBox</item>
+      <item>PostGIS_LibXML_Version</item>
+      <item>PostGIS_Lib_Build_Date</item>
+      <item>PostGIS_Lib_Version</item>
+      <item>PostGIS_Liblwgeom_Version</item>
+      <item>PostGIS_PROJ_Version</item>
+      <item>PostGIS_Scripts_Build_Date</item>
+      <item>PostGIS_Scripts_Installed</item>
+      <item>PostGIS_Scripts_Released</item>
+      <item>PostGIS_Version</item>
+      <item>PostGIS_Wagyu_Version</item>
+      <item>ST_3DArea</item>
+      <item>ST_3DClosestPoint</item>
+      <item>ST_3DConvexHull</item>
+      <item>ST_3DDifference</item>
+      <item>ST_3DDistance</item>
+      <item>ST_3DExtent</item>
+      <item>ST_3DIntersection</item>
+      <item>ST_3DLength</item>
+      <item>ST_3DLineInterpolatePoint</item>
+      <item>ST_3DLongestLine</item>
+      <item>ST_3DMakeBox</item>
+      <item>ST_3DMaxDistance</item>
+      <item>ST_3DPerimeter</item>
+      <item>ST_3DShortestLine</item>
+      <item>ST_3DUnion</item>
+      <item>ST_AddMeasure</item>
+      <item>ST_AddPoint</item>
+      <item>ST_Affine</item>
+      <item>ST_AlphaShape</item>
+      <item>ST_Angle</item>
+      <item>ST_ApproximateMedialAxis</item>
+      <item>ST_Area</item>
+      <item>ST_Azimuth</item>
+      <item>ST_Boundary</item>
+      <item>ST_BoundingDiagonal</item>
+      <item>ST_Buffer</item>
+      <item>ST_BuildArea</item>
+      <item>ST_CPAWithin</item>
+      <item>ST_Centroid</item>
+      <item>ST_ChaikinSmoothing</item>
+      <item>ST_ClipByBox2D</item>
+      <item>ST_ClosestPoint</item>
+      <item>ST_ClosestPointOfApproach</item>
+      <item>ST_ClusterDBSCAN</item>
+      <item>ST_ClusterIntersecting</item>
+      <item>ST_ClusterKMeans</item>
+      <item>ST_ClusterWithin</item>
+      <item>ST_Collect</item>
+      <item>ST_CollectionExtract</item>
+      <item>ST_CollectionHomogenize</item>
+      <item>ST_ConcaveHull</item>
+      <item>ST_ConstrainedDelaunayTriangles</item>
+      <item>ST_ConvexHull</item>
+      <item>ST_CoordDim</item>
+      <item>ST_CurveToLine</item>
+      <item>ST_DelaunayTriangles</item>
+      <item>ST_Difference</item>
+      <item>ST_Dimension</item>
+      <item>ST_Distance</item>
+      <item>ST_DistanceCPA</item>
+      <item>ST_DistanceSphere</item>
+      <item>ST_DistanceSpheroid</item>
+      <item>ST_Dump</item>
+      <item>ST_DumpPoints</item>
+      <item>ST_DumpRings</item>
+      <item>ST_DumpSegments</item>
+      <item>ST_EndPoint</item>
+      <item>ST_Envelope</item>
+      <item>ST_EstimatedExtent</item>
+      <item>ST_Expand</item>
+      <item>ST_Extent</item>
+      <item>ST_ExteriorRing</item>
+      <item>ST_Extrude</item>
+      <item>ST_FilterByM</item>
+      <item>ST_FlipCoordinates</item>
+      <item>ST_Force2D</item>
+      <item>ST_ForceCurve</item>
+      <item>ST_ForceLHR</item>
+      <item>ST_ForcePolygonCCW</item>
+      <item>ST_ForcePolygonCW</item>
+      <item>ST_ForceRHR</item>
+      <item>ST_ForceSFS</item>
+      <item>ST_Force3D</item>
+      <item>ST_Force3DM</item>
+      <item>ST_Force3DZ</item>
+      <item>ST_Force4D</item>
+      <item>ST_ForceCollection</item>
+      <item>ST_FrechetDistance</item>
+      <item>ST_GeneratePoints</item>
+      <item>ST_GeometricMedian</item>
+      <item>ST_GeometryN</item>
+      <item>ST_GeometryType</item>
+      <item>ST_HasArc</item>
+      <item>ST_HausdorffDistance</item>
+      <item>ST_Hexagon</item>
+      <item>ST_HexagonGrid</item>
+      <item>ST_InteriorRingN</item>
+      <item>ST_InterpolatePoint</item>
+      <item>ST_Intersection</item>
+      <item>ST_IsClosed</item>
+      <item>ST_IsCollection</item>
+      <item>ST_IsEmpty</item>
+      <item>ST_IsPlanar</item>
+      <item>ST_IsPolygonCCW</item>
+      <item>ST_IsPolygonCW</item>
+      <item>ST_IsRing</item>
+      <item>ST_IsSimple</item>
+      <item>ST_IsSolid</item>
+      <item>ST_IsValid</item>
+      <item>ST_IsValidDetail</item>
+      <item>ST_IsValidReason</item>
+      <item>ST_IsValidTrajectory</item>
+      <item>ST_Length</item>
+      <item>ST_Length2D</item>
+      <item>ST_LengthSpheroid</item>
+      <item>ST_Letters</item>
+      <item>ST_LineFromMultiPoint</item>
+      <item>ST_LineInterpolatePoint</item>
+      <item>ST_LineInterpolatePoints</item>
+      <item>ST_LineLocatePoint</item>
+      <item>ST_LineMerge</item>
+      <item>ST_LineSubstring</item>
+      <item>ST_LineToCurve</item>
+      <item>ST_LocateAlong</item>
+      <item>ST_LocateBetween</item>
+      <item>ST_LocateBetweenElevations</item>
+      <item>ST_LongestLine</item>
+      <item>ST_M</item>
+      <item>ST_MakeBox2D</item>
+      <item>ST_MakeEnvelope</item>
+      <item>ST_MakeLine</item>
+      <item>ST_MakePoint</item>
+      <item>ST_MakePointM</item>
+      <item>ST_MakePolygon</item>
+      <item>ST_MakeSolid</item>
+      <item>ST_MakeValid</item>
+      <item>ST_MaxDistance</item>
+      <item>ST_MaximumInscribedCircle</item>
+      <item>ST_MemSize</item>
+      <item>ST_MemUnion</item>
+      <item>ST_MinimumBoundingCircle</item>
+      <item>ST_MinimumBoundingRadius</item>
+      <item>ST_MinimumClearance</item>
+      <item>ST_MinimumClearanceLine</item>
+      <item>ST_MinkowskiSum</item>
+      <item>ST_Multi</item>
+      <item>ST_NDims</item>
+      <item>ST_NPoints</item>
+      <item>ST_NRings</item>
+      <item>ST_Node</item>
+      <item>ST_Normalize</item>
+      <item>ST_NumGeometries</item>
+      <item>ST_NumInteriorRing</item>
+      <item>ST_NumInteriorRings</item>
+      <item>ST_NumPatches</item>
+      <item>ST_NumPoints</item>
+      <item>ST_OffsetCurve</item>
+      <item>ST_OptimalAlphaShape</item>
+      <item>ST_Orientation</item>
+      <item>ST_OrientedEnvelope</item>
+      <item>ST_PatchN</item>
+      <item>ST_Perimeter</item>
+      <item>ST_Perimeter2D</item>
+      <item>ST_Point</item>
+      <item>ST_PointM</item>
+      <item>ST_PointN</item>
+      <item>ST_PointOnSurface</item>
+      <item>ST_PointZ</item>
+      <item>ST_PointZM</item>
+      <item>ST_Points</item>
+      <item>ST_Polygon</item>
+      <item>ST_Polygonize</item>
+      <item>ST_Project</item>
+      <item>ST_QuantizeCoordinates</item>
+      <item>ST_ReducePrecision</item>
+      <item>ST_RemovePoint</item>
+      <item>ST_RemoveRepeatedPoints</item>
+      <item>ST_Reverse</item>
+      <item>ST_Rotate</item>
+      <item>ST_RotateX</item>
+      <item>ST_RotateY</item>
+      <item>ST_RotateZ</item>
+      <item>ST_SRID</item>
+      <item>ST_Scale</item>
+      <item>ST_Scroll</item>
+      <item>ST_Segmentize</item>
+      <item>ST_SetEffectiveArea</item>
+      <item>ST_SetPoint</item>
+      <item>ST_SetSRID</item>
+      <item>ST_SharedPaths</item>
+      <item>ST_ShiftLongitude</item>
+      <item>ST_ShortestLine</item>
+      <item>ST_Simplify</item>
+      <item>ST_SimplifyPolygonHull</item>
+      <item>ST_SimplifyPreserveTopology</item>
+      <item>ST_SimplifyVW</item>
+      <item>ST_Snap</item>
+      <item>ST_SnapToGrid</item>
+      <item>ST_Split</item>
+      <item>ST_Square</item>
+      <item>ST_SquareGrid</item>
+      <item>ST_StartPoint</item>
+      <item>ST_StraightSkeleton</item>
+      <item>ST_Subdivide</item>
+      <item>ST_Summary</item>
+      <item>ST_SwapOrdinates</item>
+      <item>ST_SymDifference</item>
+      <item>ST_Tesselate</item>
+      <item>ST_TileEnvelope</item>
+      <item>ST_TransScale</item>
+      <item>ST_Transform</item>
+      <item>ST_Translate</item>
+      <item>ST_TriangulatePolygon</item>
+      <item>ST_UnaryUnion</item>
+      <item>ST_Union</item>
+      <item>ST_Volume</item>
+      <item>ST_VoronoiLines</item>
+      <item>ST_VoronoiPolygons</item>
+      <item>ST_WrapX</item>
+      <item>ST_X</item>
+      <item>ST_XMax</item>
+      <item>ST_XMin</item>
+      <item>ST_Y</item>
+      <item>ST_YMax</item>
+      <item>ST_YMin</item>
+      <item>ST_Z</item>
+      <item>ST_ZMax</item>
+      <item>ST_ZMin</item>
+      <item>ST_Zmflag</item>
+      <!--<item>postgis.backend</item>--><!-- Commenting out because inner dot is incompatible with the keyword delimiters. -->
+      <!--<item>postgis.enable_outdb_rasters</item>--><!-- Commenting out because inner dot is incompatible with the keyword delimiters. -->
+      <!--<item>postgis.gdal_datapath</item>--><!-- Commenting out because inner dot is incompatible with the keyword delimiters. -->
+      <!--<item>postgis.gdal_enabled_drivers</item>--><!-- Commenting out because inner dot is incompatible with the keyword delimiters. -->
+      <!--<item>postgis.gdal_config_options</item>--><!-- Commenting out because inner dot is incompatible with the keyword delimiters. -->
+      <item>postgis_sfcgal_full_version</item>
+      <item>postgis_sfcgal_version</item>
+
+      <!-- Further functions from https://postgis.net/docs/PostGIS_Special_Functions_Index.html -->
+      <item>ST_DWithin</item>
+    </list>
+    <list name="types">
+      <!-- https://www.postgresql.org/docs/current/static/datatype.html#DATATYPE-TABLE -->
+      <item>BIGINT</item>
+      <item>BIGSERIAL</item>
+      <item>BIT</item>
+      <item>BOOL</item>
+      <item>BOOLEAN</item>
+      <item>BOX</item>
+      <item>BYTEA</item>
+      <item>CHAR</item>
+      <item>CHARACTER</item>
+      <item>CIDR</item>
+      <item>CIRCLE</item>
+      <item>DATE</item>
+      <item>DECIMAL</item>
+      <item>DOUBLE</item>
+      <item>FLOAT4</item>
+      <item>FLOAT8</item>
+      <item>INET</item>
+      <item>INT</item>
+      <item>INT2</item>
+      <item>INT4</item>
+      <item>INT8</item>
+      <item>INTEGER</item>
+      <item>INTERVAL</item>
+      <item>JSON</item>
+      <item>JSONB</item>
+      <item>LINE</item>
+      <item>LSEG</item>
+      <item>MACADDR</item>
+      <item>MACADDR8</item>
+      <item>MONEY</item>
+      <item>NUMERIC</item>
+      <item>PATH</item>
+      <item>PG_LSN</item>
+      <item>POINT</item>
+      <item>POLYGON</item>
+      <item>REAL</item>
+      <item>SERIAL</item>
+      <item>SERIAL2</item>
+      <item>SERIAL4</item>
+      <item>SERIAL8</item>
+      <item>SMALLINT</item>
+      <item>SMALLSERIAL</item>
+      <item>TEXT</item>
+      <item>TIME</item>
+      <item>TIMESTAMP</item>
+      <item>TIMESTAMPTZ</item>
+      <item>TIMETZ</item>
+      <item>TSQUERY</item>
+      <item>TSVECTOR</item>
+      <item>TXID_SNAPSHOT</item>
+      <item>UUID</item>
+      <item>VARBIT</item>
+      <item>VARCHAR</item>
+      <item>XML</item>
+    </list>
+    <contexts>
+      <context name="Normal" attribute="Normal Text" lineEndContext="#stay">
+
+        <!-- comments before operators -->
+        <Detect2Chars attribute="Comment" context="SingleLineComment" char="-" char1="-"/>
+        <Detect2Chars attribute="Comment" context="MultiLineComment" char="/" char1="*" beginRegion="Comment"/>
+        <WordDetect attribute="Comment" context="SingleLineComment" String="rem" insensitive="true" column="0"/>
+
+        <!-- HACK: don't jump into DollarQuotedString for CREATE FUNCTION $funcName$...$funcName$ -->
+        <RegExpr String="create\s+(or\s+replace\s+)?function" insensitive="true" context="CreateFunction" attribute="Keyword"/>
+
+        <RegExpr String="do\s+\$([^\$\n\r]*)\$" insensitive="true" context="FunctionBody" attribute="Keyword"/>
+        <LineContinue attribute="Symbol" context="#stay" char="/" column="0"/>
+        <keyword attribute="Keyword" context="#stay" String="keywords"/>
+        <keyword attribute="Operator Keyword" context="#stay" String="operators"/>
+        <keyword attribute="ControlFlow" context="#stay" String="controlFlow"/>
+        <keyword attribute="Data Type" context="#stay" String="types"/>
+        <RegExpr attribute="Data Type" context="#stay" String="%(bulk_(exceptions|rowcount)|(not)?found|isopen|rowcount|(row)?type)\b" insensitive="true"/>
+        <!-- Highlight the names of functions when they are followed by a “(” character.
+        NOTE Some names are both, function names and data type names. Currently:
+        BOX|CIRCLE|LSEG|PATH|POINT|POLYGON|TEXT|TIMESTAMPTZ Those are always
+        catched by the above rule as data types. Highlighting them differently when
+        used as function would be tricky… -->
+        <RegExpr context="HighlightFunction" String="(?&lt;=\b)&functionName;(?=[\t ]*\()" lookAhead="true" insensitive="true"/>
+        <Float attribute="Float" context="#stay"/>
+        <Int attribute="Decimal" context="#stay"/>
+        <DetectChar attribute="Verbatim string" context="SingleQuotedString" char="'"/>
+        <Detect2Chars attribute="String delimiter" context="EscapeString" char='e' char1="'"/>
+        <Detect2Chars attribute="String delimiter" context="EscapeString" char='E' char1="'"/>
+        <!-- Supports Unicode Escape String with user-defined escape character. Example:
+             u&'y+000065' UESCAPE  'y'
+             The user-defined escape character is available to dynamic rules as capture-group 1.
+             NOTE As KSyntaxHighlighing is line-based, this highlighting rule works only if all the
+             above code is within the same line (though Postgre allows it to be on different lines). -->
+        <RegExpr attribute="String delimiter" context="UnicodeEscapeStringModified" String="U&amp;'(?=(?:[^']|'')*'[ \t]*UESCAPE[ \t]*'([^0-9a-fA-F+'&quot; \t])')" insensitive="true"/>
+        <StringDetect attribute="String delimiter" context="UnicodeEscapeString" String="U&amp;'" insensitive="true"/>
+        <DetectChar attribute="Identifier" context="Identifier" char="&quot;"/>
+        <!-- Supports Unicode Escape Identifiers with user-defined escape character. Example:
+             u&"y+000065" UESCAPE  'y'
+             The user-defined escape character is available to dynamic rules as capture-group 1.
+             NOTE As KSyntaxHighlighing is line-based, this highlighting rule works only if all the
+             above code is within the same line (though Postgre allows it to be on different lines). -->
+        <RegExpr attribute="Identifier" context="UnicodeEscapeIdentifierModified" String="U&amp;&quot;(?=(?:[^&quot;]|&quot;&quot;)*&quot;[ \t]*UESCAPE[ \t]*'([^0-9a-fA-F+'&quot; \t])')" insensitive="true"/>
+        <StringDetect attribute="Identifier" context="UnicodeEscapeIdentifier" String="U&amp;&quot;" insensitive="true"/>
+        <Detect2Chars attribute="Operator" context="#stay" char=":" char1="="/>
+        <AnyChar attribute="Symbol" context="#stay" String=":&amp;"/>
+        <Detect2Chars attribute="Operator" context="#stay" char="." char1="."/>
+        <!-- geometric operators -->
+        <Detect2Chars attribute="Operator" context="#stay" char="?" char1="#"/>
+        <Detect2Chars attribute="Operator" context="#stay" char="?" char1="-"/>
+        <Detect2Chars attribute="Operator" context="#stay" char="?" char1="|"/>
+        <RegExpr attribute="Preprocessor" context="Preprocessor" String="^@@?[^@ \t\r\n]" column="0"/>
+        <RegExpr attribute="Operator" context="DollarQuotedString" String="\$([^\$\n\r]*)\$"/>
+        <AnyChar attribute="Operator" context="#stay" String="+-*/=%^!&lt;&gt;&amp;|@~#"/>
+      </context>
+      <context attribute="Normal Text" name="HighlightFunction" fallthrough="true" fallthroughContext="#pop" lineEndContext="#pop">
+        <!-- Helper context that expects to see a function on its very beginning.
+        If it’s a PostgreSQL or PostGIS function, it is highlighted accordingly.
+        If not, by a catch-all, it gets the "Normal Text" attribute. After that,
+        it pops back to the previous context. -->
+        <keyword attribute="PostgreSQL function" context="#pop" String="functions"/>
+        <keyword attribute="PostGIS function" context="#pop" String="postgisFunctions"/>
+        <!-- Highlight user-defined functions like "Normal Text". It is not
+        possible to have an own style for this, because the syntax is
+        difficult and we could catch here strings that are not actual
+        user-defined functions. "Normal Text" is a safe alternative. Using
+        &functionName; which is the same regular expression that is used
+        by the rule that calls this context: -->
+        <RegExpr attribute="Normal Text" context="#pop" String="&functionName;" insensitive="true"/>
+      </context>
+      <context name="CreateFunction" attribute="Normal Text" lineEndContext="#stay">
+        <RegExpr attribute="Function" context="FunctionBody" String="\$([^\$\n\r]*)\$"/>
+        <IncludeRules context="Normal"/>
+      </context>
+      <context name="FunctionBody" attribute="Normal Text" lineEndContext="#stay" dynamic="true">
+        <StringDetect attribute="Function" context="#pop#pop" String="$%1$" dynamic="true"/>
+        <IncludeRules context="Normal"/>
+      </context>
+      <context name="SingleQuotedString" attribute="Verbatim string" lineEndContext="#stay">
+        <Detect2Chars attribute="Escape sequence" context="#stay" char="'" char1="'"/>
+        <DetectChar attribute="String delimiter" context="#pop" char="'"/>
+      </context>
+      <context name="DollarQuotedString" attribute="Verbatim string" lineEndContext="#stay" dynamic="true">
+        <StringDetect attribute="Operator" context="#pop" String="$%1$" dynamic="true"/>
+      </context>
+      <context name="EscapeString" attribute="String" lineEndContext="#stay">
+        <Detect2Chars attribute="Escape sequence" context="#stay" char="'" char1="'"/>
+        <!-- Default C style escapes: \n \101 \x41 … : -->
+        <HlCStringChar attribute="Escape sequence" context="#stay"/>
+        <!-- \u escapes: -->
+        <RegExpr attribute="Escape sequence" context="#stay" String="\\u&hexDigit;{4}"/>
+        <!-- Incomplete \u escape sequences are errors: -->
+        <Detect2Chars attribute="Error" context="#stay" char="\" char1="u"/>
+        <!-- \U escapes: -->
+        <RegExpr attribute="Escape sequence" context="#stay" String="\\U&hexDigit;{8}"/>
+        <!-- Incomplete \U escape sequences are errors: -->
+        <Detect2Chars attribute="Error" context="#stay" char="\" char1="U"/>
+        <!-- All other escape sequences are interpreted as escape of the concerned character: \y → y -->
+        <RegExpr attribute="Escape sequence" context="#stay" String="\\."/>
+        <!-- Even an escape sequence with the line break (means: backslash as last character of a line) is possible: -->
+        <LineContinue attribute="Escape sequence" context="#stay" char="\"/>
+        <!-- end of the string -->
+        <DetectChar attribute="String delimiter" context="#pop" char="'"/>
+      </context>
+      <context attribute="Normal Text" name="IncludeUnicodeEscapeSequences" lineEndContext="#pop">
+        <!-- four-digit/six-digit escapes: -->
+        <RegExpr attribute="Escape sequence" context="#stay" String="(\\&hexDigit;{4})|(\\\+&hexDigit;{6})"/>
+        <!-- \\ is a valid escape for the backslash: -->
+        <Detect2Chars attribute="Escape sequence" context="#stay" char="\" char1="\"/>
+        <!-- All other occurences of \ are errors: -->
+        <DetectChar attribute="Error" context="#stay" char="\"/>
+      </context>
+      <context attribute="Normal Text" name="IncludeUnicodeEscapeSequencesModified" lineEndContext="#pop">
+        <!-- Context meant to be included in other contexts, not to be used on its own.
+             Containt dynamic rules. Expects that the escape character is available
+             at capture group #1.
+             NOTE The capture group expands literally for the StringDetect and DetectChar
+             rules. For the RegExpr rule, special characters (and only special characters)
+             seem to become escaped automatically: The capture “.” is available as “\.”
+             while the capture “t” is available as “t” (and not as “\t” which would mean a
+             tabulator character). So this works fine out-of-the-box even for special
+             characters.-->
+        <!-- four-digit/six-digit escapes: -->
+        <RegExpr attribute="Escape sequence" context="#stay" String="(%1&hexDigit;{4})|(%1\+&hexDigit;{6})" dynamic="true"/>
+        <!-- The escape character can escape himself: -->
+        <StringDetect attribute="Escape sequence" context="#stay" String="%1%1" dynamic="true"/>
+        <!-- All other occurences of \ are errors: -->
+        <DetectChar attribute="Error" context="#stay" char="1" dynamic="true"/>
+      </context>
+      <context name="UnicodeEscapeString" attribute="String" lineEndContext="#stay">
+        <Detect2Chars attribute="Escape sequence" context="#stay" char="'" char1="'"/>
+        <IncludeRules context="IncludeUnicodeEscapeSequences" />
+        <!-- end of the string -->
+        <DetectChar attribute="String delimiter" context="#pop" char="'"/>
+      </context>
+      <context name="UnicodeEscapeStringModified" attribute="String" lineEndContext="#stay">
+        <Detect2Chars attribute="Escape sequence" context="#stay" char="'" char1="'"/>
+        <IncludeRules context="IncludeUnicodeEscapeSequencesModified" />
+        <!-- end of the string -->
+        <DetectChar attribute="String delimiter" context="#pop" char="'"/>
+      </context>
+      <context name="SingleLineComment" attribute="Comment" lineEndContext="#pop">
+        <DetectSpaces />
+        <IncludeRules context="##Comments"/>
+      </context>
+      <context name="MultiLineComment" attribute="Comment" lineEndContext="#stay">
+        <LineContinue attribute="Comment" context="#pop"/>
+        <DetectSpaces />
+        <Detect2Chars attribute="Comment" context="#pop" char="*" char1="/" endRegion="Comment"/>
+        <Detect2Chars attribute="Comment" context="MultiLineComment" char="/" char1="*" beginRegion="Comment"/>
+        <IncludeRules context="##Comments"/>
+      </context>
+      <context name="Identifier" attribute="Identifier" lineEndContext="#stay">
+        <Detect2Chars attribute="Escape sequence" context="#stay" char="&quot;" char1="&quot;"/>
+        <DetectChar attribute="Identifier" context="#pop" char="&quot;"/>
+      </context>
+      <context name="UnicodeEscapeIdentifier" attribute="Identifier" lineEndContext="#stay">
+        <Detect2Chars attribute="Escape sequence" context="#stay" char="&quot;" char1="&quot;"/>
+        <IncludeRules context="IncludeUnicodeEscapeSequences" />
+        <!-- end of the string -->
+        <DetectChar attribute="Identifier" context="#pop" char="&quot;"/>
+      </context>
+      <context name="UnicodeEscapeIdentifierModified" attribute="Identifier" lineEndContext="#stay">
+        <Detect2Chars attribute="Escape sequence" context="#stay" char="&quot;" char1="&quot;"/>
+        <IncludeRules context="IncludeUnicodeEscapeSequencesModified" />
+        <!-- end of the string -->
+        <DetectChar attribute="Identifier" context="#pop" char="&quot;"/>
+      </context>
+      <context name="Preprocessor" attribute="Preprocessor" lineEndContext="#pop"/>
+    </contexts>
+    <itemDatas>
+      <itemData name="Normal Text"         defStyleNum="dsNormal"      spellChecking="false"/>
+      <itemData name="Keyword"             defStyleNum="dsKeyword"     spellChecking="false"/>
+      <itemData name="ControlFlow"         defStyleNum="dsControlFlow" spellChecking="false"/>
+      <itemData name="Operator"            defStyleNum="dsOperator"    spellChecking="false"/>
+      <itemData name="Operator Keyword"    defStyleNum="dsKeyword"     spellChecking="false"/>
+      <itemData name="Function"            defStyleNum="dsFunction"    spellChecking="false"/>
+      <itemData name="PostgreSQL function" defStyleNum="dsFunction"    spellChecking="false"/>
+      <itemData name="PostGIS function"    defStyleNum="dsExtension"   spellChecking="false"/>
+      <itemData name="Data Type"           defStyleNum="dsDataType"    spellChecking="false"/>
+      <itemData name="Decimal"             defStyleNum="dsDecVal"      spellChecking="false"/>
+      <itemData name="Float"               defStyleNum="dsFloat"       spellChecking="false"/>
+      <itemData name="String"              defStyleNum="dsString"/>
+      <!-- The only purpose of "String delimiter" is correct spell checking. If we would use
+           "String" also for the delimiters, code like E'test' would generate spell checking
+           errors because the E is considered part of the word that will be checked. -->
+      <itemData name="String delimiter"    defStyleNum="dsString"      spellChecking="false"/>
+      <itemData name="Verbatim string"     defStyleNum="dsVerbatimString"/>
+      <itemData name="Escape sequence"     defStyleNum="dsChar"        spellChecking="false"/>
+      <itemData name="Comment"             defStyleNum="dsComment"/>
+      <itemData name="Identifier"          defStyleNum="dsOthers"      spellChecking="false"/>
+      <itemData name="Symbol"              defStyleNum="dsChar"        spellChecking="false"/>
+      <itemData name="Preprocessor"        defStyleNum="dsOthers"      spellChecking="false"/>
+      <itemData name="Error"               defStyleNum="dsError"       spellChecking="false"/>
+    </itemDatas>
+  </highlighting>
+  <general>
+    <comments>
+      <comment name="singleLine" start="--" position="afterwhitespace"/>
+      <comment name="multiLine" start="/*" end="*/" region="Comment"/>
+    </comments>
+    <keywords casesensitive="0"/>
+  </general>
+</language>
+<!-- kate: replace-tabs on; tab-width 2; indent-width 2; -->


### PR DESCRIPTION
This PR implements what the title says using Pandoc's custom syntax highlighting mechanism that accepts an XML file with the keywords: https://pandoc.org/chunkedhtml-demo/13-syntax-highlighting.html

Our XML is currently a copy of the Postgres syntax (with only the name/some comments changed). Later, this should be updated to match the complete set of keywords (`<list name="keywords">`) and function (`<list name="functions">`) but this is not a huge priority.

As the images below show, it's not perfect but it's a good start and we can work from here later.

# Before
<img width="659" alt="Screenshot 2023-09-22 at 10 19 31" src="https://github.com/duckdb/duckdb-web/assets/1402801/4274508b-b7ad-4e3b-b333-8e0166bbdd3e">

# After
<img width="659" alt="Screenshot 2023-09-22 at 10 31 57" src="https://github.com/duckdb/duckdb-web/assets/1402801/280deb35-a20a-4cae-97eb-38c21fe761a0">
