### PR TITLE
CI: Pin LinkChecker version

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -6,7 +6,7 @@
 # Sample workflow for building and deploying a Jekyll site to GitHub Pages
 name: Deploy Jekyll site to Pages
 
-on: [push, workflow_dispatch]
+on: [push]
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -20,99 +20,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Build job
-  build_html:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.0' # Not needed with a .ruby-version file
-          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-          cache-version: 0 # Increment this number if you need to re-download cached gems
-      - name: Setup Pages
-        id: pages
-        uses: actions/configure-pages@v3
-      - name: Build with Jekyll
-        # Outputs to the './_site' directory by default
-        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
-        env:
-          JEKYLL_ENV: production
-      - name: Upload HTML artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: html_artifact
-          path: _site
-
-  build_pdf:
-    runs-on: ubuntu-latest
-    container:
-      image: docker://pandoc/extra:3.1.1.0
-      options: --entrypoint=sh
-    defaults:
-      run:
-        working-directory: single-file-document
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup Python
-        run: |
-          PYTHONUNBUFFERED=1
-          apk add --update --no-cache python3 && ln -sf python3 /usr/bin/python
-          python3 -m ensurepip
-      - name: Install dependencies
-        run: pip3 install -r requirements.txt
-      - name: Concatenate files
-        run: python3 concatenate_to_single_file.py
-      - name: Convert with pandoc
-        run: pandoc --defaults pandoc-configuration.yaml
-      - name: Move artifact
-        run: |
-          mkdir -p ../_pdf
-          mv duckdb-docs.pdf ../_pdf
-      - name: Upload PDF artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: pdf_artifact
-          path: _pdf
-
-  package_into_a_single_artifact:
-    runs-on: ubuntu-latest
-    needs: [build_html, build_pdf]
-    steps:
-      # download both the html and the pdf artifacts into the _site directory
-      - uses: actions/download-artifact@v3
-        with:
-          name: html_artifact
-          path: _site
-      - uses: actions/download-artifact@v3
-        with:
-          name: pdf_artifact
-          path: _site
-      - name: Upload artifact for GitHub Pages
-        uses: actions/upload-pages-artifact@v2
-
-  # Deployment job
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    if: github.ref == 'refs/heads/main' && github.repository == 'duckdb/duckdb-web'
-    runs-on: ubuntu-latest
-    needs: package_into_a_single_artifact
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v1
-        with:
-          timeout: 3600000
 
   LinkChecker:
     name: Link Checker
     runs-on: ubuntu-latest
-    needs: deploy
     steps:
       - uses: actions/checkout@v4
         with:
@@ -123,12 +34,14 @@ jobs:
         with:
           python-version: '3.9'
 
-      - run: pip install linkchecker --user
+      - run: pip install linkchecker==10.2.1 --user
 
       - name: Link Checker on latest
         run: |
+          linkchecker --version
           linkchecker https://duckdb.org/ --ignore-url 'https://duckdb\.org/docs/archive/.*' --config .github/linkchecker/linkchecker.conf --file-output html/utf-8/report.html
-          echo $?
+          echo "Link Checker exit code: $?"
+          cat report.html
 
       - run: cat report.html >> ${GITHUB_STEP_SUMMARY}
         if: always()

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -36,10 +36,10 @@ jobs:
 
       - run: pip install linkchecker==10.2.1 --user
 
-      - name: Link Checker on latest but only on the root site
+      - name: Link Checker on latest
         run: |
           linkchecker --version
-          linkchecker https://duckdb.org/ --ignore-url 'https://duckdb\.org/.*' --config .github/linkchecker/linkchecker.conf --file-output html/utf-8/report.html
+          linkchecker https://duckdb.org/ --ignore-url 'https://duckdb\.org/docs/archive/.*' --config .github/linkchecker/linkchecker.conf --file-output html/utf-8/report.html
           echo "Link Checker exit code: $?"
           cat report.html
 

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -36,10 +36,10 @@ jobs:
 
       - run: pip install linkchecker==10.2.1 --user
 
-      - name: Link Checker on latest
+      - name: Link Checker on latest but only on the root site
         run: |
           linkchecker --version
-          linkchecker https://duckdb.org/ --ignore-url 'https://duckdb\.org/docs/archive/.*' --config .github/linkchecker/linkchecker.conf --file-output html/utf-8/report.html
+          linkchecker https://duckdb.org/ --ignore-url 'https://duckdb\.org/.*' --config .github/linkchecker/linkchecker.conf --file-output html/utf-8/report.html
           echo "Link Checker exit code: $?"
           cat report.html
 


### PR DESCRIPTION
Debugging #1220

The "smoke test" command takes <5 seconds to run locally (macOS 13.6, Python 3.11.5):

```bash
$ linkchecker --version && linkchecker https://duckdb.org/ --ignore-url 'https://duckdb\.org/.*' --config .github/linkchecker/linkchecker.conf --file-output html/utf-8/report.html --verbose; echo "Error code: $?"

LinkChecker 10.2.1 released 2022-12-05
Copyright (C) 2000-2016 Bastian Kleineidam, 2010-2022 LinkChecker Authors
 8 threads active,     0 links queued,   40 links in  48 URLs checked, runtime 1 seconds
Error code: 0
```