### PR TITLE
Remove 'unreleased' notice from extensions that are released with v0.9.0

### DIFF
--- a/docs/extensions/aws.md
+++ b/docs/extensions/aws.md
@@ -7,8 +7,6 @@ The `aws` extension provides features that depend on the AWS SDK.
 
 > This extension is currently in an experimental state. Feel free to try it out, but be aware some things may not work as expected.
 
-> Binaries are available in the main extension repository for DuckDB only for nightly builds at the moment, but will be available next release of DuckDB (v0.9.0).
-
 ## Features
 
 | function | type | description | 

--- a/docs/extensions/azure.md
+++ b/docs/extensions/azure.md
@@ -7,8 +7,6 @@ The `azure` extension adds a filesystem abstraction for the [Azure Blob storage]
 
 > This extension is currently in an experimental state. Feel free to try it out, but be aware some things may not work as expected.
 
-> Binaries are available in the main extension repository for DuckDB only for nightly builds at the moment, but will be available next release of DuckDB (v0.9.0).
-
 ## Usage
 
 Authentication is done by setting the connection string:

--- a/docs/extensions/iceberg.md
+++ b/docs/extensions/iceberg.md
@@ -5,8 +5,6 @@ title: Iceberg
 
 The `iceberg` extension is a loadable extension that implements support for the [Apache Iceberg format](https://iceberg.apache.org/).
 
-> This extension currently only works on the `main` branch of DuckDB (bleeding edge releases).
-
 ## Usage
 
 To test the examples, download the [`iceberg_data.zip`](/data/iceberg_data.zip) file and unzip it.


### PR DESCRIPTION
Towards #1190