### PR TITLE
Add new storage version

### DIFF
--- a/internals/storage.md
+++ b/internals/storage.md
@@ -52,65 +52,23 @@ with open('test/sql/storage_version/storage_version.db', 'rb') as fh:
 For changes in each given release, check out the [changelog](https://github.com/duckdb/duckdb/releases) on GitHub.
 To see the commits that changed each storage version, see the [commit log](https://github.com/duckdb/duckdb/commits/main/src/storage/storage_info.cpp).
 
-| Storage version | DuckDB versions                                             |
-|-----------------|-------------------------------------------------------------|
-| 64              | [#9075](https://github.com/duckdb/duckdb/pull/9075) onwards |
-| 59              | [#8863](https://github.com/duckdb/duckdb/pull/8863) onwards |
-| 58              | [#8869](https://github.com/duckdb/duckdb/pull/8869) onwards |
-| 57              | [#8752](https://github.com/duckdb/duckdb/pull/8752) onwards |
-| 56              | [#8650](https://github.com/duckdb/duckdb/pull/8650) onwards |
-| 55              | [#8513](https://github.com/duckdb/duckdb/pull/8513) onwards |
-| 54              | [#8378](https://github.com/duckdb/duckdb/pull/8378) onwards |
-| 53              | [#8323](https://github.com/duckdb/duckdb/pull/8323) onwards |
-| 52              | [#7126](https://github.com/duckdb/duckdb/pull/7126) onwards |
-| 51              | v0.8.0, v0.8.1                                              |
-| 50              | [#7270](https://github.com/duckdb/duckdb/pull/7270) onwards |
-| 49              | [#6841](https://github.com/duckdb/duckdb/pull/6841) onwards |
-| 48              | [#6715](https://github.com/duckdb/duckdb/pull/6715) onwards |
-| 47              |                                                             |
-| 46              | [#6621](https://github.com/duckdb/duckdb/pull/6621) onwards |
-| 45              | [#6560](https://github.com/duckdb/duckdb/pull/6560) onwards |
-| 44              | [#6499](https://github.com/duckdb/duckdb/pull/6499) onwards |
-| 43              | v0.7.0, v0.7.1                                              |
-| 42              | [#5544](https://github.com/duckdb/duckdb/pull/5544) onwards |
-| 41              | [#5768](https://github.com/duckdb/duckdb/pull/5768) onwards |
-| 40              | [#5491](https://github.com/duckdb/duckdb/pull/5491) onwards |
-| 39              | v0.6.0, v0.6.1                                              |
-| 38              | v0.5.0, v0.5.1                                              |
-| 37              | [#3985](https://github.com/duckdb/duckdb/pull/3985) onwards |
-| 36              | [#4022](https://github.com/duckdb/duckdb/pull/4022) onwards |
-| 35              |                                                             |
-| 34              |                                                             |
-| 33              | v0.3.3, v0.3.4, v0.4.0                                      |
-| 32              | [#3084](https://github.com/duckdb/duckdb/pull/3084)         |
-| 31              | v0.3.2                                                      |
-| 30              |                                                             |
-| 29              |                                                             |
-| 28              |                                                             |
-| 27              | v0.3.1                                                      |
-| 26              |                                                             |
-| 25              | v0.3.0                                                      |
-| 24              |                                                             |
-| 23              |                                                             |
-| 22              |                                                             |
-| 21              | v0.2.9                                                      |
-| 20              |                                                             |
-| 19              |                                                             |
-| 18              | v0.2.8                                                      |
-| 17              | v0.2.7                                                      |
-| 16              |                                                             |
-| 15              | v0.2.6                                                      |
-| 14              |                                                             |
-| 13              | v0.2.5                                                      |
-| 12              |                                                             |
-| 11              | v0.2.4                                                      |
-| 10              |                                                             |
-| 9               |                                                             |
-| 8               |                                                             |
-| 7               |                                                             |
-| 6               | v0.2.3                                                      |
-| 5               |                                                             |
-| 4               | v0.2.2                                                      |
-| 3               |                                                             |
-| 2               |                                                             |
-| 1               | v0.2.1 and prior                                            |
+| Storage version | DuckDB version(s)      |
+|-----------------|------------------------|
+| 64              | v0.9.0                 |
+| 51              | v0.8.0, v0.8.1         |
+| 43              | v0.7.0, v0.7.1         |
+| 39              | v0.6.0, v0.6.1         |
+| 38              | v0.5.0, v0.5.1         |
+| 33              | v0.3.3, v0.3.4, v0.4.0 |
+| 31              | v0.3.2                 |
+| 27              | v0.3.1                 |
+| 25              | v0.3.0                 |
+| 21              | v0.2.9                 |
+| 18              | v0.2.8                 |
+| 17              | v0.2.7                 |
+| 15              | v0.2.6                 |
+| 13              | v0.2.5                 |
+| 11              | v0.2.4                 |
+| 6               | v0.2.3                 |
+| 4               | v0.2.2                 |
+| 1               | v0.2.1 and prior       |

--- a/internals/storage.md
+++ b/internals/storage.md
@@ -54,6 +54,9 @@ To see the commits that changed each storage version, see the [commit log](https
 
 | Storage version | DuckDB versions                                             |
 |-----------------|-------------------------------------------------------------|
+| 64              | [#9075](https://github.com/duckdb/duckdb/pull/9075) onwards |
+| 59              | [#8863](https://github.com/duckdb/duckdb/pull/8863) onwards |
+| 58              | [#8869](https://github.com/duckdb/duckdb/pull/8869) onwards |
 | 57              | [#8752](https://github.com/duckdb/duckdb/pull/8752) onwards |
 | 56              | [#8650](https://github.com/duckdb/duckdb/pull/8650) onwards |
 | 55              | [#8513](https://github.com/duckdb/duckdb/pull/8513) onwards |


### PR DESCRIPTION
I'm adding the new storage version, 64, to the table.

@Maxxen @Mytherin is it okay to skip versions 60..63? These were bumped by the following commits (although I cannot seem to find version 60):
https://github.com/duckdb/duckdb/commit/72f6b3880b05faf6540f971b3169e9a2ab0a8aa8
https://github.com/duckdb/duckdb/commit/d8d26a8c599ebef2b45862333835355dfc509b90
https://github.com/duckdb/duckdb/commit/61b7edfb618c31aeb810842f264b0747a1f97640
https://github.com/duckdb/duckdb/commit/e3af76c8af91764be8f48a92ffc494080832a589

It seems a lot of things were flux, and it's unlikely that someone will use e.g. version 61. WDYT?