### PR TITLE
COPY statement

### DIFF
--- a/docs/data/csv/overview.md
+++ b/docs/data/csv/overview.md
@@ -112,7 +112,7 @@ Multiple files can be read at once by providing a glob or a list of files. Refer
 
 ## Writing Using the COPY Statement
 
-The `COPY` statement can be used to load data from a CSV file into a table. This statement has the same syntax as the [`COPY` statement](../../sql/statements/copy#copy-to) supported by PostgreSQL. To load the data using the `COPY` statement, we must first create a table with the correct schema (which matches the order of the columns in the CSV file and uses types that fit the values in the CSV file). We then specify the CSV file to load from plus any configuration options separately.
+The [`COPY` statement](../../sql/statements/copy#copy-to) can be used to load data from a CSV file into a table. This statement has the same syntax as the one used in PostgreSQL. To load the data using the `COPY` statement, we must first create a table with the correct schema (which matches the order of the columns in the CSV file and uses types that fit the values in the CSV file). We then specify the CSV file to load from plus any configuration options separately.
 
 ```sql
 CREATE TABLE ontime(flightdate DATE, uniquecarrier VARCHAR, origincityname VARCHAR, destcityname VARCHAR);

--- a/docs/data/parquet/overview.md
+++ b/docs/data/parquet/overview.md
@@ -45,7 +45,7 @@ Parquet files are compressed columnar files that are efficient to load and proce
 
 ## Parameters
 
-Parquet files are self-describing, as such far fewer parameters are required than with CSV files. Nevertheless, there are a number of options exposed that can be passed to the `read_parquet` function, or the `COPY` statement.
+Parquet files are self-describing, as such far fewer parameters are required than with CSV files. Nevertheless, there are a number of options exposed that can be passed to the `read_parquet` function, or the [`COPY` statement](../../sql/statements/copy).
 
 | Name | Description | Type | Default |
 |:--|:-----|:-|:-|
@@ -100,7 +100,7 @@ SELECT * FROM people;
 
 ## Writing to Parquet Files
 
-DuckDB also has support for writing to Parquet files using the `COPY` statement syntax. See the [Copy Statement page](../../sql/statements/copy) for details, including all possible parameters for the copy statement.
+DuckDB also has support for writing to Parquet files using the `COPY` statement syntax. See the [`COPY` Statement page](../../sql/statements/copy) for details, including all possible parameters for the `COPY` statement.
 
 ```sql
 -- write a query to a snappy compressed parquet file

--- a/docs/data/partitioning/partitioned_writes.md
+++ b/docs/data/partitioning/partitioned_writes.md
@@ -14,7 +14,7 @@ COPY orders TO 'orders' (FORMAT CSV, PARTITION_BY (year, month), OVERWRITE_OR_IG
 
 ## Partitioned Writes
 
-When the `partition_by` clause is specified for the `COPY` statement, the files are written in a [hive partitioned](hive_partitioning) folder hierarchy. The target is the name of the root directory (in the example above: `orders`). The files are written in-order in the file hierarchy. Currently, one file is written per thread to each directory.
+When the `partition_by` clause is specified for the [`COPY` statement](../../sql/statements/copy), the files are written in a [hive partitioned](hive_partitioning) folder hierarchy. The target is the name of the root directory (in the example above: `orders`). The files are written in-order in the file hierarchy. Currently, one file is written per thread to each directory.
 
 ```text
 orders

--- a/docs/guides/import/csv_import.md
+++ b/docs/guides/import/csv_import.md
@@ -33,4 +33,4 @@ Alternatively, the `COPY` statement can also be used to load data from a CSV fil
 COPY tbl FROM 'input.csv';
 ```
 
-For additional options, see the [CSV Loading reference](../../data/csv) and the [COPY statement documentation](../../sql/statements/copy).
+For additional options, see the [CSV Loading reference](../../data/csv) and the [`COPY` statement documentation](../../sql/statements/copy).

--- a/docs/guides/import/json_export.md
+++ b/docs/guides/import/json_export.md
@@ -15,4 +15,4 @@ The result of queries can also be directly exported to a JSON file.
 COPY (SELECT * FROM tbl) TO 'output.json';
 ```
 
-For additional options, see the [COPY statement documentation](../../sql/statements/copy).
+For additional options, see the [`COPY` statement documentation](../../sql/statements/copy).

--- a/docs/guides/import/json_import.md
+++ b/docs/guides/import/json_import.md
@@ -26,4 +26,4 @@ Alternatively, the `COPY` statement can also be used to load data from a JSON fi
 COPY tbl FROM 'input.json';
 ```
 
-For additional options, see the [JSON Loading reference](../../data/json) and the [COPY statement documentation](../../sql/statements/copy).
+For additional options, see the [JSON Loading reference](../../data/json) and the [`COPY` statement documentation](../../sql/statements/copy).

--- a/docs/sql/functions/dateformat.md
+++ b/docs/sql/functions/dateformat.md
@@ -29,7 +29,7 @@ SELECT strptime('Monday, 2 March 1992 - 08:32:45 PM', '%A, %-d %B %Y - %I:%M:%S 
 
 ## CSV Parsing
 
-The date formats can also be specified during CSV parsing, either in the `COPY` statement or in the `read_csv` function. This can be done by either specifying a `DATEFORMAT` or a `TIMESTAMPFORMAT` (or both). `DATEFORMAT` will be used for converting dates, and `TIMESTAMPFORMAT` will be used for converting timestamps. Below are some examples for how to use this:
+The date formats can also be specified during CSV parsing, either in the [`COPY` statement](../statements/copy) or in the `read_csv` function. This can be done by either specifying a `DATEFORMAT` or a `TIMESTAMPFORMAT` (or both). `DATEFORMAT` will be used for converting dates, and `TIMESTAMPFORMAT` will be used for converting timestamps. Below are some examples for how to use this:
 
 ```sql
 -- in COPY statement

--- a/docs/sql/statements/export.md
+++ b/docs/sql/statements/export.md
@@ -21,7 +21,7 @@ EXPORT DATABASE 'target_directory' (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_
 IMPORT DATABASE 'target_directory';
 ```
 
-For details regarding the writing of Parquet files, see the [Parquet Files page in the Data Import section](../../data/parquet/overview#writing-to-parquet-files), and the [Copy Statement page](copy).
+For details regarding the writing of Parquet files, see the [Parquet Files page in the Data Import section](../../data/parquet/overview#writing-to-parquet-files), and the [`COPY` Statement page](copy).
 
 ## Syntax
 


### PR DESCRIPTION
It turns out there are many ways to spell COPY statement. This PR tries to use a single one and also link the page.