### PR TITLE
Use YUM for CentOS build instructions

### DIFF
--- a/dev/building.md
+++ b/dev/building.md
@@ -17,7 +17,7 @@ Install the required packages with the package manager of your distribution.
 Fedora, CentOS, and Red Hat:
 
 ```bash
-sudo dnf install -y git g++ cmake ninja-build
+sudo yum install -y git g++ cmake ninja-build
 ```
 
 Ubuntu and Debian:


### PR DESCRIPTION
It turns out that CentOS 7, where people actually have to [build DuckDB from source](https://github.com/duckdb/duckdb/issues/1708), has yum instead of dnf.