### PR TITLE
Add dummy div to fix front page colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,9 @@ description: DuckDB is an in-process SQL OLAP database management system. Simple
 body_class: landing nowrap
 ---
 
+<div class="dummy">
+</div>
+
 <section>
 	<div class="welcome">
 		<div id="duckdbdanimationcircled" style="width: 75px; height: 75px; margin: 0 auto; margin-bottom: 35px;"></div>


### PR DESCRIPTION
The colors on the front page are alternating shades of gray. Removing the Discord banner inadvertently caused this to start from a different shade of gray, which makes the installation box and features (simple, etc.) no longer stand out. 

Illustrations below.

## Bad (before this PR)
<img width="1490" alt="Screenshot 2023-09-28 at 14 13 10" src="https://github.com/duckdb/duckdb-web/assets/1402801/8e31eba6-65d0-48a5-9d89-fb881a1aaddc">

## Good (after this PR)
<img width="1490" alt="Screenshot 2023-09-28 at 14 10 42" src="https://github.com/duckdb/duckdb-web/assets/1402801/069aedee-2912-41f7-afbc-c11425912ea5">
