### PR TITLE
Reduce code block width back to the text width

### DIFF
--- a/css/docu.scss
+++ b/css/docu.scss
@@ -75,7 +75,7 @@ pre.highlight{
 }
 div.highlight{
 	width: calc(100vw - 380px);
-	max-width: 1000px;
+	max-width: 720px;
     position: relative;
 }
 blockquote {


### PR DESCRIPTION
I originally asked for the code blocks to be wider (1000px) but after looking at the docs with this for ~3 weeks, I still couldn't get used to it. Curiously, I find that this looks okay for tables. I think the key difference is that there are *many* code blocks and only a few tables.

So I propose reverting it back to the width of the text (720px).