### PR TITLE
Add script to redirect between versions

### DIFF
--- a/scripts/redirect.py
+++ b/scripts/redirect.py
@@ -1,0 +1,32 @@
+import frontmatter
+import sys
+from glob import glob
+from pathlib import Path
+import re
+
+if len(sys.argv) < 3:
+    print(
+        "Expected usage: python3 scripts/redirect.py from_directory to_directory"
+    )
+    exit(1)
+
+
+
+from_directory = sys.argv[1]
+to_directory = sys.argv[2]
+
+
+source = Path(from_directory)
+for path in source.glob("**/*.md"):
+    doc = frontmatter.load(path)
+
+    filename = str(path)
+    filename = re.sub(r"\.md$", "", filename)
+    filename = re.sub(r"/overview$", "", filename)
+
+    new_redirect_entry = str(filename).replace(from_directory, to_directory)
+
+    doc["redirect_from"] = doc.get("redirect_from", []) + [new_redirect_entry]
+
+    with open(path, "w") as f:
+        f.write(frontmatter.dumps(doc))

--- a/scripts/redirect.py
+++ b/scripts/redirect.py
@@ -5,11 +5,8 @@ from pathlib import Path
 import re
 
 if len(sys.argv) < 3:
-    print(
-        "Expected usage: python3 scripts/redirect.py from_directory to_directory"
-    )
+    print("Expected usage: python3 scripts/redirect.py from_directory to_directory")
     exit(1)
-
 
 
 from_directory = sys.argv[1]


### PR DESCRIPTION
Sketch script that would redirect from e.g., 0.9.1 to 0.9.0.

Tested locally. It works but I noticed a small issue:

from 
http://localhost:4000/docs/archive/0.9.1/guides/import/parquet_import

it redirects to
http://localhost:4000/docs/archive/0.9.0/guides/import/parquet_import.html

(note the .html)

@Mause WDYT?