### PR TITLE
Simplify R docs by using library(duckdb)

### DIFF
--- a/docs/api/r.md
+++ b/docs/api/r.md
@@ -16,13 +16,15 @@ The standard DuckDB R API implements the [DBI interface](https://CRAN.R-project.
 To use DuckDB, you must first create a connection object that represents the database. The connection object takes as parameter the database file to read and write from. If the database file does not exist, it will be created (the file extension may be `.db`, `.duckdb`, or anything else). The special value `:memory:` (the default) can be used to create an **in-memory database**. Note that for an in-memory database no data is persisted to disk (i.e., all data is lost when you exit the R process). If you would like to connect to an existing database in read-only mode, set the `read_only` flag to `TRUE`. Read-only mode is required if multiple R processes want to access the same database file at the same time.
 
 ```R
-library("DBI")
+library("duckdb")
 # to start an in-memory database
-con <- dbConnect(duckdb::duckdb(), dbdir = ":memory:")
+con <- dbConnect(duckdb())
+# or
+con <- dbConnect(duckdb(), dbdir = ":memory:")
 # to use a database file (not shared between processes)
-con <- dbConnect(duckdb::duckdb(), dbdir = "my-db.duckdb", read_only = FALSE)
+con <- dbConnect(duckdb(), dbdir = "my-db.duckdb", read_only = FALSE)
 # to use a database file (shared between processes)
-con <- dbConnect(duckdb::duckdb(), dbdir = "my-db.duckdb", read_only = TRUE)
+con <- dbConnect(duckdb(), dbdir = "my-db.duckdb", read_only = TRUE)
 ```
 Connections are closed implicitly when they go out of scope or if they are explicitly closed using `dbDisconnect()`. To shut down the database instance associated with the connection, use `dbDisconnect(con, shutdown=TRUE)`
 
@@ -79,14 +81,14 @@ print(res)
 It is also possible to "register" a R data frame as a virtual table, comparable to a SQL `VIEW`. This *does not actually transfer data* into DuckDB yet. Below is an example:
 
 ```R
-duckdb::duckdb_register(con, "iris_view", iris)
+duckdb_register(con, "iris_view", iris)
 res <- dbGetQuery(con, "SELECT * FROM iris_view LIMIT 1")
 print(res)
 #   Sepal.Length Sepal.Width Petal.Length Petal.Width Species
 # 1          5.1         3.5          1.4         0.2  setosa
 ```
 
-> DuckDB keeps a reference to the R data frame after registration. This prevents the data frame from being garbage-collected. The reference is cleared when the connection is closed, but can also be cleared manually using the `duckdb::duckdb_unregister()` method.
+> DuckDB keeps a reference to the R data frame after registration. This prevents the data frame from being garbage-collected. The reference is cleared when the connection is closed, but can also be cleared manually using the `duckdb_unregister()` method.
 
 Also refer to [the data import documentation](../data/overview) for more options of efficiently importing data.
 
@@ -95,10 +97,10 @@ Also refer to [the data import documentation](../data/overview) for more options
 DuckDB also plays well with the [dbplyr](https://CRAN.R-project.org/package=dbplyr) / [dplyr](https://dplyr.tidyverse.org) packages for programmatic query construction from R. Here is an example:
 
 ```R
-library("DBI")
+library("duckdb")
 library("dplyr")
-con <- dbConnect(duckdb::duckdb())
-duckdb::duckdb_register(con, "flights", nycflights13::flights)
+con <- dbConnect(duckdb())
+duckdb_register(con, "flights", nycflights13::flights)
 
 tbl(con, "flights") |>
   group_by(dest) |>


### PR DESCRIPTION
I use `library(duckdb)` in the R docs which allowed me to remove `duckdb::` from a few places.
@Tmonster @hannes WDYT?