### PR TITLE
Link Checker: Ignore links of the 'Report Issue' button

### DIFF
--- a/.github/linkchecker/linkchecker.conf
+++ b/.github/linkchecker/linkchecker.conf
@@ -22,3 +22,4 @@ ignore=
    https://www\.tpc\.org/.*
    https://meltano\.com/.*
    https://github\.com/duckdb/duckdb-web/edit/.*
+   https://github\.com/duckdb/duckdb-web/issues/new\?.*


### PR DESCRIPTION
It turns out sending a million requests to `github.com` causes Link Checker to fail... which was the likely cause of #1346.