### PR TITLE
Avoid redirect by appending "/" for docs link

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@ body_class: landing nowrap
 		<div class="mainlinks">
 			<ul>
 				<a href="#quickinstall"><li class="highlighted">Installation <span class="duckdbsymbol">&#x2193;</span> </li></a>
-				<a href="/docs/archive/{{ site.currentduckdbversion }}"><li>Documentation</li></a>
+				<a href="/docs/archive/{{ site.currentduckdbversion }}/"><li>Documentation</li></a>
 				<a href="https://shell.duckdb.org"><li>Live Demo</li></a>
 				<a href="https://duckdblabs.com/support/"><li>Support</li></a>
 			</ul>


### PR DESCRIPTION
This eliminate the un-necessary redirect. 

However, it seems maintainer that have access to CloudFlare for dubckdb.org account should configure http -> https redirect to avoid folks accessing straight http protocol for the domain.