### PR TITLE
Revert "Increase required Python version from 3.7 to 3.8"

### DIFF
--- a/docs/api/python/overview.md
+++ b/docs/api/python/overview.md
@@ -7,7 +7,7 @@ title: Python API
 
 The DuckDB Python API can be installed using [pip](https://pip.pypa.io): `pip install duckdb`. Please see the [installation page](../../installation?environment=python) for details. It is also possible to install DuckDB using [conda](https://docs.conda.io): `conda install python-duckdb -c conda-forge`.
 
-You must be using Python 3.8 or newer.
+You must be using Python 3.7 or newer.
 
 ## Basic API Usage
 

--- a/docs/archive/0.9.1/api/python/overview.md
+++ b/docs/archive/0.9.1/api/python/overview.md
@@ -7,7 +7,7 @@ title: Python API
 
 The DuckDB Python API can be installed using [pip](https://pip.pypa.io): `pip install duckdb`. Please see the [installation page](../../installation?environment=python) for details. It is also possible to install DuckDB using [conda](https://docs.conda.io): `conda install python-duckdb -c conda-forge`.
 
-You must be using Python 3.8 or newer.
+You must be using Python 3.7 or newer.
 
 ## Basic API Usage
 


### PR DESCRIPTION
Reverts duckdb/duckdb-web#1304

This was incorrectly bumped, we support >=3.7, see https://github.com/duckdb/duckdb/blob/main/tools/pythonpkg/setup.py#L351