### PR TITLE
Update timezone of Greenland

### DIFF
--- a/docs/sql/data_types/timezones.md
+++ b/docs/sql/data_types/timezones.md
@@ -142,7 +142,7 @@ ORDER BY
 | America/Fort_Wayne               | IET                              | -05:00:00  |
 | America/Fortaleza                | America/Fortaleza                | -03:00:00  |
 | America/Glace_Bay                | America/Glace_Bay                | -04:00:00  |
-| America/Godthab                  | America/Godthab                  | -03:00:00  |
+| America/Godthab                  | America/Godthab                  | -02:00:00  |
 | America/Goose_Bay                | America/Goose_Bay                | -04:00:00  |
 | America/Grand_Turk               | America/Grand_Turk               | -05:00:00  |
 | America/Grenada                  | PRT                              | -04:00:00  |
@@ -202,7 +202,7 @@ ORDER BY
 | America/North_Dakota/Beulah      | America/North_Dakota/Beulah      | -06:00:00  |
 | America/North_Dakota/Center      | America/North_Dakota/Center      | -06:00:00  |
 | America/North_Dakota/New_Salem   | America/North_Dakota/New_Salem   | -06:00:00  |
-| America/Nuuk                     | America/Nuuk                     | -03:00:00  |
+| America/Nuuk                     | America/Nuuk                     | -02:00:00  |
 | America/Ojinaga                  | America/Ojinaga                  | -06:00:00  |
 | America/Panama                   | America/Panama                   | -05:00:00  |
 | America/Pangnirtung              | America/Pangnirtung              | -05:00:00  |


### PR DESCRIPTION
Greenland (or at least parts of it) [has changed its timezone](https://www.timeanddate.com/news/time/greenland-change-timezone.html) from UTC-3 to UTC-2. This is reflected now when using `pg_timezone_names`. This PR updates the reference list.

America/Nuuk and America/Godthab are synonymous as Godthab is the old name of Nuuk.