### PR TITLE
Update nested.md

### DIFF
--- a/docs/archive/0.9.1/sql/functions/nested.md
+++ b/docs/archive/0.9.1/sql/functions/nested.md
@@ -89,7 +89,7 @@ SELECT [upper(x) for x in strings if len(x)>0] FROM (VALUES (['Hello', '', 'Worl
 | `map()` | Returns an empty map. | `map()` | `{}` |
 | `map_keys(`*`map`*`)` | Return a list of all keys in the map. | `map_keys(map([100, 5], [42, 43]))` | `[100, 42]` |
 | `map_values(`*`map`*`)` | Return a list of all values in the map. | `map_values(map([100, 5], [42, 43]))` | `[5, 33]` |
-| `map_entries(`*`map`*`)` | Return a list of struct(k, v) for each key-value pair in the map. | `map_entries(map([100, 5], [42, 43]))` | `[{'k': 100, 'v': 42}, {'k': 5, 'v': 43}]` |
+| `map_entries(`*`map`*`)` | Return a list of struct(k, v) for each key-value pair in the map. | `map_entries(map([100, 5], [42, 43]))` | `[{'key': 100, 'value': 42}, {'key': 5, 'value': 43}]` |
 
 ## Union Functions
 


### PR DESCRIPTION
The v0.91 version of the documentation does not reflect updates to the `map_entries(map)` function that is present in the version. The change to the documentation is present in dev but not 9.1
```
v0.9.1 401c8061c6
Enter ".help" for usage hints.
Connected to a transient in-memory database.
Use ".open FILENAME" to reopen on a persistent database.
D select  map_entries(map([100, 5], [42, 43])) ;
┌────────────────────────────────────────────────────────────────────┐
│ map_entries(map(main.list_value(100, 5), main.list_value(42, 43))) │
│              struct("key" integer, "value" integer)[]              │
├────────────────────────────────────────────────────────────────────┤
│ [{'key': 100, 'value': 42}, {'key': 5, 'value': 43}]               │
└────────────────────────────────────────────────────────────────────┘

```