### PR TITLE
Link PDF documentation in S3

### DIFF
--- a/docs/archive/0.9.0/index.md
+++ b/docs/archive/0.9.0/index.md
@@ -7,7 +7,7 @@ Welcome to the DuckDB Documentation!
 
 You have two options to read the DuckDB Documentation:
 * this online documentation page
-* a PDF of the documentation <a href="/pdf/duckdb-docs-0.9.0.pdf" class="pill">Documentation (PDF)</a>
+* a PDF of the documentation <a href="https://blobs.duckdb.org/docs/duckdb-docs-0.9.0.pdf" class="pill">Documentation (PDF)</a>
 
 
 <h1>Sitemap</h1>

--- a/docs/archive/0.9.1/index.md
+++ b/docs/archive/0.9.1/index.md
@@ -7,7 +7,7 @@ Welcome to the DuckDB Documentation!
 
 You have two options to read the DuckDB Documentation:
 * this online documentation page
-* a PDF of the documentation <a href="/pdf/duckdb-docs-0.9.0.pdf" class="pill">Documentation (PDF)</a>
+* a PDF of the documentation <a href="https://blobs.duckdb.org/docs/duckdb-docs-0.9.1.pdf" class="pill">Documentation (PDF)</a>
 
 
 <h1>Sitemap</h1>


### PR DESCRIPTION
From now on, we'll store the documentation PDFs in AWS S3, exposed to blobs.duckdb.org
This resolves #1053