### PR TITLE
Clarify why DETACH is required in scripts

### DIFF
--- a/docs/sql/statements/attach.md
+++ b/docs/sql/statements/attach.md
@@ -39,6 +39,8 @@ USE file;
 
 The `DETACH` statement allows previously attached database files to be closed and detached, releasing any locks held on the database file.
 
+> Closing the connection, e.g., invoking the [`close()` function in Python](../../api/python/dbapi#connection)), does not release the locks held on the database files as the file handle is held by the main DuckDB instance (in Python's case, the `duckdb` module).
+
 ## Name Qualification
 
 The fully qualified name of catalog objects contains the *catalog*, the *schema* and the *name* of the object. For example:


### PR DESCRIPTION
Added a clarification on why invoking `DETACH` may be nessary even if `close` is called.

@Tishj does the text added by this PR make sense?