### PR TITLE
Documentation for fixed size lists

### DIFF
--- a/_data/menu_docs_dev.json
+++ b/_data/menu_docs_dev.json
@@ -725,6 +725,10 @@
                   "url": "overview"
                 },
                 {
+                  "page": "Array",
+                  "url": "Array"
+                },
+                {
                   "page": "Bitstring",
                   "url": "bitstring"
                 },

--- a/_data/menu_docs_dev.json
+++ b/_data/menu_docs_dev.json
@@ -725,7 +725,7 @@
                   "url": "overview"
                 },
                 {
-                  "page":"Bitstring",
+                  "page": "Bitstring",
                   "url": "bitstring"
                 },
                 {
@@ -749,11 +749,11 @@
                   "url": "interval"
                 },
                 {
-                  "page":"List",
+                  "page": "List",
                   "url": "list"
                 },
                 {
-                  "page":"Map",
+                  "page": "Map",
                   "url": "map"
                 },
                 {
@@ -765,7 +765,7 @@
                   "url": "numeric"
                 },
                 {
-                  "page":"Struct",
+                  "page": "Struct",
                   "url": "struct"
                 },
                 {
@@ -785,7 +785,7 @@
                   "url": "timezones"
                 },
                 {
-                  "page":"Union",
+                  "page": "Union",
                   "url": "union"
                 }
               ]

--- a/docs/sql/data_types/array.md
+++ b/docs/sql/data_types/array.md
@@ -1,0 +1,83 @@
+---
+layout: docu
+title: Array
+---
+An `ARRAY` column stores arrays. All fields in the column must have the same length and the same underlying type. `ARRAY`s are typically used to store arrays of numbers, but can contain any uniform data type, including other `ARRAY`s, `LIST`s and `STRUCT`s.
+
+> The `ARRAY` type in PostgreSQL allows variable-length fields. DuckDB's `ARRAY` type is fixed-length.
+
+See the [data types overview](../../sql/data_types/overview) for a comparison between nested data types.
+
+> To store variable-length lists, use the [`LIST` type](list).
+
+## Creating Arrays
+
+Arrays can be created using the [`array_value(expr, ...)`](../functions/nested#list-functions) function.
+
+```sql
+-- Construct with the 'array_value' function
+SELECT array_value(1, 2, 3);
+-- You can always implicitly cast an array to a list (and use list functions, like list_extract, '[i]')
+SELECT array_value(1, 2, 3)[2];
+-- You can cast from a list to an array, but the dimensions have to match up!
+SELECT [3, 2, 1]::INT[3];
+-- Arrays can be nested
+SELECT array_value(array_value(1, 2), array_value(3, 4), array_value(5, 6));
+-- Arrays can store structs
+SELECT array_value({'a': 1, 'b': 2}, {'a': 3, 'b': 4});
+```
+
+## Defining an Array Field
+
+Arrays can be created using the `<TYPE_NAME>[<LENGTH>]` syntax. For example, to create an array field for 3 integers, run:
+
+```sql
+CREATE TABLE array_table(id INT, arr INT[3]);
+INSERT INTO array_table VALUES (10, [1, 2, 3]), (20, [4, 5, 6]);
+```
+
+## Retrieving from Arrays
+
+Retrieving one or more values from an array can be accomplished using brackets and slicing notation, or through [list functions](../functions/nested#list-functions) like `list_extract` and `array_extract`. Using the example in [Defining an Array Field](#defining-an-array-field).
+
+The following queries for extracting the second element of an array are equivalent:
+
+```sql
+SELECT id, arr[1] AS element FROM array_table;
+SELECT id, list_extract(arr, 1) AS element FROM array_table;
+SELECT id, array_extract(arr, 1) AS element FROM array_table;
+```
+
+```text
+┌───────┬─────────┐
+│  id   │ element │
+│ int32 │  int32  │
+├───────┼─────────┤
+│    10 │       1 │
+│    20 │       4 │
+└───────┴─────────┘
+```
+
+Slicing notation returns a `LIST`:
+
+```sql
+SELECT id, arr[1:2] AS elements FROM array_table;
+```
+
+```text
+┌───────┬──────────┐
+│  id   │ elements │
+│ int32 │ int32[]  │
+├───────┼──────────┤
+│    10 │ [1, 2]   │
+│    20 │ [4, 5]   │
+└───────┴──────────┘
+```
+
+## Ordering
+
+The ordering is defined using a lexicographical order. `NULL` values compare greater than all other values and are considered equal to each other.
+
+## Functions
+
+See [Nested Functions](../../sql/functions/nested).

--- a/docs/sql/data_types/list.md
+++ b/docs/sql/data_types/list.md
@@ -3,8 +3,6 @@ layout: docu
 title: List
 ---
 
-## List Data Type
-
 A `LIST` column encodes lists of values. Fields in the column can have values with different lengths, but they must all have the same underlying type. `LIST`s are typically used to store arrays of numbers, but can contain any uniform data type, including other `LIST`s and `STRUCT`s.
 
 `LIST`s are similar to PostgreSQL's `ARRAY` type. DuckDB uses the `LIST` terminology, but some [array functions](../functions/nested#list-functions) are provided for PostgreSQL compatibility.
@@ -13,7 +11,7 @@ See the [data types overview](../../sql/data_types/overview) for a comparison be
 
 Lists can be created using the [`list_value(expr, ...)`](../functions/nested#list-functions) function or the equivalent bracket notation `[expr, ...]`. The expressions can be constants or arbitrary expressions.
 
-### Creating Lists
+## Creating Lists
 
 ```sql
 -- List of integers
@@ -28,7 +26,7 @@ SELECT list_value(1, 2, 3);
 CREATE TABLE list_table (int_list INT[], varchar_list VARCHAR[]);
 ```
 
-### Retrieving from Lists
+## Retrieving from Lists
 
 Retrieving one or more values from a list can be accomplished using brackets and slicing notation, or through [list functions](../functions/nested#list-functions) like `list_extract`. Multiple equivalent functions are provided as aliases for compatibility with systems that refer to lists as arrays. For example, the function `array_slice`.
 ```sql

--- a/docs/sql/data_types/list.md
+++ b/docs/sql/data_types/list.md
@@ -11,6 +11,8 @@ See the [data types overview](../../sql/data_types/overview) for a comparison be
 
 Lists can be created using the [`list_value(expr, ...)`](../functions/nested#list-functions) function or the equivalent bracket notation `[expr, ...]`. The expressions can be constants or arbitrary expressions.
 
+> For storing fixed-length lists, DuckDB uses the [`ARRAY` type](array).
+
 ## Creating Lists
 
 ```sql

--- a/docs/sql/data_types/list.md
+++ b/docs/sql/data_types/list.md
@@ -5,13 +5,13 @@ title: List
 
 ## List Data Type
 
-A `LIST` column can have values with different lengths, but they must all have the same underlying type. `LIST`s are typically used to store arrays of numbers, but can contain any uniform data type, including other `LIST`s and `STRUCT`s.
+A `LIST` column encodes lists of values. Fields in the column can have values with different lengths, but they must all have the same underlying type. `LIST`s are typically used to store arrays of numbers, but can contain any uniform data type, including other `LIST`s and `STRUCT`s.
 
 `LIST`s are similar to PostgreSQL's `ARRAY` type. DuckDB uses the `LIST` terminology, but some [array functions](../functions/nested#list-functions) are provided for PostgreSQL compatibility.
 
 See the [data types overview](../../sql/data_types/overview) for a comparison between nested data types.
 
-Lists can be created using the [`LIST_VALUE(expr, ...)`](../functions/nested#list-functions) function or the equivalent bracket notation `[expr, ...]`. The expressions can be constants or arbitrary expressions.
+Lists can be created using the [`list_value(expr, ...)`](../functions/nested#list-functions) function or the equivalent bracket notation `[expr, ...]`. The expressions can be constants or arbitrary expressions.
 
 ### Creating Lists
 

--- a/docs/sql/data_types/list.md
+++ b/docs/sql/data_types/list.md
@@ -9,11 +9,11 @@ A `LIST` column encodes lists of values. Fields in the column can have values wi
 
 See the [data types overview](../../sql/data_types/overview) for a comparison between nested data types.
 
-Lists can be created using the [`list_value(expr, ...)`](../functions/nested#list-functions) function or the equivalent bracket notation `[expr, ...]`. The expressions can be constants or arbitrary expressions.
-
 > For storing fixed-length lists, DuckDB uses the [`ARRAY` type](array).
 
 ## Creating Lists
+
+Lists can be created using the [`list_value(expr, ...)`](../functions/nested#list-functions) function or the equivalent bracket notation `[expr, ...]`. The expressions can be constants or arbitrary expressions.
 
 ```sql
 -- List of integers

--- a/docs/sql/data_types/overview.md
+++ b/docs/sql/data_types/overview.md
@@ -39,14 +39,14 @@ DuckDB supports four nested data types: `LIST`, `STRUCT`, `MAP` and `UNION`. Eac
 
 | Name | Description | Rules when used in a column | Build from values | Define in DDL/CREATE |
 |:-|:---|:---|:--|:--|
-| [LIST](../../sql/data_types/list) | An ordered sequence of data values of the same type. | Each row must have the same data type within each LIST, but can have any number of elements. | `[1, 2, 3]` | INT[ ] |
-| [STRUCT](../../sql/data_types/struct) | A dictionary of multiple named values, where each key is a string, but the value can be a different type for each key. | Each row must have the same keys. | `{'i': 42, 'j': 'a'}` | STRUCT(i INT, j VARCHAR) |
-| [MAP](../../sql/data_types/map) | A dictionary of multiple named values, each key having the same type and each value having the same type. Keys and values can be any type and can be different types from one another. | Rows may have different keys. | `map([1, 2], ['a', 'b'])` | MAP(INT, VARCHAR) |
-| [UNION](../../sql/data_types/union) | A union of multiple alternative data types, storing one of them in each value at a time. A union also contains a discriminator "tag" value to inspect and access the currently set member type. | Rows may be set to different member types of the union. | union_value(num := 2) | UNION(num INT, text VARCHAR) |
+| [`LIST`](../../sql/data_types/list) | An ordered sequence of data values of the same type. | Each row must have the same data type within each `LIST`, but can have any number of elements. | `[1, 2, 3]` | `INT[]` |
+| [`MAP`](../../sql/data_types/map) | A dictionary of multiple named values, each key having the same type and each value having the same type. Keys and values can be any type and can be different types from one another. | Rows may have different keys. | `map([1, 2], ['a', 'b'])` | `MAP(INT, VARCHAR)` |
+| [`STRUCT`](../../sql/data_types/struct) | A dictionary of multiple named values, where each key is a string, but the value can be a different type for each key. | Each row must have the same keys. | `{'i': 42, 'j': 'a'}` | `STRUCT(i INT, j VARCHAR)` |
+| [`UNION`](../../sql/data_types/union) | A union of multiple alternative data types, storing one of them in each value at a time. A union also contains a discriminator "tag" value to inspect and access the currently set member type. | Rows may be set to different member types of the union. | `union_value(num := 2)` | `UNION(num INT, text VARCHAR)` |
 
 ## Nesting
 
-`LIST`s, `STRUCT`s, `MAP`s and `UNION`s can be arbitrarily nested to any depth, so long as the type rules are observed.
+`LIST`, `STRUCT`, `MAP` and `UNION` types can be arbitrarily nested to any depth, so long as the type rules are observed.
 
 ```sql
 -- Struct with lists


### PR DESCRIPTION
DuckDB PR https://github.com/duckdb/duckdb/pull/8983 by @Maxxen introduces fixed-size lists. This PR documents them. WIP.

Will eventually fix #1521