### PR TITLE
Use double quotes for Python examples

### DIFF
--- a/docs/api/nodejs/overview.md
+++ b/docs/api/nodejs/overview.md
@@ -73,7 +73,7 @@ con.all('SELECT 42 AS fortytwo', function(err, res) {
 From connections, you can create prepared statements (and only that) using `con.prepare()`:
 
 ```js
-const stmt = con.prepare('select ?::INTEGER as fortytwo');
+const stmt = con.prepare('SELECT ?::INTEGER AS fortytwo');
 ``` 
 
 To execute this statement, you can call for example `all()` on the `stmt` object:
@@ -107,7 +107,7 @@ con.all('SELECT * FROM a', function(err, res) {
 `prepare()` can also take a callback which gets the prepared statement as an argument:
 
 ```js
-const stmt = con.prepare('select ?::INTEGER as fortytwo', function(err, stmt) {
+const stmt = con.prepare('SELECT ?::INTEGER AS fortytwo', function(err, stmt) {
   stmt.all(42, function(err, res) {
     if (err) {
       throw err;

--- a/docs/api/python/data_ingestion.md
+++ b/docs/api/python/data_ingestion.md
@@ -10,15 +10,15 @@ CSV files can be read using the `read_csv` function, called either from within P
 ```python
 import duckdb
 # read from a file using fully auto-detected settings
-duckdb.read_csv('example.csv')
+duckdb.read_csv("example.csv")
 # read multiple CSV files from a folder
-duckdb.read_csv('folder/*.csv')
+duckdb.read_csv("folder/*.csv")
 # specify options on how the CSV is formatted internally
-duckdb.read_csv('example.csv', header=False, sep=',')
+duckdb.read_csv("example.csv", header=False, sep=",")
 # override types of the first two columns
-duckdb.read_csv('example.csv', dtype=['int', 'varchar'])
+duckdb.read_csv("example.csv", dtype=["int", "varchar"])
 # use the (experimental) parallel CSV reader
-duckdb.read_csv('example.csv', parallel=True)
+duckdb.read_csv("example.csv", parallel=True)
 # directly read a CSV file from within SQL
 duckdb.sql("SELECT * FROM 'example.csv'")
 # call read_csv from within SQL
@@ -34,9 +34,9 @@ Parquet files can be read using the `read_parquet` function, called either from 
 ```python
 import duckdb
 # read from a single Parquet file
-duckdb.read_parquet('example.parquet')
+duckdb.read_parquet("example.parquet")
 # read multiple Parquet files from a folder
-duckdb.read_parquet('folder/*.parquet')
+duckdb.read_parquet("folder/*.parquet")
 # directly read a Parquet file from within SQL
 duckdb.sql("SELECT * FROM 'example.parquet'")
 # call read_parquet from within SQL
@@ -52,9 +52,9 @@ JSON files can be read using the `read_json` function, called either from within
 ```python
 import duckdb
 # read from a single JSON file
-duckdb.read_json('example.json')
+duckdb.read_json("example.json")
 # read multiple JSON files from a folder
-duckdb.read_json('folder/*.json')
+duckdb.read_json("folder/*.json")
 # directly read a JSON file from within SQL
 duckdb.sql("SELECT * FROM 'example.json'")
 # call read_json from within SQL
@@ -68,8 +68,8 @@ DuckDB is automatically able to query a Pandas DataFrame, Polars DataFrame, or A
 ```python
 import duckdb
 import pandas as pd
-test_df = pd.DataFrame.from_dict({"i":[1, 2, 3, 4], "j":["one", "two", "three", "four"]})
-duckdb.sql('SELECT * FROM test_df').fetchall()
+test_df = pd.DataFrame.from_dict({"i": [1, 2, 3, 4], "j": ["one", "two", "three", "four"]})
+duckdb.sql("SELECT * FROM test_df").fetchall()
 # [(1, 'one'), (2, 'two'), (3, 'three'), (4, 'four')]
 ```
 
@@ -80,9 +80,9 @@ If your Pandas DataFrame is stored in another location, here is an example of ma
 import duckdb
 import pandas as pd
 my_dictionary = {}
-my_dictionary['test_df'] = pd.DataFrame.from_dict({"i":[1, 2, 3, 4], "j":["one", "two", "three", "four"]})
-duckdb.register('test_df_view', my_dictionary['test_df'])
-duckdb.sql('SELECT * FROM test_df_view').fetchall()
+my_dictionary["test_df"] = pd.DataFrame.from_dict({"i": [1, 2, 3, 4], "j": ["one", "two", "three", "four"]})
+duckdb.register("test_df_view", my_dictionary["test_df"])
+duckdb.sql("SELECT * FROM test_df_view").fetchall()
 # [(1, 'one'), (2, 'two'), (3, 'three'), (4, 'four')]
 ```
 
@@ -90,9 +90,9 @@ You can also create a persistent table in DuckDB from the contents of the DataFr
 
 ```python
 # create a new table from the contents of a DataFrame
-con.execute('CREATE TABLE test_df_table AS SELECT * FROM test_df')
+con.execute("CREATE TABLE test_df_table AS SELECT * FROM test_df")
 # insert into an existing table from the contents of a DataFrame
-con.execute('INSERT INTO test_df_table SELECT * FROM test_df')
+con.execute("INSERT INTO test_df_table SELECT * FROM test_df")
 ```
 
 ### Pandas DataFrames – `object` Columns
@@ -171,7 +171,7 @@ We check against `datetime.date.min` and `datetime.date.max` to convert to `-inf
 ```python
 my_list_value = [
     12345,
-    'test'
+    "test"
 ]
 ```
 Will become `VARCHAR[]` because 12345 can convert to `VARCHAR` but `test` can not convert to `INTEGER`.
@@ -186,11 +186,11 @@ If the dict has a structure similar to:
 
 ```python
 my_map_dict = {
-    'key': [
+    "key": [
         1, 2, 3
     ],
-    'value': [
-        'one', 'two', 'three'
+    "value": [
+        "one", "two", "three"
     ]
 }
 ```
@@ -206,9 +206,9 @@ Otherwise we'll try to convert it to a `STRUCT`.
 
 ```python
 my_struct_dict = {
-    1: 'one',
-    '2': 2,
-    'three': [1,2,3],
+    1: "one",
+    "2": 2,
+    "three": [1,2,3],
     False: True
 }
 ```

--- a/docs/api/python/dbapi.md
+++ b/docs/api/python/dbapi.md
@@ -16,9 +16,9 @@ You can also get a reference to this connection by providing the special value `
 ```python
 import duckdb
 
-duckdb.execute('CREATE TABLE tbl AS SELECT 42 a')
-con = duckdb.connect(':default:')
-con.sql('SELECT * FROM tbl')
+duckdb.execute("CREATE TABLE tbl AS SELECT 42 a")
+con = duckdb.connect(":default:")
+con.sql("SELECT * FROM tbl")
 # ┌───────┐
 # │   a   │
 # │ int32 │
@@ -30,13 +30,13 @@ con.sql('SELECT * FROM tbl')
 ```python
 import duckdb
 # to start an in-memory database
-con = duckdb.connect(database=':memory:')
+con = duckdb.connect(database=":memory:")
 # to use a database file (not shared between processes)
-con = duckdb.connect(database='my-db.duckdb', read_only=False)
+con = duckdb.connect(database="my-db.duckdb", read_only=False)
 # to use a database file (shared between processes)
-con = duckdb.connect(database='my-db.duckdb', read_only=True)
+con = duckdb.connect(database="my-db.duckdb", read_only=True)
 # to explicitly get the default connection
-con = duckdb.connect(database=':default:')
+con = duckdb.connect(database=":default:")
 ```
 If you want to create a second connection to an existing database, you can use the `cursor()` method. This might be useful for example to allow parallel threads running queries independently. A single connection is thread-safe but is locked for the duration of the queries, effectively serializing database access in this case.
 
@@ -75,10 +75,10 @@ Here are some examples:
 
 ```python
 # insert a row using prepared statements
-con.execute("INSERT INTO items VALUES (?, ?, ?)", ['laptop', 2000, 1])
+con.execute("INSERT INTO items VALUES (?, ?, ?)", ["laptop", 2000, 1])
 
 # insert several rows using prepared statements
-con.executemany("INSERT INTO items VALUES (?, ?, ?)", [['chainsaw', 500, 10], ['iphone', 300, 2]] )
+con.executemany("INSERT INTO items VALUES (?, ?, ?)", [["chainsaw", 500, 10], ["iphone", 300, 2]] )
 
 # query the database using a prepared statement
 con.execute("SELECT item FROM items WHERE value > ?", [400])
@@ -99,18 +99,19 @@ An example use:
 ```python
 import duckdb
 
-duckdb.execute("""
+res = duckdb.execute("""
     SELECT
         $my_param,
         $other_param,
         $also_param
     """,
     {
-        'my_param': 5,
-        'other_param': 'DuckDB',
-        'also_param': [42]
+        "my_param": 5,
+        "other_param": "DuckDB",
+        "also_param": [42]
     }
 ).fetchall()
+print(res)
 # [(5, 'DuckDB', [42])]
 ```
 

--- a/docs/api/python/function.md
+++ b/docs/api/python/function.md
@@ -17,8 +17,8 @@ def random_name():
     fake = Faker()
     return fake.name()
 
-duckdb.create_function('random_name', random_name, [], VARCHAR)
-res = duckdb.sql('select random_name()').fetchall()
+duckdb.create_function("random_name", random_name, [], VARCHAR)
+res = duckdb.sql("SELECT random_name()").fetchall()
 print(res)
 # [('Gerald Ashley',)]
 ```
@@ -55,14 +55,15 @@ con.remove_function(name)
 When the function has type annotation it's often possible to leave out all of the optional parameters.  
 Using `DuckDBPyType` we can implicitly convert many known types to DuckDBs type system.  
 For example:
+
 ```python
 import duckdb
 
 def my_function(x: int) -> str:
     return x
 
-duckdb.create_function('my_func', my_function)
-duckdb.sql('select my_func(42)')
+duckdb.create_function("my_func", my_function)
+duckdb.sql("SELECT my_func(42)")
 # ┌─────────────┐
 # │ my_func(42) │
 # │   varchar   │
@@ -76,7 +77,7 @@ If only the parameter list types can be inferred, you'll need to pass in `None` 
 ## Null Handling
 
 By default when functions receive a NULL value, this instantly returns NULL, as part of the default null handling.  
-When this is not desired, you need to explicitly set this parameter to `'special'`.
+When this is not desired, you need to explicitly set this parameter to `"special"`.
 
 ```python
 import duckdb
@@ -85,18 +86,14 @@ from duckdb.typing import *
 def dont_intercept_null(x):
     return 5
 
-duckdb.create_function('dont_intercept', dont_intercept_null, [BIGINT], BIGINT)
-res = duckdb.sql("""
-    select dont_intercept(NULL)
-""").fetchall()
+duckdb.create_function("dont_intercept", dont_intercept_null, [BIGINT], BIGINT)
+res = duckdb.sql("SELECT dont_intercept(NULL)").fetchall()
 print(res)
 # [(None,)]
 
-duckdb.remove_function('dont_intercept')
-duckdb.create_function('dont_intercept', dont_intercept_null, [BIGINT], BIGINT, null_handling='special')
-res = duckdb.sql("""
-    select dont_intercept(NULL)
-""").fetchall()
+duckdb.remove_function("dont_intercept")
+duckdb.create_function("dont_intercept", dont_intercept_null, [BIGINT], BIGINT, null_handling="special")
+res = duckdb.sql("SELECT dont_intercept(NULL)").fetchall()
 print(res)
 # [(5,)]
 ```
@@ -104,7 +101,7 @@ print(res)
 ## Exception Handling
 
 By default, when an exception is thrown from the Python function, we'll forward (re-throw) the exception.
-If you want to disable this behavior, and instead return null, you'll need to set this parameter to `'return_null'`
+If you want to disable this behavior, and instead return null, you'll need to set this parameter to `"return_null"`
 
 ```python
 import duckdb
@@ -113,18 +110,14 @@ from duckdb.typing import *
 def will_throw():
     raise ValueError("ERROR")
 
-duckdb.create_function('throws', will_throw, [], BIGINT)
+duckdb.create_function("throws", will_throw, [], BIGINT)
 try:
-    res = duckdb.sql("""
-        select throws()
-    """).fetchall()
+    res = duckdb.sql("SELECT throws()").fetchall()
 except duckdb.InvalidInputException as e:
     print(e)
 
-duckdb.create_function('doesnt_throw', will_throw, [], BIGINT, exception_handling='return_null')
-res = duckdb.sql("""
-    select doesnt_throw()
-""").fetchall()
+duckdb.create_function("doesnt_throw", will_throw, [], BIGINT, exception_handling="return_null")
+res = duckdb.sql("SELECT doesnt_throw()").fetchall()
 print(res)
 # [(None,)]
 ```
@@ -135,25 +128,34 @@ By default DuckDB will assume the created function is a *pure* function, meaning
 If your function does not follow that rule, for example when your function makes use of randomness, then you will need to mark this function as having `side_effects`.
 
 For example, this function will produce a new count for every invocation
+
 ```python
 def count() -> int:
     old = count.counter;
     count.counter += 1
     return old
+
 count.counter = 0
 ```
 
 If we create this function without marking it as having side effects, the result will be the following:
+
 ```python
 con = duckdb.connect()
-con.create_function('my_counter', count, side_effects=False)
-res = con.sql('select my_counter() from range(10)').fetchall()
+con.create_function("my_counter", count, side_effects=False)
+res = con.sql("SELECT my_counter() FROM range(10)").fetchall()
+print(res)
 # [(0,), (0,), (0,), (0,), (0,), (0,), (0,), (0,), (0,), (0,)]
 ```
+
 Which is obviously not the desired result, when we add `side_effects=True`, the result is as we would expect:
+
 ```python
-con.create_function('my_counter', count, side_effects=True)
-res = con.sql('select my_counter() from range(10)').fetchall()
+con.remove_function("my_counter")
+count.counter = 0
+con.create_function("my_counter", count, side_effects=True)
+res = con.sql("SELECT my_counter() FROM range(10)").fetchall()
+print(res)
 # [(0,), (1,), (2,), (3,), (4,), (5,), (6,), (7,), (8,), (9,)]
 ```
 
@@ -171,6 +173,7 @@ This will let the system know to provide arrow arrays of up to `STANDARD_VECTOR_
 
 When the function type is set to `native` the function will be provided with a single tuple at a time, and expect only a single value to be returned.  
 This can be useful to interact with Python libraries that don't operate on Arrow, such as `faker`:
+
 ```python
 import duckdb
 
@@ -181,8 +184,8 @@ def random_date():
     fake = Faker()
     return fake.date_between()
 
-duckdb.create_function('random_date', random_date, [], DATE, type='native')
-res = duckdb.sql('select random_date()').fetchall()
+duckdb.create_function("random_date", random_date, [], DATE, type="native")
+res = duckdb.sql("SELECT random_date()").fetchall()
 print(res)
 # [(datetime.date(2019, 5, 15),)]
 ```

--- a/docs/api/python/overview.md
+++ b/docs/api/python/overview.md
@@ -15,7 +15,7 @@ The most straight-forward manner of running SQL queries using DuckDB is using th
 
 ```python
 import duckdb
-duckdb.sql('SELECT 42').show()
+duckdb.sql("SELECT 42").show()
 ```
 
 This will run queries using an **in-memory database** that is stored globally inside the Python module. The result of the query is returned as a **Relation**. A relation is a symbolic representation of the query. The query is not executed until the result is fetched or requested to be printed to the screen.
@@ -24,8 +24,8 @@ Relations can be referenced in subsequent queries by storing them inside variabl
 
 ```python
 import duckdb
-r1 = duckdb.sql('SELECT 42 AS i')
-duckdb.sql('SELECT i * 2 AS k FROM r1').show()
+r1 = duckdb.sql("SELECT 42 AS i")
+duckdb.sql("SELECT i * 2 AS k FROM r1").show()
 ```
 
 ## Data Input
@@ -52,18 +52,18 @@ import duckdb
 
 # directly query a Pandas DataFrame
 import pandas as pd
-pandas_df = pd.DataFrame({'a': [42]})
-duckdb.sql('SELECT * FROM pandas_df')
+pandas_df = pd.DataFrame({"a": [42]})
+duckdb.sql("SELECT * FROM pandas_df")
 
 # directly query a Polars DataFrame
 import polars as pl
-polars_df = pl.DataFrame({'a': [42]})
-duckdb.sql('SELECT * FROM polars_df')
+polars_df = pl.DataFrame({"a": [42]})
+duckdb.sql("SELECT * FROM polars_df")
 
 # directly query a pyarrow table
 import pyarrow as pa
-arrow_table = pa.Table.from_pydict({'a':[42]})
-duckdb.sql('SELECT * FROM arrow_table')
+arrow_table = pa.Table.from_pydict({"a": [42]})
+duckdb.sql("SELECT * FROM arrow_table")
 ```
 
 ## Result Conversion
@@ -72,11 +72,11 @@ DuckDB supports converting query results efficiently to a variety of formats. Se
 
 ```python
 import duckdb
-duckdb.sql('SELECT 42').fetchall()   # Python objects
-duckdb.sql('SELECT 42').df()         # Pandas DataFrame
-duckdb.sql('SELECT 42').pl()         # Polars DataFrame
-duckdb.sql('SELECT 42').arrow()      # Arrow Table
-duckdb.sql('SELECT 42').fetchnumpy() # NumPy Arrays
+duckdb.sql("SELECT 42").fetchall()   # Python objects
+duckdb.sql("SELECT 42").df()         # Pandas DataFrame
+duckdb.sql("SELECT 42").pl()         # Polars DataFrame
+duckdb.sql("SELECT 42").arrow()      # Arrow Table
+duckdb.sql("SELECT 42").fetchnumpy() # NumPy Arrays
 ```
 
 ## Writing Data to Disk
@@ -85,21 +85,21 @@ DuckDB supports writing Relation objects directly to disk in a variety of format
 
 ```python
 import duckdb
-duckdb.sql('SELECT 42').write_parquet('out.parquet') # Write to a Parquet file
-duckdb.sql('SELECT 42').write_csv('out.csv')         # Write to a CSV file
+duckdb.sql("SELECT 42").write_parquet("out.parquet") # Write to a Parquet file
+duckdb.sql("SELECT 42").write_csv("out.csv")         # Write to a CSV file
 duckdb.sql("COPY (SELECT 42) TO 'out.parquet'")      # Copy to a parquet file
 ```
 
 ## Using an In-Memory Database
 
 When using DuckDB through `duckdb.sql()`, it operates on an **in-memory** database, i.e., no tables are persisted on disk.
-The `duckdb.connect()` method returns a connection to an in-memory database:
+Invoking the `duckdb.connect()` method without arguments returns a connection, which also uses an in-memory database:
 
 ```python
 import duckdb
 
 con = duckdb.connect()
-con.sql('SELECT 42 AS x').show()
+con.sql("SELECT 42 AS x").show()
 ```
 
 ## Persistent Storage
@@ -111,12 +111,12 @@ Any data written to that connection will be persisted, and can be reloaded by re
 import duckdb
 
 # create a connection to a file called 'file.db'
-con = duckdb.connect('file.db')
+con = duckdb.connect("file.db")
 # create a table and load data into it
-con.sql('CREATE TABLE test(i INTEGER)')
-con.sql('INSERT INTO test VALUES (42)')
+con.sql("CREATE TABLE test(i INTEGER)")
+con.sql("INSERT INTO test VALUES (42)")
 # query the table
-con.table('test').show()
+con.table("test").show()
 # explicitly close the connection
 con.close()
 # Note: connections also closed implicitly when they go out of scope
@@ -127,10 +127,10 @@ You can also use a context manager to ensure that the connection is closed:
 ```python
 import duckdb
 
-with duckdb.connect('file.db') as con:
-    con.sql('CREATE TABLE test(i INTEGER)')
-    con.sql('INSERT INTO test VALUES (42)')
-    con.table('test').show()
+with duckdb.connect("file.db") as con:
+    con.sql("CREATE TABLE test(i INTEGER)")
+    con.sql("INSERT INTO test VALUES (42)")
+    con.table("test").show()
     # the context manager closes the connection automatically
 ```
 

--- a/docs/api/python/overview.md
+++ b/docs/api/python/overview.md
@@ -34,13 +34,13 @@ DuckDB can ingest data from a wide variety of formats – both on-disk and in-me
 
 ```python
 import duckdb
-duckdb.read_csv('example.csv')                # read a CSV file into a Relation
-duckdb.read_parquet('example.parquet')        # read a Parquet file into a Relation
-duckdb.read_json('example.json')              # read a JSON file into a Relation
+duckdb.read_csv("example.csv")                # read a CSV file into a Relation
+duckdb.read_parquet("example.parquet")        # read a Parquet file into a Relation
+duckdb.read_json("example.json")              # read a JSON file into a Relation
 
-duckdb.sql('SELECT * FROM "example.csv"')     # directly query a CSV file
-duckdb.sql('SELECT * FROM "example.parquet"') # directly query a Parquet file
-duckdb.sql('SELECT * FROM "example.json"')    # directly query a JSON file
+duckdb.sql("SELECT * FROM 'example.csv'")     # directly query a CSV file
+duckdb.sql("SELECT * FROM 'example.parquet'") # directly query a Parquet file
+duckdb.sql("SELECT * FROM 'example.json'")    # directly query a JSON file
 ```
 
 ### DataFrames

--- a/docs/api/python/relational_api.md
+++ b/docs/api/python/relational_api.md
@@ -13,7 +13,7 @@ For example, here we create a relation from a SQL query:
 
 ```python
 import duckdb
-rel = duckdb.sql('SELECT * FROM range(10000000000) tbl(id)');
+rel = duckdb.sql("SELECT * FROM range(10000000000) tbl(id)")
 rel.show()
 ```
 
@@ -71,8 +71,8 @@ Relation objects can be queried through SQL through so-called **replacement scan
 
 ```python
 import duckdb
-rel = duckdb.sql('SELECT * FROM range(1000000) tbl(id)');
-duckdb.sql('SELECT sum(id) FROM rel').show()
+rel = duckdb.sql("SELECT * FROM range(1000000) tbl(id)")
+duckdb.sql("SELECT sum(id) FROM rel").show()
 ```
 
 ```text
@@ -94,8 +94,8 @@ Apply an (optionally grouped) aggregate over the relation. The system will autom
 
 ```python
 import duckdb
-rel = duckdb.sql('SELECT * FROM range(1000000) tbl(id)');
-rel.aggregate('id % 2 AS g, sum(id), min(id), max(id)')
+rel = duckdb.sql("SELECT * FROM range(1000000) tbl(id)")
+rel.aggregate("id % 2 AS g, sum(id), min(id), max(id)")
 ```
 
 ```text
@@ -114,8 +114,8 @@ Select all rows in the first relation, that do not occur in the second relation.
 
 ```python
 import duckdb
-r1 = duckdb.sql('SELECT * FROM range(10) tbl(id)');
-r2 = duckdb.sql('SELECT * FROM range(5) tbl(id)');
+r1 = duckdb.sql("SELECT * FROM range(10) tbl(id)")
+r2 = duckdb.sql("SELECT * FROM range(5) tbl(id)")
 r1.except_(r2).show()
 ```
 
@@ -138,8 +138,8 @@ Apply the given condition to the relation, filtering any rows that do not satisf
 
 ```python
 import duckdb
-rel = duckdb.sql('SELECT * FROM range(1000000) tbl(id)');
-rel.filter('id > 5').limit(3).show()
+rel = duckdb.sql("SELECT * FROM range(1000000) tbl(id)")
+rel.filter("id > 5").limit(3).show()
 ```
 
 ```text
@@ -159,8 +159,8 @@ Select the intersection of two relations - returning all rows that occur in both
 
 ```python
 import duckdb
-r1 = duckdb.sql('SELECT * FROM range(10) tbl(id)');
-r2 = duckdb.sql('SELECT * FROM range(5) tbl(id)');
+r1 = duckdb.sql("SELECT * FROM range(10) tbl(id)")
+r2 = duckdb.sql("SELECT * FROM range(5) tbl(id)")
 r1.intersect(r2).show()
 ```
 
@@ -177,15 +177,15 @@ r1.intersect(r2).show()
 └───────┘
 ```
 
-### `join(rel, condition, type = 'inner')`
+### `join(rel, condition, type = "inner")`
 
 Combine two relations, joining them based on the provided condition. 
 
 ```python
 import duckdb
-r1 = duckdb.sql('SELECT * FROM range(5) tbl(id)').set_alias('r1');
-r2 = duckdb.sql('SELECT * FROM range(10, 15) tbl(id)').set_alias('r2');
-r1.join(r2, 'r1.id + 10 = r2.id').show()
+r1 = duckdb.sql("SELECT * FROM range(5) tbl(id)").set_alias("r1")
+r2 = duckdb.sql("SELECT * FROM range(10, 15) tbl(id)").set_alias("r2")
+r1.join(r2, "r1.id + 10 = r2.id").show()
 ```
 
 ```text
@@ -207,7 +207,7 @@ Select the first *n* rows, optionally offset by *offset*.
 
 ```python
 import duckdb
-rel = duckdb.sql('SELECT * FROM range(1000000) tbl(id)');
+rel = duckdb.sql("SELECT * FROM range(1000000) tbl(id)")
 rel.limit(3).show()
 ```
 
@@ -228,8 +228,8 @@ Sort the relation by the given set of expressions.
 
 ```python
 import duckdb
-rel = duckdb.sql('SELECT * FROM range(1000000) tbl(id)');
-rel.order('id DESC').limit(3).show()
+rel = duckdb.sql("SELECT * FROM range(1000000) tbl(id)")
+rel.order("id DESC").limit(3).show()
 ```
 
 ```text
@@ -249,8 +249,8 @@ Apply the given expression to each row in the relation.
 
 ```python
 import duckdb
-rel = duckdb.sql('SELECT * FROM range(1000000) tbl(id)');
-rel.project('id + 10 AS id_plus_ten').limit(3).show()
+rel = duckdb.sql("SELECT * FROM range(1000000) tbl(id)")
+rel.project("id + 10 AS id_plus_ten").limit(3).show()
 ```
 
 ```text
@@ -270,8 +270,8 @@ Combine two relations, returning all rows in `r1` followed by all rows in `r2`. 
 
 ```python
 import duckdb
-r1 = duckdb.sql('SELECT * FROM range(5) tbl(id)');
-r2 = duckdb.sql('SELECT * FROM range(10, 15) tbl(id)');
+r1 = duckdb.sql("SELECT * FROM range(5) tbl(id)")
+r2 = duckdb.sql("SELECT * FROM range(10, 15) tbl(id)")
 r1.union(r2).show()
 ```
 

--- a/docs/guides/python/execute_sql.md
+++ b/docs/guides/python/execute_sql.md
@@ -32,8 +32,8 @@ By default, a global in-memory connection will be used. Any data stored in files
 After connecting, SQL queries can be executed using the `sql` command.
 
 ```python
-con = duckdb.connect('file.db')
-con.sql('CREATE TABLE integers(i INTEGER)')
-con.sql('INSERT INTO integers VALUES (42)')
-con.sql('SELECT * FROM integers').show()
+con = duckdb.connect("file.db")
+con.sql("CREATE TABLE integers(i INTEGER)")
+con.sql("INSERT INTO integers VALUES (42)")
+con.sql("SELECT * FROM integers").show()
 ```

--- a/docs/guides/python/polars.md
+++ b/docs/guides/python/polars.md
@@ -28,7 +28,7 @@ df = pl.DataFrame(
         "cars": ["beetle", "audi", "beetle", "beetle", "beetle"],
     }
 )
-duckdb.sql('SELECT * FROM df').show()
+duckdb.sql("SELECT * FROM df").show()
 ```
 
 ## DuckDB to Polars


### PR DESCRIPTION
This PR introduces a consistent style for strings in Python. My original motivation for doing this was #1538 but it's something we should do regardless.

Why double quotes?
* This is the style [preferred by Black](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#strings).
* If single quotes are used in SQL, then we can write e.g. `duckdb.sql("FROM 'my.csv'")` without escaping or using triple quotes/triple apostrophes.
