### PR TITLE
fix insertCSVFromPath in docs

### DIFF
--- a/docs/api/wasm/data_ingestion.md
+++ b/docs/api/wasm/data_ingestion.md
@@ -62,7 +62,7 @@ await Promise.all(streamInserts);
 const csvContent = '1|foo\n2|bar\n';
 await db.registerFileText(`data.csv`, csvContent);
 // ... with typed insert options
-await db.insertCSVFromPath('data.csv', {
+await c.insertCSVFromPath('data.csv', {
     schema: 'main',
     name: 'foo',
     detect: false,

--- a/docs/archive/0.8.1/api/wasm/data_ingestion.md
+++ b/docs/archive/0.8.1/api/wasm/data_ingestion.md
@@ -63,7 +63,7 @@ CSV
 const csvContent = '1|foo\n2|bar\n';
 await db.registerFileText(`data.csv`, csvContent);
 // ... with typed insert options
-await db.insertCSVFromPath('data.csv', {
+await c.insertCSVFromPath('data.csv', {
     schema: 'main',
     name: 'foo',
     detect: false,

--- a/docs/archive/0.9.0/api/wasm/data_ingestion.md
+++ b/docs/archive/0.9.0/api/wasm/data_ingestion.md
@@ -62,7 +62,7 @@ await Promise.all(streamInserts);
 const csvContent = '1|foo\n2|bar\n';
 await db.registerFileText(`data.csv`, csvContent);
 // ... with typed insert options
-await db.insertCSVFromPath('data.csv', {
+await c.insertCSVFromPath('data.csv', {
     schema: 'main',
     name: 'foo',
     detect: false,

--- a/docs/archive/0.9.1/api/wasm/data_ingestion.md
+++ b/docs/archive/0.9.1/api/wasm/data_ingestion.md
@@ -62,7 +62,7 @@ await Promise.all(streamInserts);
 const csvContent = '1|foo\n2|bar\n';
 await db.registerFileText(`data.csv`, csvContent);
 // ... with typed insert options
-await db.insertCSVFromPath('data.csv', {
+await c.insertCSVFromPath('data.csv', {
     schema: 'main',
     name: 'foo',
     detect: false,

--- a/docs/archive/0.9.2/api/wasm/data_ingestion.md
+++ b/docs/archive/0.9.2/api/wasm/data_ingestion.md
@@ -62,7 +62,7 @@ await Promise.all(streamInserts);
 const csvContent = '1|foo\n2|bar\n';
 await db.registerFileText(`data.csv`, csvContent);
 // ... with typed insert options
-await db.insertCSVFromPath('data.csv', {
+await c.insertCSVFromPath('data.csv', {
     schema: 'main',
     name: 'foo',
     detect: false,


### PR DESCRIPTION
insertCSVFromPath() is a function of the connection and not the database. Error message:
TypeError: Cannot read properties of undefined (reading 'columns')