### PR TITLE
Add script to find misaligned titles

### DIFF
--- a/_data/menu_docs_dev.json
+++ b/_data/menu_docs_dev.json
@@ -117,7 +117,7 @@
           "slug": "python",
           "subfolderitems": [
             {
-              "page": "Install",
+              "page": "Installation",
               "url": "install"
             },
             {

--- a/_data/menu_docs_dev.json
+++ b/_data/menu_docs_dev.json
@@ -121,7 +121,7 @@
               "url": "install"
             },
             {
-              "page": "Execute SQL",
+              "page": "Execution SQL",
               "url": "execute_sql"
             },
             {

--- a/_data/menu_docs_dev.json
+++ b/_data/menu_docs_dev.json
@@ -35,7 +35,7 @@
               "url": "parquet_export"
             },
             {
-              "page": "Query Parquet",
+              "page": "Querying Parquet Files",
               "url": "query_parquet"
             },
             {
@@ -161,23 +161,23 @@
               "url": "multiple_threads"
             },
             {
-              "page": "DuckDB with Ibis",
+              "page": "Integration with Ibis",
               "url": "ibis"
             },
             {
-              "page": "DuckDB with Polars",
+              "page": "Integration with Polars",
               "url": "polars"
             },
             {
-              "page": "DuckDB with Vaex",
+              "page": "Integration with Vaex",
               "url": "vaex"
             },
             {
-              "page": "DuckDB with DataFusion",
+              "page": "Integration with DataFusion",
               "url": "datafusion"
             },
             {
-              "page": "DuckDB with fsspec Filesystems",
+              "page": "Using fsspec Filesystems",
               "url": "filesystems"
             }
           ]
@@ -215,7 +215,7 @@
               "url": "tableau"
             },
             {
-              "page": "YouPlot",
+              "page": "CLI Charting with YouPlot",
               "url": "youplot"
             }
           ]
@@ -345,7 +345,7 @@
                   "url": "connect"
                 },
                 {
-                  "page": "Configure",
+                  "page": "Configuration",
                   "url": "config"
                 },
                 {
@@ -811,7 +811,7 @@
                 "url": "comparison_operators"
               },
               {
-                "page": "In",
+                "page": "IN Operator",
                 "url": "in"
               },
               {
@@ -899,7 +899,7 @@
             ]
           },
           {
-            "page": "Aggregates",
+            "page": "Aggregate Functions",
             "url": "aggregates"
           },
           {

--- a/docs/api/nodejs/reference.md
+++ b/docs/api/nodejs/reference.md
@@ -1,6 +1,6 @@
 ---
 layout: docu
-title: NodeJS API
+title: Node.js API
 ---
 ## Modules
 

--- a/docs/guides/data_viewers/youplot.md
+++ b/docs/guides/data_viewers/youplot.md
@@ -1,6 +1,6 @@
 ---
 layout: docu
-title: CLI Charting - Using DuckDB with CLI Tools
+title: CLI Charting with YouPlot
 ---
 
 DuckDB can be used with CLI graphing tools to quickly pipe input to stdout to graph your data in one line.

--- a/docs/guides/import/query_parquet.md
+++ b/docs/guides/import/query_parquet.md
@@ -1,6 +1,6 @@
 ---
 layout: docu
-title: Parquet Import
+title: Querying Parquet Files
 ---
 
 To run a query directly on a Parquet file, use the `read_parquet` function in the `FROM` clause of a query. 

--- a/docs/guides/import/s3_import.md
+++ b/docs/guides/import/s3_import.md
@@ -1,6 +1,6 @@
 ---
 layout: docu
-title: S3, GCS, or R2 Parquet Import
+title: S3 Parquet Import
 ---
 
 To load a Parquet file from S3, the [`httpfs` extension](../../extensions/httpfs) is required. This can be installed use the `INSTALL` SQL command. This only needs to be run once.

--- a/docs/guides/import/s3_import.md
+++ b/docs/guides/import/s3_import.md
@@ -41,6 +41,8 @@ After the `httpfs` extension is set up and the S3 configuration is set correctly
 SELECT * FROM read_parquet('s3://<bucket>/<file>');
 ```
 
+## Google Cloud Storage (GCS)
+
 For Google Cloud Storage (GCS), the Interoperability API enables you to have access to it like an S3 connection.
 You need to create [HMAC keys](https://console.cloud.google.com/storage/settings;tab=interoperability) and declare them:
 
@@ -55,6 +57,8 @@ Please note you will need to use the `s3://` URL to read your data.
 ```sql
 SELECT * FROM read_parquet('s3://<gcs_bucket>/<file>');
 ```
+
+## Cloudflare R2
 
 For Cloudflare R2, the [S3 Compatibility API](https://developers.cloudflare.com/r2/data-access/s3-api/api/) allows you to use DuckDB's S3 support to read and write from R2 buckets. You will need to [generate an S3 auth token](https://developers.cloudflare.com/r2/data-access/s3-api/tokens/) and update the `s3_endpoint` used:
 

--- a/docs/guides/meta/explain.md
+++ b/docs/guides/meta/explain.md
@@ -1,6 +1,6 @@
 ---
 layout: docu
-title: Explain
+title: Inspecting Query Plans Using `EXPLAIN`
 ---
 
 In order to view the query plan of a query, prepend `EXPLAIN` to a query.

--- a/docs/guides/python/datafusion.md
+++ b/docs/guides/python/datafusion.md
@@ -1,6 +1,6 @@
 ---
 layout: docu
-title: DuckDB with DataFusion
+title: Integration with DataFusion
 ---
 
 [DataFusion](https://github.com/apache/arrow-datafusion-python/) is a DataFrame and SQL library built in Rust with bindings for Python. It uses [Apache Arrow's columnar format](https://arrow.apache.org/docs/format/Columnar.html) as its memory model.

--- a/docs/guides/python/execute_sql.md
+++ b/docs/guides/python/execute_sql.md
@@ -1,9 +1,9 @@
 ---
 layout: docu
-title: Execute SQL
+title: Executing SQL in Python
 ---
 
-SQL queries can be executed using the `duckdb.sql` command.
+SQL queries can be executed using the `duckdb.sql` function.
 
 ```python
 import duckdb

--- a/docs/guides/python/filesystems.md
+++ b/docs/guides/python/filesystems.md
@@ -1,5 +1,5 @@
 ---
-title: Filesystems
+title: Using fsspec Filesystems
 layout: docu
 ---
 

--- a/docs/guides/python/ibis.md
+++ b/docs/guides/python/ibis.md
@@ -1,6 +1,6 @@
 ---
 layout: docu
-title: DuckDB with Ibis
+title: Integration with Ibis
 ---
 
 [Ibis](https://ibis-project.org) is a Python dataframe library that supports 15+ backends, with DuckDB as the default. Ibis with DuckDB provides a Pythonic interface for SQL with great performance.

--- a/docs/guides/python/install.md
+++ b/docs/guides/python/install.md
@@ -1,7 +1,9 @@
 ---
 layout: docu
-title: Install the Python Client
+title: Installing the Python Client
 ---
+
+## Installing via Pip
 
 The latest release of the Python client can be installed using `pip`.
 
@@ -14,6 +16,8 @@ The pre-release Python client can be installed using `--pre`.
 ```bash
 pip install duckdb --upgrade --pre
 ```
+
+## Installing from Source
 
 The latest Python client can be installed from source from the [`tools/pythonpkg` directory in the DuckDB GitHub repository](https://github.com/duckdb/duckdb/tree/main/tools/pythonpkg).
 

--- a/docs/guides/python/polars.md
+++ b/docs/guides/python/polars.md
@@ -1,6 +1,6 @@
 ---
 layout: docu
-title: DuckDB with Polars
+title: Integration with Polars
 ---
 
 [Polars](https://github.com/pola-rs/polars) is a DataFrames library built in Rust with bindings for Python and Node.js. It uses [Apache Arrow's columnar format](https://arrow.apache.org/docs/format/Columnar.html) as its memory model. DuckDB can read Polars DataFrames and convert query results to Polars DataFrames. It does this internally using the efficient Apache Arrow integration. Note that the `pyarrow` library must be installed for the integration to work.

--- a/docs/guides/python/vaex.md
+++ b/docs/guides/python/vaex.md
@@ -1,6 +1,6 @@
 ---
 layout: docu
-title: DuckDB with Vaex
+title: Integration with Vaex
 ---
 
 [Vaex](https://github.com/vaexio/vaex/) is a high performance DataFrame library in Python. Vaex is a hybrid DataFrame, as it supports both [Numpy's](https://numpy.org/doc/stable/) and [Apache Arrow's](https://arrow.apache.org/docs/python/index.html) data structures.

--- a/docs/guides/sql_features/asof_join.md
+++ b/docs/guides/sql_features/asof_join.md
@@ -1,6 +1,6 @@
 ---
 layout: docu
-title: DuckDB ASOF Join
+title: ASOF JOIN
 ---
 
 Problem: we have a time-based price table; traditional joins against this table get NULL

--- a/docs/sql/data_types/timestamp.md
+++ b/docs/sql/data_types/timestamp.md
@@ -64,11 +64,6 @@ The `TIMESTAMPTZ` type can be binned into calendar and clock bins using a suitab
 The built-in [ICU extension](../../extensions/icu) implements all the binning and arithmetic functions using the
 [International Components for Unicode](https://icu.unicode.org) time zone and calendar functions.
 
-<!-- 
-    To find the ICU installation information, for Python and R look in CMakeLists.txt.
-    For JDBC/ODBC, check the GitHub Actions CI workflows (duckdb/.github/workflows/). 
-    For NodeJS, I couldn't find anything
--->
 To set the time zone to use, first load the ICU extension. The ICU extension comes pre-bundled with several DuckDB clients (including Python, R, JDBC, and ODBC), so this step can be skipped in those cases. In other cases you might first need to install and load the ICU extension.
 
 ```sql

--- a/docs/sql/functions/dateformat.md
+++ b/docs/sql/functions/dateformat.md
@@ -1,6 +1,6 @@
 ---
 layout: docu
-title: Date Format
+title: Date Format Functions
 ---
 
 The `strftime` and `strptime` functions can be used to convert between dates/timestamps and strings. This is often required when parsing CSV files, displaying output to the user or transferring information between programs. Because there are many possible date representations, these functions accept a format string that describes how the date or timestamp should be structured.

--- a/docs/sql/functions/datepart.md
+++ b/docs/sql/functions/datepart.md
@@ -1,6 +1,6 @@
 ---
 layout: docu
-title: Date Parts
+title: Date Part Functions
 ---
 
 The `date_part` and `date_diff` and `date_trunc` functions can be used to manipulate the fields of temporal types.

--- a/internals/repositories.md
+++ b/internals/repositories.md
@@ -13,7 +13,7 @@ Several components of DuckDB are maintained in separate repositories.
 
 ## Clients
 
-* [`duckdb-node`](https://github.com/duckdb/duckdb-node): Node.JS client
+* [`duckdb-node`](https://github.com/duckdb/duckdb-node): Node.js client
 * [`duckdb-r`](https://github.com/duckdb/duckdb-r): R client
 * [`duckdb-rs`](https://github.com/duckdb/duckdb-rs): Rust client
 * [`duckdb-swift`](https://github.com/duckdb/duckdb-swift): Swift client

--- a/scripts/find_misaligned_titles.py
+++ b/scripts/find_misaligned_titles.py
@@ -79,7 +79,6 @@ def check_section(docs_root, data, section_title):
 
 docs_root = "../docs"
 
-# compile concatenated document
 with open("../_data/menu_docs_dev.json") as menu_docs_file:
     data = json.load(menu_docs_file)
     check_section(docs_root, data, "Documentation")

--- a/scripts/find_misaligned_titles.py
+++ b/scripts/find_misaligned_titles.py
@@ -4,10 +4,11 @@ import frontmatter
 
 # This script finds misaligned titles, i.e., instances where the page title displayed in the menu bar
 # (on the left side) and the title in the page header do not align.
-# 
+#
 # Usage: in the scripts/ directory, run
 #
 # $ python find_misaligned_titles.py
+
 
 def check_page_for_misaligned_title(menu_bar_title, docs_root, doc_file_path):
     # skip index files
@@ -21,7 +22,7 @@ def check_page_for_misaligned_title(menu_bar_title, docs_root, doc_file_path):
     with open(doc_file_full_path) as doc_file:
         doc = frontmatter.load(doc_file)
         doc_title = doc["title"]
-    
+
     if menu_bar_title == "Overview":
         return
 
@@ -43,7 +44,9 @@ def check_section(docs_root, data, section_title):
         main_slug = main_level_page.get("slug")
 
         if main_url:
-            check_page_for_misaligned_title(main_title, docs_root, f"{section_slug}{main_url}")
+            check_page_for_misaligned_title(
+                main_title, docs_root, f"{section_slug}{main_url}"
+            )
 
         if not main_slug:
             continue
@@ -54,7 +57,11 @@ def check_section(docs_root, data, section_title):
             subfolder_slug = subfolder_page.get("slug")
 
             if subfolder_url:
-                check_page_for_misaligned_title(subfolder_page_title, docs_root, f"{section_slug}{main_slug}/{subfolder_url}")
+                check_page_for_misaligned_title(
+                    subfolder_page_title,
+                    docs_root,
+                    f"{section_slug}{main_slug}/{subfolder_url}",
+                )
 
             if not subfolder_slug:
                 continue
@@ -63,7 +70,11 @@ def check_section(docs_root, data, section_title):
                 subsubfolder_page_title = subsubfolder_page["page"]
                 subsubfolder_url = subsubfolder_page.get("url")
 
-                check_page_for_misaligned_title(subsubfolder_page_title, docs_root, f"{section_slug}{main_slug}/{subfolder_slug}/{subsubfolder_url}")
+                check_page_for_misaligned_title(
+                    subsubfolder_page_title,
+                    docs_root,
+                    f"{section_slug}{main_slug}/{subfolder_slug}/{subsubfolder_url}",
+                )
 
 
 docs_root = "../docs"

--- a/scripts/find_misaligned_titles.py
+++ b/scripts/find_misaligned_titles.py
@@ -1,0 +1,75 @@
+import json
+import os
+import frontmatter
+
+# This script finds misaligned titles, i.e., instances where the page title displayed in the menu bar
+# (on the left side) and the title in the page header do not align.
+# 
+# Usage: in the scripts/ directory, run
+#
+# $ python find_misaligned_titles.py
+
+def check_page_for_misaligned_title(menu_bar_title, docs_root, doc_file_path):
+    # skip index files
+    if doc_file_path.endswith("index"):
+        return
+    doc_file_full_path = f"{docs_root}/{doc_file_path}.md"
+
+    if not os.path.exists(doc_file_full_path):
+        doc_file_full_path = f"{docs_root}/{doc_file_path}/index.md"
+
+    with open(doc_file_full_path) as doc_file:
+        doc = frontmatter.load(doc_file)
+        doc_title = doc["title"]
+    
+    if menu_bar_title == "Overview":
+        return
+
+    if menu_bar_title != doc_title and not menu_bar_title in doc_title:
+        print(doc_file_path)
+        print(f"- menu title: {menu_bar_title}")
+        print(f"- doc title:  {doc_title}")
+        print()
+
+
+def check_section(docs_root, data, section_title):
+    section_json = [x for x in data["docsmenu"] if x["page"] == section_title][0]
+    section_slug = section_json["slug"]
+    main_level_pages = section_json["mainfolderitems"]
+
+    for main_level_page in main_level_pages:
+        main_title = main_level_page["page"]
+        main_url = main_level_page.get("url")
+        main_slug = main_level_page.get("slug")
+
+        if main_url:
+            check_page_for_misaligned_title(main_title, docs_root, f"{section_slug}{main_url}")
+
+        if not main_slug:
+            continue
+
+        for subfolder_page in main_level_page["subfolderitems"]:
+            subfolder_page_title = subfolder_page["page"]
+            subfolder_url = subfolder_page.get("url")
+            subfolder_slug = subfolder_page.get("slug")
+
+            if subfolder_url:
+                check_page_for_misaligned_title(subfolder_page_title, docs_root, f"{section_slug}{main_slug}/{subfolder_url}")
+
+            if not subfolder_slug:
+                continue
+
+            for subsubfolder_page in subfolder_page["subsubfolderitems"]:
+                subsubfolder_page_title = subsubfolder_page["page"]
+                subsubfolder_url = subsubfolder_page.get("url")
+
+                check_page_for_misaligned_title(subsubfolder_page_title, docs_root, f"{section_slug}{main_slug}/{subfolder_slug}/{subsubfolder_url}")
+
+
+docs_root = "../docs"
+
+# compile concatenated document
+with open("../_data/menu_docs_dev.json") as menu_docs_file:
+    data = json.load(menu_docs_file)
+    check_section(docs_root, data, "Documentation")
+    check_section(docs_root, data, "Guides")


### PR DESCRIPTION
Adds a script and fixes #1551

I dropped "DuckDB" from most titles. Jekyll adds "- DuckDB" anyways and there's a DuckDB logo in the top left, so the users know that they are reading a DuckDB page.