### PR TITLE
Add s3 iceberg import guide

### DIFF
--- a/_data/menu_docs_dev.json
+++ b/_data/menu_docs_dev.json
@@ -51,6 +51,10 @@
               "url": "s3_export"
             },
             {
+              "page": "S3 iceberg Import",
+              "url": "s3_iceberg_import"
+            },
+            {
               "page": "JSON Import",
               "url": "json_import"
             },
@@ -220,7 +224,6 @@
             }
           ]
         }
-
       ]
     },
     {
@@ -795,157 +798,157 @@
               ]
             },
             {
-            "page": "Expressions",
-            "slug": "expressions",
-            "subsubfolderitems": [
-              {
-                "page": "Overview",
-                "url": "overview"
-              },
-              {
-                "page": "Case",
-                "url": "case"
-              },
-              {
-                "page": "Casting",
-                "url": "cast"
-              },
-              {
-                "page": "Collations",
-                "url": "collations"
-              },
-              {
-                "page": "Comparisons",
-                "url": "comparison_operators"
-              },
-              {
-                "page": "IN Operator",
-                "url": "in"
-              },
-              {
-                "page": "Logical",
-                "url": "logical_operators"
-              },
-              {
-                "page": "Star",
-                "url": "star"
-              },
-              {
-                "page": "Subqueries",
-                "url": "subqueries"
-              }
-            ]
-          },
-          {
-            "page": "Functions",
-            "slug": "functions",
-            "subsubfolderitems": [
-              {
-                "page": "Overview",
-                "url": "overview"
-              },
-              {
-                "page": "Bitstring Functions",
-                "url": "bitstring"
-              },
-              {
-                "page": "Blob Functions",
-                "url": "blob"
-              },
-              {
-                "page": "Date Format Functions",
-                "url": "dateformat"
-              },
-              {
-                "page": "Date Functions",
-                "url": "date"
-              },
-              {
-                "page": "Date Part Functions",
-                "url": "datepart"
-              },
-              {
-                "page": "Enum Functions",
-                "url": "enum"
-              },
-              {
-                "page": "Interval Functions",
-                "url": "interval"
-              },
-              {
-                "page": "Nested Functions",
-                "url": "nested"
-              },
-              {
-                "page": "Numeric Functions",
-                "url": "numeric"
-              },
-              {
-                "page": "Pattern Matching",
-                "url": "patternmatching"
-              },
-              {
-                "page": "Text Functions",
-                "url": "char"
-              },
-              {
-                "page": "Time Functions",
-                "url": "time"
-              },
-              {
-                "page": "Timestamp Functions",
-                "url": "timestamp"
-              },
-              {
-                "page": "Timestamp with Time Zone Functions",
-                "url": "timestamptz"
-              },
-              {
-                "page": "Utility Functions",
-                "url": "utility"
-              }
-            ]
-          },
-          {
-            "page": "Aggregate Functions",
-            "url": "aggregates"
-          },
-          {
-            "page": "Configuration",
-            "url": "configuration"
-          },
-          {
-            "page": "Constraints",
-            "url": "constraints"
-          },
-          {
-            "page": "Indexes",
-            "url": "indexes"
-          },
-          {
-            "page": "Information Schema",
-            "url": "information_schema"
-          },
-          {
-            "page": "Metadata Functions",
-            "url": "duckdb_table_functions"
-          },
-          {
-            "page": "Pragmas",
-            "url": "pragmas"
-          },
-          {
-            "page": "Rules for Case Sensitivity",
-            "url": "case_sensitivity"
-          },
-          {
-            "page": "Samples",
-            "url": "samples"
-          },
-          {
-            "page": "Window Functions",
-            "url": "window_functions"
-          }
+              "page": "Expressions",
+              "slug": "expressions",
+              "subsubfolderitems": [
+                {
+                  "page": "Overview",
+                  "url": "overview"
+                },
+                {
+                  "page": "Case",
+                  "url": "case"
+                },
+                {
+                  "page": "Casting",
+                  "url": "cast"
+                },
+                {
+                  "page": "Collations",
+                  "url": "collations"
+                },
+                {
+                  "page": "Comparisons",
+                  "url": "comparison_operators"
+                },
+                {
+                  "page": "IN Operator",
+                  "url": "in"
+                },
+                {
+                  "page": "Logical",
+                  "url": "logical_operators"
+                },
+                {
+                  "page": "Star",
+                  "url": "star"
+                },
+                {
+                  "page": "Subqueries",
+                  "url": "subqueries"
+                }
+              ]
+            },
+            {
+              "page": "Functions",
+              "slug": "functions",
+              "subsubfolderitems": [
+                {
+                  "page": "Overview",
+                  "url": "overview"
+                },
+                {
+                  "page": "Bitstring Functions",
+                  "url": "bitstring"
+                },
+                {
+                  "page": "Blob Functions",
+                  "url": "blob"
+                },
+                {
+                  "page": "Date Format Functions",
+                  "url": "dateformat"
+                },
+                {
+                  "page": "Date Functions",
+                  "url": "date"
+                },
+                {
+                  "page": "Date Part Functions",
+                  "url": "datepart"
+                },
+                {
+                  "page": "Enum Functions",
+                  "url": "enum"
+                },
+                {
+                  "page": "Interval Functions",
+                  "url": "interval"
+                },
+                {
+                  "page": "Nested Functions",
+                  "url": "nested"
+                },
+                {
+                  "page": "Numeric Functions",
+                  "url": "numeric"
+                },
+                {
+                  "page": "Pattern Matching",
+                  "url": "patternmatching"
+                },
+                {
+                  "page": "Text Functions",
+                  "url": "char"
+                },
+                {
+                  "page": "Time Functions",
+                  "url": "time"
+                },
+                {
+                  "page": "Timestamp Functions",
+                  "url": "timestamp"
+                },
+                {
+                  "page": "Timestamp with Time Zone Functions",
+                  "url": "timestamptz"
+                },
+                {
+                  "page": "Utility Functions",
+                  "url": "utility"
+                }
+              ]
+            },
+            {
+              "page": "Aggregate Functions",
+              "url": "aggregates"
+            },
+            {
+              "page": "Configuration",
+              "url": "configuration"
+            },
+            {
+              "page": "Constraints",
+              "url": "constraints"
+            },
+            {
+              "page": "Indexes",
+              "url": "indexes"
+            },
+            {
+              "page": "Information Schema",
+              "url": "information_schema"
+            },
+            {
+              "page": "Metadata Functions",
+              "url": "duckdb_table_functions"
+            },
+            {
+              "page": "Pragmas",
+              "url": "pragmas"
+            },
+            {
+              "page": "Rules for Case Sensitivity",
+              "url": "case_sensitivity"
+            },
+            {
+              "page": "Samples",
+              "url": "samples"
+            },
+            {
+              "page": "Window Functions",
+              "url": "window_functions"
+            }
           ]
         },
         {

--- a/_data/menu_docs_dev.json
+++ b/_data/menu_docs_dev.json
@@ -51,7 +51,7 @@
               "url": "s3_export"
             },
             {
-              "page": "S3 iceberg Import",
+              "page": "S3 Iceberg Import",
               "url": "s3_iceberg_import"
             },
             {

--- a/docs/guides/import/s3_iceberg_import.md
+++ b/docs/guides/import/s3_iceberg_import.md
@@ -4,21 +4,23 @@ title: S3 Iceberg Import
 selected: S3 Iceberg Import
 ---
 
-# How to load an Iceberg table directly from S3
+## Prerequisites
 
-To load an Iceberg file from S3, both the `HTTPFS` and `iceberg` extensions are required. This can be installed use the `INSTALL` SQL command. This only needs to be run once.
+To load an Iceberg file from S3, both the [`httpfs`](../../extensions/httpfs) and [`iceberg`](../../extensions/iceberg) extensions are required. They can be installed use the `INSTALL` SQL command. The extensions only need to be installed once.
 
 ```sql
 INSTALL httpfs;
 INSTALL iceberg;
 ```
 
-To load the extensions for usage, use the `LOAD` SQL command:
+To load the extensions for usage, use the `LOAD` command:
 
 ```sql
 LOAD httpfs;
 LOAD iceberg;
 ```
+
+## Credentials
 
 After loading the extensions, set up the credentials and S3 region to read data. You may either use an access key and secret, or a token.
 
@@ -27,30 +29,31 @@ SET s3_region='us-east-1';
 SET s3_access_key_id='<AWS access key id>';
 SET s3_secret_access_key='<AWS secret access key>';
 ```
+
 The alternative is to use a token:
+
 ```sql
 SET s3_region='us-east-1';
 SET s3_session_token='<AWS session token>';
 ```
 
-Note: You can additionaly use the aws extension to retrieve the credentials from the aws config file. See [AWS Credentials](/docs/extensions/aws.html) for more information. To load the credentials:
+ALternatively, use the [`aws` extension](../../extensions/aws) to retrieve the credentials from the aws config file. To load the credentials:
 
 ```sql
 CALL load_aws_credentials();
 ```
 
+## Loading Iceberg Tables from S3
+
 After the extensions are set up and the S3 credentials are correctly configured, Iceberg table can be read from S3 using the following command:
 
 ```sql
 SELECT *
-FROM
-    iceberg_scan('s3://<bucket>/<iceberg-table-folder>/metadata/<id>.metadata.json')
+FROM iceberg_scan('s3://<bucket>/<iceberg-table-folder>/metadata/<id>.metadata.json')
 ```
 
-Note: Note that you need to link directly to the manifest file. Otherwise you'll get an error like this:
+Note that you need to link directly to the manifest file. Otherwise you'll get an error like this:
 
-```shell
+```text
 Error: IO Error: Cannot open file "s3://<bucket>/<iceberg-table-folder>/metadata/version-hint.text": No such file or directory
 ```
-
-

--- a/docs/guides/import/s3_iceberg_import.md
+++ b/docs/guides/import/s3_iceberg_import.md
@@ -33,10 +33,10 @@ SET s3_region='us-east-1';
 SET s3_session_token='<AWS session token>';
 ```
 
-Note: You can additionaly use the aws extension to retrieve the credentials from the aws config file. See [AWS Credentials](/docs/0.4.0/extensions/aws.html) for more information. To load the credentials:
+Note: You can additionaly use the aws extension to retrieve the credentials from the aws config file. See [AWS Credentials](/docs/extensions/aws.html) for more information. To load the credentials:
 
 ```sql
-call load_aws_credentials();
+CALL load_aws_credentials();
 ```
 
 After the extensions are set up and the S3 credentials are correctly configured, Iceberg table can be read from S3 using the following command:

--- a/docs/guides/import/s3_iceberg_import.md
+++ b/docs/guides/import/s3_iceberg_import.md
@@ -1,0 +1,56 @@
+---
+layout: docu
+title: S3 Iceberg Import
+selected: S3 Iceberg Import
+---
+
+# How to load an Iceberg table directly from S3
+
+To load an Iceberg file from S3, both the `HTTPFS` and `iceberg` extensions are required. This can be installed use the `INSTALL` SQL command. This only needs to be run once.
+
+```sql
+INSTALL httpfs;
+INSTALL iceberg;
+```
+
+To load the extensions for usage, use the `LOAD` SQL command:
+
+```sql
+LOAD httpfs;
+LOAD iceberg;
+```
+
+After loading the extensions, set up the credentials and S3 region to read data. You may either use an access key and secret, or a token.
+
+```sql
+SET s3_region='us-east-1';
+SET s3_access_key_id='<AWS access key id>';
+SET s3_secret_access_key='<AWS secret access key>';
+```
+The alternative is to use a token:
+```sql
+SET s3_region='us-east-1';
+SET s3_session_token='<AWS session token>';
+```
+
+Note: You can additionaly use the aws extension to retrieve the credentials from the aws config file. See [AWS Credentials](/docs/0.4.0/extensions/aws.html) for more information. To load the credentials:
+
+```sql
+call load_aws_credentials();
+```
+
+After the extensions are set up and the S3 credentials are correctly configured, Iceberg table can be read from S3 using the following command:
+
+```sql
+SELECT *
+FROM
+    iceberg_scan('s3://<bucket>/<iceberg-table-folder>/metadata/<id>.metadata.json')
+```
+
+Note: Note that you need to link directly to the manifest file. Otherwise you'll get an error like this:
+
+```shell
+Error: IO Error: Cannot open file "s3://<bucket>/<iceberg-table-folder>/metadata/version-hint.text": No such file or directory
+```
+
+

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -32,6 +32,7 @@ The guides section contains compact how-to guides that are focused on achieving 
 
 * [How to load a Parquet file directly from HTTP(S)](../guides/import/http_import)
 * [How to load a Parquet file directly from S3 or GCS](../guides/import/s3_import)
+* [How to load an Iceberg table directly from S3](../guides/import/s3_iceberg_import)
 
 ## Meta Queries
 


### PR DESCRIPTION
Adds a new guide to better explain how to retrieve an iceberg table from S3. Up until now all examples were for local files.