### PR TITLE
Add note about using the list aggregate function to create lists from columns

### DIFF
--- a/docs/sql/data_types/list.md
+++ b/docs/sql/data_types/list.md
@@ -13,7 +13,7 @@ See the [data types overview](../../sql/data_types/overview) for a comparison be
 
 ## Creating Lists
 
-Lists can be created using the [`list_value(expr, ...)`](../functions/nested#list-functions) function or the equivalent bracket notation `[expr, ...]`. The expressions can be constants or arbitrary expressions.
+Lists can be created using the [`list_value(expr, ...)`](../functions/nested#list-functions) function or the equivalent bracket notation `[expr, ...]`. The expressions can be constants or arbitrary expressions. To create a list from a table column, use the [`list`](../aggregates.md#general-aggregate-functions) aggregate function.
 
 ```sql
 -- List of integers


### PR DESCRIPTION
After hearing a talk yesterday about DuckDB's list functions, I started playing with it. However, it took me a very long time to figure out how to create a list from a table column since I tried to somehow do it using the `list_value` function. Only by chance I stumbled across the `list` aggregate function which does the job.

To help people like myself in the future, I added a short note to the _Creating Lists_ section that refers to the `list` aggregate function.