### PR TITLE
Remove CLI example for the SQL intro

### DIFF
--- a/docs/sql/introduction.md
+++ b/docs/sql/introduction.md
@@ -5,18 +5,7 @@ title: SQL Introduction
 
 Here we provide an overview of how to perform simple operations in SQL. This tutorial is only intended to give you an introduction and is in no way a complete tutorial on SQL. This tutorial is adapted from the [PostgreSQL tutorial](https://www.postgresql.org/docs/11/tutorial-sql-intro.html).
 
-In the examples that follow, we assume that you have installed the DuckDB Command Line Interface (CLI) shell. See the [installation page](../installation?environment=cli) for information on how to install the CLI. Launching the shell should give you the following prompt:
-
-```text
-v0.9.2 3c695d7ba9
-Enter ".help" for usage hints.
-Connected to a transient in-memory database.
-Use ".open FILENAME" to reopen on a persistent database.
-D
-```
-
-
-> By launching the database like this, an **in-memory database is launched**. That means that no data is persisted on disk. To persist data on disk you should also pass a database path to the shell. The database will then be stored at that path and can be reloaded from disk later.
+In the examples that follow, we assume that you have installed the DuckDB Command Line Interface (CLI) shell. See the [installation page](../installation?environment=cli) for information on how to install the CLI.
 
 ## Concepts
 


### PR DESCRIPTION
I find it a bit strange that the SQL intro starts with a run-down of the CLI client, it prompt, and how it handles persistence. I'd say that these are hardly relevant – and presumably many readers of the SQL intro will have a different setup (e.g. DBeaver).