### PR TITLE
Move shell autocomplete rules to the autocomplete extension's page

### DIFF
--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -165,29 +165,6 @@ Error: Expected usage: .keywordcode [terminal_code]
 Error: Expected usage: .constantcode [terminal_code]
 ```
 
-## Auto-Complete
-
-The shell offers context-aware auto-complete of SQL queries. Auto-complete is triggered by pressing the tab character. The shell auto-completes four different groups: (1) keywords, (2) table names + table functions, (3) column names + scalar functions, and (4) file names. The shell looks at the position in the SQL statement to determine which of these auto-completions to trigger. For example:
-
-```sql
-S -> SELECT
-```
-```sql
-SELECT s -> student_id
-```
-```sql
-SELECT student_id F -> FROM
-```
-```sql
-SELECT student_id FROM g -> grades
-```
-```sql
-SELECT student_id FROM 'd -> data/
-```
-```sql
-SELECT student_id FROM 'data/ -> data/grades.csv
-```
-
 ## Output Formats
 
 The `.mode` command may be used to change the appearance of the tables returned in the terminal output. In addition to customizing the appearance, these modes have additional benefits. This can be useful for presenting DuckDB output elsewhere by redirecting the terminal output to a file, for example (see "Writing Results to a File" section below). Using the `insert` mode will build a series of SQL statements that can be used to insert the data at a later point. The `markdown` mode is particularly useful for building documentation!

--- a/docs/extensions/autocomplete.md
+++ b/docs/extensions/autocomplete.md
@@ -3,7 +3,33 @@ layout: docu
 title: AutoComplete Extension
 ---
 
-This extension adds supports for autocomplete in the [CLI client](../api/cli).
+The `autocomplete` extension adds supports for autocomplete in the [CLI client](../api/cli).
+The extension is shipped by default with the CLI client.
+
+## Auto-Completion Rules
+
+The DuckDB shell auto-completes four different groups: (1) keywords, (2) table names + table functions, (3) column names + scalar functions, and (4) file names. The shell looks at the position in the SQL statement to determine which of these auto-completions to trigger. For example:
+
+```sql
+S -> SELECT
+```
+```sql
+SELECT s -> student_id
+```
+```sql
+SELECT student_id F -> FROM
+```
+```sql
+SELECT student_id FROM g -> grades
+```
+```sql
+SELECT student_id FROM 'd -> data/
+```
+```sql
+SELECT student_id FROM 'data/ -> data/grades.csv
+```
+
+## Functions
 
 <div class="narrow_table"></div>
 


### PR DESCRIPTION
This part of the CLI page is a waste of screen real estate. I moved it to the autocomplete extension's page.

![Screenshot 2023-11-25 at 18 20 53](https://github.com/duckdb/duckdb-web/assets/1402801/7f38df2f-1b01-4182-a0a2-6bd01de62b13)
