### PR TITLE
Rework FTS pages

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/duckdb/rouge.git
-  revision: ab981ee7e83cf1c96f2d6e181ef6da13080e2a14
+  revision: 3b970eaa8e3dfc4f6b0abe755f15eef4f55ab719
   branch: duckdb
   specs:
     rouge (3.3823.1)

--- a/docs/guides/sql_features/full_text_search.md
+++ b/docs/guides/sql_features/full_text_search.md
@@ -3,13 +3,16 @@ layout: docu
 title: DuckDB Full Text Search
 ---
 
+DuckDB supports full text search via the [`fts` extension](../../extensions/full_text_search).
 A full text index allows for a query to quickly search for all occurrences of individual words within longer text strings.
+
+## Example: Shakespeare Corpus
+
 Here's an example of building a full text index of Shakespeare's plays.
 
 ```sql
 CREATE TABLE corpus AS
-    SELECT * FROM read_parquet(
-        'https://blobs.duckdb.org/data/shakespeare.parquet');
+    SELECT * FROM 'https://blobs.duckdb.org/data/shakespeare.parquet';
 ```
 
 ```sql
@@ -30,11 +33,11 @@ DESCRIBE corpus;
 
 The text of each line is in `text_entry`, and a unique key for each line is in `line_id`.
 
+## Creating a Full Text Search Index
+
 First, we create the index, specifying the table name, the unique id column, and the column(s) to index. We will just index the single column `text_entry`, which contains the text of the lines in the play.
 
 ```sql
-INSTALL fts;
-LOAD fts;
 PRAGMA create_fts_index('corpus', 'line_id', 'text_entry');
 ```
 
@@ -78,7 +81,7 @@ Unlike standard indexes, full text indexes don't auto-update as the underlying d
 
 ## Note on Generating the Corpus Table
 
-For details, see the ["Generating a Shakespeare corpus for full-text searching from JSON" blog post](https://duckdb.blogspot.com/2023/04/generating-shakespeare-corpus-for-full.html)
-* The Columns are:  line_id, play_name, line_number, speaker, text_entry.
+For more details, see the ["Generating a Shakespeare corpus for full-text searching from JSON" blog post](https://duckdb.blogspot.com/2023/04/generating-shakespeare-corpus-for-full.html)
+* The Columns are: line_id, play_name, line_number, speaker, text_entry.
 * We need a unique key for each row in order for full text searching to work.
 * The line_id "KL/2.4.132" means King Lear, Act 2, Scene 4, Line 132.


### PR DESCRIPTION
I'm not sure what I had in mind when I opened #1446, where I complained that there's a big overlap between the FTS extension's documentation page and its guide. The overlap is minimal (and perfeclty in line with how we use the documentation vs the guides). Still, I revised both pages, so this PR fixes #1446.