### PR TITLE
Nits 2023 11 26

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/duckdb/rouge.git
-  revision: 139257bea95a44517635bbbe247447783a1775c4
+  revision: 6cb8993d71cb019cdd69774138d81751fc054c6c
   branch: duckdb
   specs:
     rouge (3.3823.1)

--- a/_data/menu_docs_dev.json
+++ b/_data/menu_docs_dev.json
@@ -802,7 +802,7 @@
                   "url": "overview"
                 },
                 {
-                  "page": "Case",
+                  "page": "CASE statement",
                   "url": "case"
                 },
                 {
@@ -822,11 +822,11 @@
                   "url": "in"
                 },
                 {
-                  "page": "Logical",
+                  "page": "Logical Operators",
                   "url": "logical_operators"
                 },
                 {
-                  "page": "Star",
+                  "page": "Star Expression",
                   "url": "star"
                 },
                 {

--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -15,4 +15,4 @@ If you are made uncomfortable in your role as DuckDB community member, please le
 
 #### Attribution
 
-This Code of Conduct is adapted from the [CCC event CoC](https://www.ccc.de/en/updates/2016/a-reminder-to-be-excellent-to-each-other)
+This Code of Conduct is adapted from the [CCC event CoC](https://www.ccc.de/en/updates/2016/a-reminder-to-be-excellent-to-each-other).

--- a/docs/sql/data_types/overview.md
+++ b/docs/sql/data_types/overview.md
@@ -11,7 +11,7 @@ The table below shows all the built-in general-purpose data types. The alternati
 | Name | Aliases | Description |
 |:--|:--|:----|
 | `BIGINT` | `INT8`, `LONG` | signed eight-byte integer |
-| `BIT` | `BITSTRING` | string of 1's and 0's |
+| `BIT` | `BITSTRING` | string of 1s and 0s |
 | `BOOLEAN` | `BOOL`, `LOGICAL` | logical boolean (true/false) |
 | `BLOB` | `BYTEA`, `BINARY,` `VARBINARY` | variable-length binary data |
 | `DATE` |   | calendar date (year, month day) |

--- a/docs/sql/data_types/struct.md
+++ b/docs/sql/data_types/struct.md
@@ -11,7 +11,7 @@ Conceptually, a `STRUCT` column contains an ordered list of columns called "entr
 
 See the [data types overview](../../sql/data_types/overview) for a comparison between nested data types.
 
-Structs can be created using the [`STRUCT_PACK(name := expr, ...)`](../functions/nested#struct-functions) function or the equivalent array notation `{'name': expr, ...}` notation. The expressions can be constants or arbitrary expressions.
+Structs can be created using the [`struct_pack(name := expr, ...)`](../functions/nested#struct-functions) function or the equivalent array notation `{'name': expr, ...}` notation. The expressions can be constants or arbitrary expressions.
 
 ### Creating Structs
 

--- a/docs/sql/expressions/case.md
+++ b/docs/sql/expressions/case.md
@@ -1,6 +1,6 @@
 ---
 layout: docu
-title: Case Statement
+title: CASE Statement
 railroad: expressions/case.js
 ---
 

--- a/docs/sql/expressions/star.md
+++ b/docs/sql/expressions/star.md
@@ -35,7 +35,7 @@ SELECT * FROM tbl;
 
 The `*` expression can be modified using the `EXCLUDE` and `REPLACE`.
 
-### EXCLUDE Clause
+### `EXCLUDE` Clause
 
 `EXCLUDE` allows us to exclude specific columns from the `*` expression.
 
@@ -43,7 +43,7 @@ The `*` expression can be modified using the `EXCLUDE` and `REPLACE`.
 SELECT * EXCLUDE (col) FROM tbl;
 ```
 
-### Replace Clause
+### `REPLACE` Clause
 
 `REPLACE` allows us to replace specific columns with different expressions.
 
@@ -51,7 +51,7 @@ SELECT * EXCLUDE (col) FROM tbl;
 SELECT * REPLACE (col / 1000 AS col) FROM tbl;
 ```
 
-## COLUMNS
+## `COLUMNS` Expression
 
 The `COLUMNS` expression can be used to execute the same expression on multiple columns. Like the `*` expression, it can only be used in the `SELECT` clause.
 
@@ -79,7 +79,7 @@ SELECT min(COLUMNS(* REPLACE (number + id AS number))), count(COLUMNS(* EXCLUDE 
 |-----------------|------------------------------|-------------------|
 | 1               | 11                           | 3                 |
 
-COLUMNS expressions can also be combined, as long as the `COLUMNS` contains the same (star) expression:
+`COLUMNS` expressions can also be combined, as long as the `COLUMNS` contains the same (star) expression:
 
 ```sql
 SELECT COLUMNS(*) + COLUMNS(*) FROM numbers;
@@ -110,7 +110,7 @@ SELECT COLUMNS('(id|numbers?)') FROM numbers;
 | 2  | 20     |
 | 3  | NULL   |
 
-## COLUMNS Lambda Function
+## `COLUMNS` Lambda Function
 
 `COLUMNS` also supports passing in a lambda function. The lambda function will be evaluated for all columns present in the `FROM` clause, and only columns that match the lambda function will be returned. This allows the execution of arbitrary expressions in order to select columns.
 

--- a/docs/sql/functions/blob.md
+++ b/docs/sql/functions/blob.md
@@ -7,7 +7,7 @@ This section describes functions and operators for examining and manipulating bl
 
 | Function | Description | Example | Result |
 |:-|:--|:---|:-|
-| *`blob`* `||` *`blob`* | Blob concatenation | `'\xAA'::BLOB || '\xBB'::BLOB` | \xAA\xBB |
-| `decode(`*`blob`*`)` | Convert blob to varchar. Fails if blob is not valid utf-8. | `decode('\xC3\xBC'::BLOB)` | ü |
-| `encode(`*`string`*`)` | Convert varchar to blob. Converts utf-8 characters into literal encoding. | `encode('my_string_with_ü')` | my_string_with_\xC3\xBC |
-| `octet_length(`*`blob`*`)` | Number of bytes in blob | `octet_length('\xAA\xBB'::BLOB)` | 2 |
+| *`blob`* `||` *`blob`* | Blob concatenation | `'\xAA'::BLOB || '\xBB'::BLOB` | `\xAA\xBB` |
+| `decode(`*`blob`*`)` | Convert blob to varchar. Fails if blob is not valid utf-8. | `decode('\xC3\xBC'::BLOB)` | `ü` |
+| `encode(`*`string`*`)` | Convert varchar to blob. Converts utf-8 characters into literal encoding. | `encode('my_string_with_ü')` | `my_string_with_\xC3\xBC` |
+| `octet_length(`*`blob`*`)` | Number of bytes in blob | `octet_length('\xAA\xBB'::BLOB)` | `2` |

--- a/docs/sql/functions/date.md
+++ b/docs/sql/functions/date.md
@@ -11,12 +11,12 @@ The table below shows the available mathematical operators for `DATE` types.
 
 | Operator | Description | Example | Result |
 |:-|:--|:---|:--|
-| `+` | addition of days (integers) | `DATE '1992-03-22' + 5` | 1992-03-27 |
-| `+` | addition of an `INTERVAL` | `DATE '1992-03-22' + INTERVAL 5 DAY` | 1992-03-27 |
-| `+` | addition of a variable `INTERVAL` | `SELECT DATE '1992-03-22' + INTERVAL 1 DAY * d.days FROM (VALUES (5), (11)) AS d(days)` |1992-03-27 1992-04-02 |
-| `-` | subtraction of `DATE`s | `DATE '1992-03-27' - DATE '1992-03-22'` | 5 |
-| `-` | subtraction of an `INTERVAL` | `DATE '1992-03-27' - INTERVAL 5 DAY` | 1992-03-22 |
-| `-` | subtraction of a variable `INTERVAL` | `SELECT DATE '1992-03-27' - INTERVAL 1 DAY * d.days FROM (VALUES (5), (11)) AS d(days)` |1992-03-22 1992-03-16 |
+| `+` | addition of days (integers) | `DATE '1992-03-22' + 5` | `1992-03-27` |
+| `+` | addition of an `INTERVAL` | `DATE '1992-03-22' + INTERVAL 5 DAY` | `1992-03-27` |
+| `+` | addition of a variable `INTERVAL` | `SELECT DATE '1992-03-22' + INTERVAL 1 DAY * d.days FROM (VALUES (5), (11)) AS d(days)` | `1992-03-27` and `1992-04-02` |
+| `-` | subtraction of `DATE`s | `DATE '1992-03-27' - DATE '1992-03-22'` | `5` |
+| `-` | subtraction of an `INTERVAL` | `DATE '1992-03-27' - INTERVAL 5 DAY` | `1992-03-22` |
+| `-` | subtraction of a variable `INTERVAL` | `SELECT DATE '1992-03-27' - INTERVAL 1 DAY * d.days FROM (VALUES (5), (11)) AS d(days)` | `1992-03-22` and `1992-03-16` |
 
 Adding to or subtracting from [infinite values](../../sql/data_types/date#special-values) produces the same infinite value.
 

--- a/docs/sql/functions/datepart.md
+++ b/docs/sql/functions/datepart.md
@@ -15,34 +15,34 @@ The examples are the corresponding parts of the timestamp `2021-08-03 11:59:44.1
 
 | Specifier | Description | Synonyms | Example |
 |:--|:--|:---|:-|
-| `'century'` | Gregorian century | `'cent'`, `'centuries'`, `'c'` | 21 |
-| `'day'` | Gregorian day | `'days'`, `'d'`, `'dayofmonth'` | 3 |
-| `'decade'` | Gregorian decade | `'dec'`, `'decades'`, `'decs'` | 202 |
-| `'hour'` | Hours | `'hr'`, `'hours'`, `'hrs'`, `'h'` | 11 |
-| `'microseconds'` | Sub-minute microseconds | `'microsecond'`, `'us'`, `'usec'`, `'usecs'`, `'usecond'`, `'useconds'` | 44123456 |
-| `'millennium'` | Gregorian millennium | `'mil'`, `'millenniums'`, `'millenia'`, `'mils'`, `'millenium'` | 3 |
-| `'milliseconds'` | Sub-minute milliseconds | `'millisecond'`, `'ms'`, `'msec'`, `'msecs'`, `'msecond'`, `'mseconds'` | 44123 |
-| `'minute'` | Minutes | `'min'`, `'minutes'`, `'mins'`, `'m'` | 59 |
-| `'month'` | Gregorian month | `'mon'`, `'months'`, `'mons'` | 8 |
-| `'quarter'` | Quarter of the year (1-4) | `'quarters'` | 3 |
-| `'second'` | Seconds | `'sec'`, `'seconds'`, `'secs'`, `'s'` | 44 |
-| `'year'` | Gregorian year | `'yr'`, `'y'`, `'years'`, `'yrs'` | 2021 |
+| `'century'` | Gregorian century | `'cent'`, `'centuries'`, `'c'` | `21` |
+| `'day'` | Gregorian day | `'days'`, `'d'`, `'dayofmonth'` | `3` |
+| `'decade'` | Gregorian decade | `'dec'`, `'decades'`, `'decs'` | `202` |
+| `'hour'` | Hours | `'hr'`, `'hours'`, `'hrs'`, `'h'` | `11` |
+| `'microseconds'` | Sub-minute microseconds | `'microsecond'`, `'us'`, `'usec'`, `'usecs'`, `'usecond'`, `'useconds'` | `44123456` |
+| `'millennium'` | Gregorian millennium | `'mil'`, `'millenniums'`, `'millenia'`, `'mils'`, `'millenium'` | `3` |
+| `'milliseconds'` | Sub-minute milliseconds | `'millisecond'`, `'ms'`, `'msec'`, `'msecs'`, `'msecond'`, `'mseconds'` | `44123` |
+| `'minute'` | Minutes | `'min'`, `'minutes'`, `'mins'`, `'m'` | `59` |
+| `'month'` | Gregorian month | `'mon'`, `'months'`, `'mons'` | `8` |
+| `'quarter'` | Quarter of the year (1-4) | `'quarters'` | `3` |
+| `'second'` | Seconds | `'sec'`, `'seconds'`, `'secs'`, `'s'` | `44` |
+| `'year'` | Gregorian year | `'yr'`, `'y'`, `'years'`, `'yrs'` | `2021` |
 
 ### Usable in Date Part Specifiers Only
 
 | Specifier | Description | Synonyms | Example |
 |:--|:--|:---|:-|
-| `'dayofweek'` | Day of the week (Sunday = 0, Saturday = 6) | `'weekday'`, `'dow'` | 2 |
-| `'dayofyear'` | Day of the year (1-365/366) | `'doy'` | 215 |
-| `'epoch'` | Seconds since 1970-01-01 | | 1627991984 |
-| `'era'` | Gregorian era (CE/AD, BCE/BC) | | 1 |
-| `'isodow'` | ISO day of the week (Monday = 1, Sunday = 7) | | 2 |
-| `'isoyear'` | ISO Year number (Starts on Monday of week containing Jan 4th) | | 2021 |
-| `'timezone'` | Time zone offset in seconds | | 0 |
-| `'timezone_hour'` | Time zone offset hour portion | | 0 |
-| `'timezone_minute'` | Time zone offset minute portion | | 0 |
-| `'week'` | Week number | `'weeks'`, `'w'` | 31 |
-| `'yearweek'` | ISO year and week number in `YYYYWW` format | | 202131 |
+| `'dayofweek'` | Day of the week (Sunday = 0, Saturday = 6) | `'weekday'`, `'dow'` | `2` |
+| `'dayofyear'` | Day of the year (1-365/366) | `'doy'` | `215` |
+| `'epoch'` | Seconds since 1970-01-01 | | `1627991984` |
+| `'era'` | Gregorian era (CE/AD, BCE/BC) | | `1` |
+| `'isodow'` | ISO day of the week (Monday = 1, Sunday = 7) | | `2` |
+| `'isoyear'` | ISO Year number (Starts on Monday of week containing Jan 4th) | | `2021` |
+| `'timezone'` | Time zone offset in seconds | | `0` |
+| `'timezone_hour'` | Time zone offset hour portion | | `0` |
+| `'timezone_minute'` | Time zone offset minute portion | | `0` |
+| `'week'` | Week number | `'weeks'`, `'w'` | `31` |
+| `'yearweek'` | ISO year and week number in `YYYYWW` format | | `202131` |
 
 Note that the time zone parts are all zero unless a time zone plugin such as ICU
 has been installed to support `TIMESTAMP WITH TIME ZONE`.

--- a/docs/sql/functions/interval.md
+++ b/docs/sql/functions/interval.md
@@ -11,14 +11,14 @@ The table below shows the available mathematical operators for `INTERVAL` types.
 
 | Operator | Description | Example | Result |
 |:-|:--|:----|:--|
-| `+` | addition of an `INTERVAL` | `INTERVAL 1 HOUR + INTERVAL 5 HOUR` | INTERVAL 6 HOUR |
-| `+` | addition to a `DATE` | `DATE '1992-03-22' + INTERVAL 5 DAY` | 1992-03-27 |
-| `+` | addition to a `TIMESTAMP` | `TIMESTAMP '1992-03-22 01:02:03' + INTERVAL 5 DAY` | 1992-03-27 01:02:03 |
-| `+` | addition to a `TIME` | `TIME '01:02:03' + INTERVAL 5 HOUR` | 06:02:03 |
-| `-` | subtraction of an `INTERVAL` | `INTERVAL 5 HOUR - INTERVAL 1 HOUR` | INTERVAL 4 HOUR |
-| `-` | subtraction from a `DATE` | `DATE '1992-03-27' - INTERVAL 5 DAY` | 1992-03-22 |
-| `-` | subtraction from a `TIMESTAMP` | `TIMESTAMP '1992-03-27 01:02:03' - INTERVAL 5 DAY` | 1992-03-22 01:02:03 |
-| `-` | subtraction from a `TIME` | `TIME '06:02:03' - INTERVAL 5 HOUR` | 01:02:03 |
+| `+` | addition of an `INTERVAL` | `INTERVAL 1 HOUR + INTERVAL 5 HOUR` | `INTERVAL 6 HOUR` |
+| `+` | addition to a `DATE` | `DATE '1992-03-22' + INTERVAL 5 DAY` | `1992-03-27` |
+| `+` | addition to a `TIMESTAMP` | `TIMESTAMP '1992-03-22 01:02:03' + INTERVAL 5 DAY` | `1992-03-27 01:02:03` |
+| `+` | addition to a `TIME` | `TIME '01:02:03' + INTERVAL 5 HOUR` | `06:02:03` |
+| `-` | subtraction of an `INTERVAL` | `INTERVAL 5 HOUR - INTERVAL 1 HOUR` | `INTERVAL 4 HOUR` |
+| `-` | subtraction from a `DATE` | `DATE '1992-03-27' - INTERVAL 5 DAY` | `1992-03-22` |
+| `-` | subtraction from a `TIMESTAMP` | `TIMESTAMP '1992-03-27 01:02:03' - INTERVAL 5 DAY` | `1992-03-22 01:02:03` |
+| `-` | subtraction from a `TIME` | `TIME '06:02:03' - INTERVAL 5 HOUR` | `01:02:03` |
 
 ## Interval Functions
 
@@ -26,16 +26,16 @@ The table below shows the available scalar functions for `INTERVAL` types.
 
 | Function | Description | Example | Result |
 |:--|:--|:---|:--|
-| `date_part(`*`part`*`, `*`interval`*`)` | Get [subfield](../../sql/functions/datepart) (equivalent to *extract*) | `date_part('year', INTERVAL '14 months')` | 1 |
-| `datepart(`*`part`*`, `*`interval`*`)` | Alias of date_part. Get [subfield](../../sql/functions/datepart) (equivalent to *extract*) | `datepart('year', INTERVAL '14 months')` | 1 |
+| `date_part(`*`part`*`, `*`interval`*`)` | Get [subfield](../../sql/functions/datepart) (equivalent to *extract*) | `date_part('year', INTERVAL '14 months')` | `1` |
+| `datepart(`*`part`*`, `*`interval`*`)` | Alias of date_part. Get [subfield](../../sql/functions/datepart) (equivalent to *extract*) | `datepart('year', INTERVAL '14 months')` | `1` |
 | `extract(`*`part`* `from` *`interval`*`)` | Get [subfield](../../sql/functions/datepart) from a date | `extract('month' FROM INTERVAL '14 months')` | 2 |
-| `to_days(`*`integer`*`)` | Construct a day interval | `to_days(5)` | INTERVAL 5 DAY |
-| `to_hours(`*`integer`*`)` | Construct a hour interval | `to_hours(5)` | INTERVAL 5 HOUR |
-| `to_microseconds(`*`integer`*`)` | Construct a microsecond interval | `to_microseconds(5)` | INTERVAL 5 MICROSECOND |
-| `to_milliseconds(`*`integer`*`)` | Construct a millisecond interval | `to_milliseconds(5)` | INTERVAL 5 MILLISECOND |
-| `to_minutes(`*`integer`*`)` | Construct a minute interval | `to_minutes(5)` | INTERVAL 5 MINUTE |
-| `to_months(`*`integer`*`)` | Construct a month interval | `to_months(5)` | INTERVAL 5 MONTH |
-| `to_seconds(`*`integer`*`)` | Construct a second interval | `to_seconds(5)` | INTERVAL 5 SECOND |
-| `to_years(`*`integer`*`)` | Construct a year interval | `to_years(5)` | INTERVAL 5 YEAR |
+| `to_days(`*`integer`*`)` | Construct a day interval | `to_days(5)` | `INTERVAL 5 DAY` |
+| `to_hours(`*`integer`*`)` | Construct a hour interval | `to_hours(5)` | `INTERVAL 5 HOUR` |
+| `to_microseconds(`*`integer`*`)` | Construct a microsecond interval | `to_microseconds(5)` | `INTERVAL 5 MICROSECOND` |
+| `to_milliseconds(`*`integer`*`)` | Construct a millisecond interval | `to_milliseconds(5)` | `INTERVAL 5 MILLISECOND` |
+| `to_minutes(`*`integer`*`)` | Construct a minute interval | `to_minutes(5)` | `INTERVAL 5 MINUTE` |
+| `to_months(`*`integer`*`)` | Construct a month interval | `to_months(5)` | `INTERVAL 5 MONTH` |
+| `to_seconds(`*`integer`*`)` | Construct a second interval | `to_seconds(5)` | `INTERVAL 5 SECOND` |
+| `to_years(`*`integer`*`)` | Construct a year interval | `to_years(5)` | `INTERVAL 5 YEAR` |
 
 Only the documented [date parts](../../sql/functions/datepart) are defined for intervals.

--- a/docs/sql/functions/numeric.md
+++ b/docs/sql/functions/numeric.md
@@ -43,56 +43,56 @@ The table below shows the available mathematical functions.
 
 | Function | Description | Example | Result |
 |:---|:---|:---|:--|
-| `abs(x)` | Absolute value | `abs(-17.4)` | 17.4 |
-| `acos(x)` | Computes the arccosine of x | `acos(0.5)` | 1.0471975511965976 |
+| `abs(x)` | Absolute value | `abs(-17.4)` | `17.4` |
+| `acos(x)` | Computes the arccosine of x | `acos(0.5)` | `1.0471975511965976` |
 | `add(x, y)` | Alias for `x + y` | `add(2, 3)` | `5` |
-| `asin(x)` | Computes the arcsine of x | `asin(0.5)` | 0.5235987755982989 |
-| `atan(x)` | Computes the arctangent of x | `atan(0.5)` | 0.4636476090008061 |
-| `atan2(y, x)` | Computes the arctangent (y, x) | `atan2(0.5, 0.5)` | 0.7853981633974483 |
-| `bit_count(x)` | Returns the number of bits that are set | `bit_count(31)` | 5 |
-| `cbrt(x)` | Returns the cube root of the number | `cbrt(8)` | 2 |
-| `ceil(x)` | Rounds the number up | `ceil(17.4)` | 18 |
-| `ceiling(x)` | Rounds the number up. Alias of `ceil` | `ceiling(17.4)` | 18 |
-| `cos(x)` | Computes the cosine of x | `cos(90)` | -0.4480736161291701 |
-| `cot(x)` | Computes the cotangent of x | `cot(0.5)` | 1.830487721712452 |
-| `degrees(x)` | Converts radians to degrees | `degrees(pi())` | 180 |
+| `asin(x)` | Computes the arcsine of x | `asin(0.5)` | `0.5235987755982989` |
+| `atan(x)` | Computes the arctangent of x | `atan(0.5)` | `0.4636476090008061` |
+| `atan2(y, x)` | Computes the arctangent (y, x) | `atan2(0.5, 0.5)` | `0.7853981633974483` |
+| `bit_count(x)` | Returns the number of bits that are set | `bit_count(31)` | `5` |
+| `cbrt(x)` | Returns the cube root of the number | `cbrt(8)` | `2` |
+| `ceil(x)` | Rounds the number up | `ceil(17.4)` | `18` |
+| `ceiling(x)` | Rounds the number up. Alias of `ceil` | `ceiling(17.4)` | `18` |
+| `cos(x)` | Computes the cosine of x | `cos(90)` | `-0.4480736161291701` |
+| `cot(x)` | Computes the cotangent of x | `cot(0.5)` | `1.830487721712452` |
+| `degrees(x)` | Converts radians to degrees | `degrees(pi())` | `180` |
 | `divide(x, y)` | Alias for `x // y` | `divide(5, 2)` | `2` |
-| `even(x)` | Round to next even number by rounding away from zero | `even(2.9)` | 4 |
-| `exp(x)` | Computes `e ** x` | `exp(0.693)` | 2 |
-| `factorial(x)` | See `!` operator. Computes the product of the current integer and all integers below it | `factorial(4)` | 24 |
+| `even(x)` | Round to next even number by rounding away from zero | `even(2.9)` | `4` |
+| `exp(x)` | Computes `e ** x` | `exp(0.693)` | `2` |
+| `factorial(x)` | See `!` operator. Computes the product of the current integer and all integers below it | `factorial(4)` | `24` |
 | `fdiv(x, y)` | Performs integer division (`x // y`) but returns a `DOUBLE` value | `fdiv(5, 2)` | `2.0` |
-| `floor(x)` | Rounds the number down | `floor(17.4)` | 17 |
+| `floor(x)` | Rounds the number down | `floor(17.4)` | `17` |
 | `fmod(x, y)` | Calculates the modulo value. Always returns a `DOUBLE` value | `fmod(5, 2)` | `1.0` |
-| `gamma(x)` | Interpolation of (x-1) factorial (so decimal inputs are allowed) | `gamma(5.5)` | 52.34277778455352 |
-| `gcd(x, y)` | Computes the greatest common divisor of x and y | `gcd(42, 57)` | 3 |
-| `greatest_common_divisor(x, y)` | Computes the greatest common divisor of x and y | `greatest_common_divisor(42, 57)` | 3 |
-| `greatest(x1, x2, ...)` | Selects the largest value | `greatest(3, 2, 4, 4)` | 4 |
+| `gamma(x)` | Interpolation of (x-1) factorial (so decimal inputs are allowed) | `gamma(5.5)` | `52.34277778455352` |
+| `gcd(x, y)` | Computes the greatest common divisor of x and y | `gcd(42, 57)` | `3` |
+| `greatest_common_divisor(x, y)` | Computes the greatest common divisor of x and y | `greatest_common_divisor(42, 57)` | `3` |
+| `greatest(x1, x2, ...)` | Selects the largest value | `greatest(3, 2, 4, 4)` | `4` |
 | `isfinite(x)` | Returns true if the floating point value is finite, false otherwise | `isfinite(5.5)` | `true` |
 | `isinf(x)` | Returns true if the floating point value is infinite, false otherwise | `isinf('Infinity'::float)` | `true` |
 | `isnan(x)` | Returns true if the floating point value is not a number, false otherwise | `isnan('NaN'::float)` | `true` |
-| `lcm(x, y)` | Computes the least common multiple of x and y | `lcm(42, 57)` | 798 |
-| `least_common_multiple(x, y)` | Computes the least common multiple of x and y | `least_common_multiple(42, 57)` | 798 |
-| `least(x1, x2, ...)` | Selects the smallest value | `least(3, 2, 4, 4)` | 2 |
-| `lgamma(x)` | Computes the log of the `gamma` function | `lgamma(2)` | 0 |
-| `ln(x)` | Computes the natural logarithm of *x* | `ln(2)` | 0.693 |
-| `log(x)` | Computes the 10-log of *x* | `log(100)` | 2 |
-| `log10(x)` | Alias of `log`. computes the 10-log of *x* | `log10(1000)` | 3 |
-| `log2(x)` | Computes the 2-log of *x* | `log2(8)` | 3 |
+| `lcm(x, y)` | Computes the least common multiple of x and y | `lcm(42, 57)` | `798` |
+| `least_common_multiple(x, y)` | Computes the least common multiple of x and y | `least_common_multiple(42, 57)` | `798` |
+| `least(x1, x2, ...)` | Selects the smallest value | `least(3, 2, 4, 4)` | `2` |
+| `lgamma(x)` | Computes the log of the `gamma` function | `lgamma(2)` | `0` |
+| `ln(x)` | Computes the natural logarithm of *x* | `ln(2)` | `0.693` |
+| `log(x)` | Computes the 10-log of *x* | `log(100)` | `2` |
+| `log10(x)` | Alias of `log`. computes the 10-log of *x* | `log10(1000)` | `3` |
+| `log2(x)` | Computes the 2-log of *x* | `log2(8)` | `3` |
 | `multiply(x, y)` | Alias for `x * y` | `multiply(2, 3)` | `6` |
-| `nextafter(x, y)` | Return the next floating point value after *x* in the direction of *y* | `nextafter(1::float, 2::float)` | 1.0000001 |
-| `pi()` | Returns the value of pi | `pi()` | 3.141592653589793 |
-| `pow(x, y)` | Computes x to the power of y | `pow(2, 3)` | 8 |
-| `power(x, y)` | Alias of `pow`. computes x to the power of y | `power(2, 3)` | 8 |
-| `radians(x)` | Converts degrees to radians | `radians(90)` | 1.5707963267948966 |
+| `nextafter(x, y)` | Return the next floating point value after *x* in the direction of *y* | `nextafter(1::float, 2::float)` | `1.0000001` |
+| `pi()` | Returns the value of pi | `pi()` | `3.141592653589793` |
+| `pow(x, y)` | Computes x to the power of y | `pow(2, 3)` | `8` |
+| `power(x, y)` | Alias of `pow`. computes x to the power of y | `power(2, 3)` | `8` |
+| `radians(x)` | Converts degrees to radians | `radians(90)` | `1.5707963267948966` |
 | `random()` | Returns a random number between 0 and 1 | `random()` | various |
 | `round_even(v NUMERIC, s INT)` | Alias of `roundbankers(v, s)`. Round to *s* decimal places using the [_rounding half to even_ rule](https://en.wikipedia.org/wiki/Rounding#Rounding_half_to_even). Values *s < 0* are allowed | `round_even(24.5, 0)` | `24.0` |
-| `round(v NUMERIC, s INT)` | Round to *s* decimal places. Values *s < 0* are allowed | `round(42.4332, 2)` | 42.43 |
+| `round(v NUMERIC, s INT)` | Round to *s* decimal places. Values *s < 0* are allowed | `round(42.4332, 2)` | `42.43` |
 | `setseed(x)` | Sets the seed to be used for the random function | `setseed(0.42)` | |
-| `sign(x)` | Returns the sign of x as -1, 0 or 1 | `sign(-349)` | -1 |
+| `sign(x)` | Returns the sign of x as -1, 0 or 1 | `sign(-349)` | `-1` |
 | `signbit(x)` | Returns whether the signbit is set or not | `signbit(-0.0)` | `true` |
-| `sin(x)` | Computes the sin of x | `sin(90)` | 0.8939966636005579 |
-| `sqrt(x)` | Returns the square root of the number | `sqrt(9)` | 3 |
+| `sin(x)` | Computes the sin of x | `sin(90)` | `0.8939966636005579` |
+| `sqrt(x)` | Returns the square root of the number | `sqrt(9)` | `3` |
 | `subtract(x, y)` | Alias for `x - y` | `subtract(2, 3)` | `-1`|
-| `tan(x)` | Computes the tangent of x | `tan(90)` | -1.995200412208242 |
-| `xor(x)` | Bitwise XOR | `xor(17, 5)` | 20 |
-| `@` | Absolute value (parentheses optional if operating on a column) | `@(-2)` | 2 |
+| `tan(x)` | Computes the tangent of x | `tan(90)` | `-1.995200412208242` |
+| `xor(x)` | Bitwise XOR | `xor(17, 5)` | `20` |
+| `@` | Absolute value (parentheses optional if operating on a column) | `@(-2)` | `2` |

--- a/docs/sql/functions/time.md
+++ b/docs/sql/functions/time.md
@@ -13,8 +13,8 @@ The table below shows the available mathematical operators for `TIME` types.
 
 | Operator | Description | Example | Result |
 |:-|:---|:----|:--|
-| `+` | addition of an `INTERVAL` | `TIME '01:02:03' + INTERVAL 5 HOUR` | 06:02:03 |
-| `-` | subtraction of an `INTERVAL` | `TIME '06:02:03' - INTERVAL 5 HOUR'` | 01:02:03 |
+| `+` | addition of an `INTERVAL` | `TIME '01:02:03' + INTERVAL 5 HOUR` | `06:02:03` |
+| `-` | subtraction of an `INTERVAL` | `TIME '06:02:03' - INTERVAL 5 HOUR'` | `01:02:03` |
 
 ## Time Functions
 
@@ -23,13 +23,13 @@ The table below shows the available scalar functions for `TIME` types.
 | Function | Description | Example | Result |
 |:--|:--|:---|:--|
 | `current_time`/`get_current_time()` | Current time (start of current transaction) | | |
-| `date_diff(`*`part`*`, `*`starttime`*`, `*`endtime`*`)` | The number of [partition](../../sql/functions/datepart) boundaries between the times | `date_diff('hour', TIME '01:02:03', TIME '06:01:03')` | 5 |
-| `datediff(`*`part`*`, `*`starttime`*`, `*`endtime`*`)` | Alias of date_diff. The number of [partition](../../sql/functions/datepart) boundaries between the times | `datediff('hour', TIME '01:02:03', TIME '06:01:03')` | 5 |
-| `date_part(`*`part`*`, `*`time`*`)` | Get [subfield](../../sql/functions/datepart) (equivalent to *extract*) | `date_part('minute', TIME '14:21:13')` | 21 |
-| `datepart(`*`part`*`, `*`time`*`)` | Alias of date_part. Get [subfield](../../sql/functions/datepart) (equivalent to *extract*) | `datepart('minute', TIME '14:21:13')` | 21 |
-| `date_sub(`*`part`*`, `*`starttime`*`, `*`endtime`*`)` | The number of complete [partitions](../../sql/functions/datepart) between the times | `date_sub('hour', TIME '01:02:03', TIME '06:01:03')` | 4 |
-| `datesub(`*`part`*`, `*`starttime`*`, `*`endtime`*`)` | Alias of date_sub. The number of complete [partitions](../../sql/functions/datepart) between the times | `datesub('hour', TIME '01:02:03', TIME '06:01:03')` | 4 |
-| `extract(`*`part`* `FROM` *`time`*`)` | Get subfield from a time | `extract('hour' FROM TIME '14:21:13')` | 14 |
+| `date_diff(`*`part`*`, `*`starttime`*`, `*`endtime`*`)` | The number of [partition](../../sql/functions/datepart) boundaries between the times | `date_diff('hour', TIME '01:02:03', TIME '06:01:03')` | `5` |
+| `datediff(`*`part`*`, `*`starttime`*`, `*`endtime`*`)` | Alias of date_diff. The number of [partition](../../sql/functions/datepart) boundaries between the times | `datediff('hour', TIME '01:02:03', TIME '06:01:03')` | `5` |
+| `date_part(`*`part`*`, `*`time`*`)` | Get [subfield](../../sql/functions/datepart) (equivalent to *extract*) | `date_part('minute', TIME '14:21:13')` | `21` |
+| `datepart(`*`part`*`, `*`time`*`)` | Alias of date_part. Get [subfield](../../sql/functions/datepart) (equivalent to *extract*) | `datepart('minute', TIME '14:21:13')` | `21` |
+| `date_sub(`*`part`*`, `*`starttime`*`, `*`endtime`*`)` | The number of complete [partitions](../../sql/functions/datepart) between the times | `date_sub('hour', TIME '01:02:03', TIME '06:01:03')` | `4` |
+| `datesub(`*`part`*`, `*`starttime`*`, `*`endtime`*`)` | Alias of date_sub. The number of complete [partitions](../../sql/functions/datepart) between the times | `datesub('hour', TIME '01:02:03', TIME '06:01:03')` | `4` |
+| `extract(`*`part`* `FROM` *`time`*`)` | Get subfield from a time | `extract('hour' FROM TIME '14:21:13')` | `14` |
 | `make_time(`*`bigint`*`, `*`bigint`*`, `*`double`*`)` | The time for the given parts | `make_time(13, 34, 27.123456)` | `13:34:27.123456` |
 
 The only [date parts](../../sql/functions/datepart) that are defined for times are `epoch`, `hours`, `minutes`, `seconds`, `milliseconds` and `microseconds`.

--- a/docs/sql/query_syntax/select.md
+++ b/docs/sql/query_syntax/select.md
@@ -32,7 +32,7 @@ SELECT min(COLUMNS(*)) FROM addresses;
 
 <div id="rrdiagram"></div>
 
-## Select List
+## `SELECT` List
 
 The `SELECT` clause contains a list of expressions that specify the result of a query. The select list can refer to any columns in the `FROM` clause, and combine them using expressions. As the output of a SQL query is a table - every expression in the `SELECT` clause also has a name. The expressions can be explicitly named using the `AS` clause (e.g., `expr AS name`). If a name is not provided by the user the expressions are named automatically by the system.
 
@@ -93,7 +93,7 @@ SELECT amount - lag(amount) OVER (ORDER BY time) FROM sales;
 
 [Window functions](../window_functions) are special functions that allow the computation of values relative to *other rows* in a result. Window functions are marked by the `OVER` clause which contains the *window specification*. The window specification defines the frame or context in which the window function is computed. See the [window functions page](../window_functions) for more information.
 
-### `UNNEST`
+### `UNNEST` Function
 
 ```sql
 -- unnest an array by one level

--- a/docs/sql/statements/unpivot.md
+++ b/docs/sql/statements/unpivot.md
@@ -94,9 +94,9 @@ INTO
 
 ### UNPIVOT Dynamically Using Columns Expression
 
-In many cases, the number of columns to unpivot is not easy to predetermine ahead of time. 
-In the case of this dataset, the query above would have to change each time a new month is added. 
-The [`COLUMNS` expression](../expressions/star#columns) can be used to select all columns that are not `empid` or `dept`. 
+In many cases, the number of columns to unpivot is not easy to predetermine ahead of time.
+In the case of this dataset, the query above would have to change each time a new month is added.
+The [`COLUMNS` expression](../expressions/star#columns-expression) can be used to select all columns that are not `empid` or `dept`.
 This enables dynamic unpivoting that will work regardless of how many months are added.
 The query below returns identical results to the one above.
 


### PR DESCRIPTION
This PR has lots of minor fixes but also a more visible fix: it bumps to a new Rouge version which will match function names to strings ending in an opening paren, i.e.,`function_name(`, but will not match them to `function_name[^(]`.
As a consequence, terms like `month`, `year`, `version`, etc. will be picked up as functions when they have arguments but they will not be picked up when they are column/table names.