### PR TITLE
Decrease line height to match CLI formatting

### DIFF
--- a/css/docu.scss
+++ b/css/docu.scss
@@ -30,7 +30,7 @@ pre {
     border-radius: 2px;
     -moz-border-radius: 2px;
     -webkit-border-radius: 2px;
-    line-height: 1.4;
+    line-height: 1.2;
 }
 code.language-plaintext{
 	background-color: rgb(245, 245, 245);


### PR DESCRIPTION
Decreased the CSS line-height for code from 1.4 to 1.2

@jonathanauch what do you think about this change?

## Before
![Screenshot 2023-11-27 at 10 16 19](https://github.com/duckdb/duckdb-web/assets/1402801/4af51ee4-2aff-48f6-8d6e-d33c68cc7723)

## After
![Screenshot 2023-11-27 at 10 16 28](https://github.com/duckdb/duckdb-web/assets/1402801/1ad5e32d-36c4-4229-8110-c6a12d7bbff0)
