### PR TITLE
json_extract_string list wildcard example

### DIFF
--- a/docs/extensions/json.md
+++ b/docs/extensions/json.md
@@ -366,6 +366,8 @@ SELECT j->'$.family' FROM example;
 -- "anatidae"
 SELECT j->'$.species[0]' FROM example;
 -- "duck"
+SELECT j->>'$.species[*]' FROM example;
+-- ["duck", "goose", "swan", null]
 SELECT j->'$.species'->0 FROM example;
 -- "duck"
 SELECT j->'species'->>[0,1] FROM example;


### PR DESCRIPTION
It's not obvious which parts of jsonpath are supported from the current docs, but it turns out list wildcards are. This adds one example.