### PR TITLE
Use 'S3 URI' instead of 'S3 URL'

### DIFF
--- a/docs/archive/0.9.0/extensions/httpfs.md
+++ b/docs/archive/0.9.0/extensions/httpfs.md
@@ -97,7 +97,7 @@ The [`aws` extension](aws) allows for loading AWS credentials.
 
 #### Per-Request Configuration
 
-Aside from the global S3 configuration described above, specific configuration values can be used on a per-request basis. This allows for use of multiple sets of credentials, regions, etc. These are used by including them on the S3 URL as query parameters. All the individual configuration values listed above can be set as query parameters. For instance:
+Aside from the global S3 configuration described above, specific configuration values can be used on a per-request basis. This allows for use of multiple sets of credentials, regions, etc. These are used by including them on the S3 URI as query parameters. All the individual configuration values listed above can be set as query parameters. For instance:
 
 ```sql
 SELECT *

--- a/docs/archive/0.9.1/extensions/httpfs.md
+++ b/docs/archive/0.9.1/extensions/httpfs.md
@@ -97,7 +97,7 @@ The [`aws` extension](aws) allows for loading AWS credentials.
 
 #### Per-Request Configuration
 
-Aside from the global S3 configuration described above, specific configuration values can be used on a per-request basis. This allows for use of multiple sets of credentials, regions, etc. These are used by including them on the S3 URL as query parameters. All the individual configuration values listed above can be set as query parameters. For instance:
+Aside from the global S3 configuration described above, specific configuration values can be used on a per-request basis. This allows for use of multiple sets of credentials, regions, etc. These are used by including them on the S3 URI as query parameters. All the individual configuration values listed above can be set as query parameters. For instance:
 
 ```sql
 SELECT *

--- a/docs/archive/0.9.2/extensions/httpfs.md
+++ b/docs/archive/0.9.2/extensions/httpfs.md
@@ -99,7 +99,7 @@ The [`aws` extension](aws) allows for loading AWS credentials.
 
 #### Per-Request Configuration
 
-Aside from the global S3 configuration described above, specific configuration values can be used on a per-request basis. This allows for use of multiple sets of credentials, regions, etc. These are used by including them on the S3 URL as query parameters. All the individual configuration values listed above can be set as query parameters. For instance:
+Aside from the global S3 configuration described above, specific configuration values can be used on a per-request basis. This allows for use of multiple sets of credentials, regions, etc. These are used by including them on the S3 URI as query parameters. All the individual configuration values listed above can be set as query parameters. For instance:
 
 ```sql
 SELECT *

--- a/docs/extensions/httpfs.md
+++ b/docs/extensions/httpfs.md
@@ -104,7 +104,7 @@ The [`aws` extension](aws) allows for loading AWS credentials.
 
 #### Per-Request Configuration
 
-Aside from the global S3 configuration described above, specific configuration values can be used on a per-request basis. This allows for use of multiple sets of credentials, regions, etc. These are used by including them on the S3 URL as query parameters. All the individual configuration values listed above can be set as query parameters. For instance:
+Aside from the global S3 configuration described above, specific configuration values can be used on a per-request basis. This allows for use of multiple sets of credentials, regions, etc. These are used by including them on the S3 URI as query parameters. All the individual configuration values listed above can be set as query parameters. For instance:
 
 ```sql
 SELECT *


### PR DESCRIPTION
Fixes #639, in the text at least (configuration table is generated from the codebase). I passed this on for discussion for the https extension.