### PR TITLE
Allow OFFSET clause without LIMIT

### DIFF
--- a/js/railroad.js
+++ b/js/railroad.js
@@ -2015,12 +2015,12 @@ function GenerateLimitAndOrderBy(options) {
 		Sequence(GenerateOrderBy(options)),
 		Optional(Sequence([
 			Keyword("LIMIT"),
-			Expression(),
-			Optional(Sequence([
-				Keyword("OFFSET"),
-				Expression()
-			]), "skip")
-		]))
+			Expression()
+		])),
+		Optional(Sequence([
+			Keyword("OFFSET"),
+			Expression()
+		])),
 	]
 }
 


### PR DESCRIPTION
OFFSET works just fine without LIMIT. This should be reflected in the railroad diagrams.

```sql
SELECT unnest([42, 43, 44]) AS x
OFFSET 2;
```
```
┌───────┐
│   x   │
│ int32 │
├───────┤
│    44 │
└───────┘
```
