### PR TITLE
Deprecate PRAGMA x=y in favor of SET x=y

### DIFF
--- a/docs/sql/configuration.md
+++ b/docs/sql/configuration.md
@@ -17,7 +17,7 @@ SET threads TO 1;
 -- enable printing of a progress bar during long-running queries
 SET enable_progress_bar = true;
 -- set the default null order to NULLS LAST
-PRAGMA default_null_order = 'nulls_last';
+SET default_null_order = 'nulls_last';
 
 -- show a list of all available settings
 SELECT * FROM duckdb_settings();

--- a/docs/sql/expressions/collations.md
+++ b/docs/sql/expressions/collations.md
@@ -42,7 +42,7 @@ SELECT 'hello' COLLATE NOCASE.NOACCENT = 'hElLÖ';
 The collations we have seen so far have all been specified *per expression*. It is also possible to specify a default collator, either on the global database level or on a base table column. The `PRAGMA` `default_collation` can be used to specify the global default collator. This is the collator that will be used if no other one is specified.
 
 ```sql
-PRAGMA default_collation = NOCASE;
+SET default_collation = NOCASE;
 
 SELECT 'hello' = 'HeLlo';
 -- true

--- a/docs/sql/pragmas.md
+++ b/docs/sql/pragmas.md
@@ -3,9 +3,9 @@ layout: docu
 title: Pragmas
 ---
 
-The `PRAGMA` statement is an SQL extension adopted by DuckDB from SQLite. `PRAGMA` statements can be issued in a similar manner to regular SQL statements. `PRAGMA` commands may alter the internal state of the database engine, and can influence the subsequent execution or behavior of the engine.
+The `PRAGMA` statement is an SQL extension adopted by DuckDB from SQLite. `PRAGMA` statements can be issued in a similar manner to regular SQL statements. `PRAGMA` commands may alter the internal state of the database engine, and can influence the subsequent execution or behavior of the engine. `PRAGMA` statements assigning a value can also be issued using the `SET` statement.
 
-## List of Supported `PRAGMA` statements
+## List of Supported `PRAGMA` Statements
 
 Below is a list of supported `PRAGMA` statements.
 
@@ -43,16 +43,16 @@ pk BOOLEAN          -- part of the primary key or not
 
 ```sql
 -- set the memory limit
-PRAGMA memory_limit = '1GB';
+SET memory_limit = '1GB';
 -- set the amount of threads for parallel query execution
-PRAGMA threads = 4;
+SET threads = 4;
 ```
 
 ### `database_size`
 
 ```sql
 -- get the file and memory size of each database
-PRAGMA database_size;
+SET database_size;
 CALL pragma_database_size();
 ```
 
@@ -76,7 +76,7 @@ memory_limit VARCHAR   -- maximum memory allowed for the database
 -- list all available collations
 PRAGMA collations;
 -- set the default collation to one of the available ones
-PRAGMA default_collation = 'nocase';
+SET default_collation = 'nocase';
 ```
 
 
@@ -84,9 +84,9 @@ PRAGMA default_collation = 'nocase';
 
 ```sql
 -- set the ordering for NULLs to be either NULLS FIRST or NULLS LAST
-PRAGMA default_null_order = 'NULLS LAST';
+SET default_null_order = 'NULLS LAST';
 -- set the default result set ordering direction to ASCENDING or DESCENDING
-PRAGMA default_order = 'DESCENDING';
+SET default_order = 'DESCENDING';
 ```
 
 ### `version`
@@ -119,17 +119,17 @@ PRAGMA enable_profiling;
 PRAGMA enable_profile;
 -- Enable profiling in a specified format
 -- Return the logical query plan as JSON
-PRAGMA enable_profiling = 'json';
+SET enable_profiling = 'json';
 -- Return the logical query plan
-PRAGMA enable_profiling = 'query_tree';
+SET enable_profiling = 'query_tree';
 -- Return the physical query plan
-PRAGMA enable_profiling = 'query_tree_optimizer';
+SET enable_profiling = 'query_tree_optimizer';
 -- Disable profiling
 PRAGMA disable_profiling;
 PRAGMA disable_profile;
 -- Specify a file to save the profiling output to
-PRAGMA profiling_output = '/path/to/file.json';
-PRAGMA profile_output = '/path/to/file.json';
+SET profiling_output = '/path/to/file.json';
+SET profile_output = '/path/to/file.json';
 ```
 
 Enable the gathering and printing of profiling information after the execution of a query. Optionally, the format of the resulting profiling information can be specified as either *json*, *query_tree*, or *query_tree_optimizer*. The default format is *query_tree*, which prints the physical operator tree together with the timings and cardinalities of each operator in the tree to the screen.
@@ -181,11 +181,11 @@ PRAGMA enable_optimizer;
 
 ```sql
 -- Set a path for query logging
-PRAGMA log_query_path = '/tmp/duckdb_log/';
+SET log_query_path = '/tmp/duckdb_log/';
 -- Disable query logging again
-PRAGMA log_query_path = '';
+SET log_query_path = '';
 -- either show 'all' or only 'optimized' plans in the EXPLAIN output
-PRAGMA explain_output = 'optimized';
+SET explain_output = 'optimized';
 -- Enable query verification (for development)
 PRAGMA enable_verification;
 -- Disable query verification (for development)
@@ -259,7 +259,7 @@ PRAGMA disable_checkpoint_on_shutdown;
 By default, DuckDB uses the `.tmp` directory to spill to disk. To change this, use:
 
 ```sql
-PRAGMA temp_directory = '/path/to/temp.tmp'
+SET temp_directory = '/path/to/temp.tmp'
 ```
 
 ### `storage_info`
@@ -322,9 +322,9 @@ The `disabled_optimizers` option allows selectively disabling optimization steps
 For example, to disable `filter_pushdown` and `statistics_propagation`, run:
 
 ```sql
-PRAGMA disabled_optimizers = 'filter_pushdown,statistics_propagation';
+SET disabled_optimizers = 'filter_pushdown,statistics_propagation';
 ```
 
 The available optimizations can be queried using the [`duckdb_optimizers()` table function](duckdb_table_functions#duckdb_optimizers).
 
-> `PRAGMA disabled_optimizers` should only be used for debugging performance issues and should be avoided in production.
+> The `disabled_optimizers` option should only be used for debugging performance issues and should be avoided in production.

--- a/docs/sql/query_syntax/orderby.md
+++ b/docs/sql/query_syntax/orderby.md
@@ -23,15 +23,15 @@ See examples below.
 ## NULL Order Modifier
 
 By default if no modifiers are provided, DuckDB sorts `ASC NULLS LAST`, i.e., the values are sorted in ascending order and null values are placed last. 
-This is identical to the default sort order of PostgreSQL. The default sort order can be changed using the following `PRAGMA` statements.
+This is identical to the default sort order of PostgreSQL. The default sort order can be changed with the following configuration options.
 
 > Using `ASC NULLS LAST` as default the default sorting order was a breaking change in version 0.8.0. Prior to 0.8.0, DuckDB sorted using `ASC NULLS FIRST`.
 
 ```sql
 -- change the default null sorting order to either NULLS FIRST and NULLS LAST
-PRAGMA default_null_order = 'NULLS FIRST';
+SET default_null_order = 'NULLS FIRST';
 -- change the default sorting order to either DESC or ASC
-PRAGMA default_order = 'DESC';
+SET default_order = 'DESC';
 ```
 
 ## Collations

--- a/docs/sql/samples.md
+++ b/docs/sql/samples.md
@@ -35,7 +35,7 @@ DuckDB supports three different types of sampling methods: `reservoir`, `bernoul
 
 Samples require a *sample size*, which is an indication of how many elements will be sampled from the total population. Samples can either be given as a percentage (`10%`) or as a fixed number of rows (`10 rows`). All three sampling methods support sampling over a percentage, but **only** reservoir sampling supports sampling a fixed number of rows.
 
-Samples are probablistic, that is to say, samples can be different between runs *unless* the seed is specifically specified. Specifying the seed *only* guarantees that the sample is the same if multi-threading is not enabled (i.e., `PRAGMA threads = 1`). In the case of multiple threads running over a sample, samples are not necessarily consistent even with a fixed seed.
+Samples are probablistic, that is to say, samples can be different between runs *unless* the seed is specifically specified. Specifying the seed *only* guarantees that the sample is the same if multi-threading is not enabled (i.e., `SET threads = 1`). In the case of multiple threads running over a sample, samples are not necessarily consistent even with a fixed seed.
 
 ### reservoir
 


### PR DESCRIPTION
Fixes #1753

@Mytherin we discussed deprecating `PRAGMA` in the documentation where possible. This is what you had in mind?