### PR TITLE
Fix instructions for generating query graph

### DIFF
--- a/dev/profiling.md
+++ b/dev/profiling.md
@@ -172,5 +172,5 @@ SELECT name FROM students JOIN exams USING (sid) WHERE name LIKE 'Ma%';
 After the query is completed, the JSON file containing the profiling output has been written to the specified file. We can then render the query graph using the Python script, provided we have the `duckdb` python module installed. This script will generate a HTML file and open it in your web browser.
 
 ```sql
-python scripts/generate_querygraph.py /path/to/file.json
+python -m duckdb.query_graph /path/to/file.json
 ```


### PR DESCRIPTION
The original instructions at the bottom of [this page](https://duckdb.org/dev/profiling.html) don't work for me.
I'm getting error saying that generate_querygraph.py doesn't exist.

I looked into my local installation of duckdb within 
/home/jhrcek/.local/lib/python3.10/site-packages/duckdb and I didn't find any file named `generate_querygraph.py `

Instead there's this (running ls in the above folder):
```
├── query_graph
│   ├── __main__.py
│   └── __pycache__
│       └── __main__.cpython-310.pyc
```

When executed using `python -m duckdb.query_graph /path/to/file.json` it works for me (generates html file and opens it in my browser).