### PR TITLE
Add GitHub links for all extensions

### DIFF
--- a/docs/extensions/arrow.md
+++ b/docs/extensions/arrow.md
@@ -21,3 +21,7 @@ LOAD arrow;
 |--|----|-------|
 | `to_arrow_ipc` | Table in-out-function | Serializes a table into a stream of blobs containing Arrow IPC buffers  
 | `scan_arrow_ipc` | Table function | Scan a list of pointers pointing to Arrow IPC buffers
+
+## GitHub Repository
+
+[<span class="github">GitHub</span>](https://github.com/duckdb/arrow)

--- a/docs/extensions/autocomplete.md
+++ b/docs/extensions/autocomplete.md
@@ -69,3 +69,7 @@ Returns:
 | DEALLOCATE  |                0 |
 | UPDATE      |                0 |
 | DROP        |                0 |
+
+## GitHub
+
+The `autocomplete` extension is part of the [main DuckDB repository](https://github.com/duckdb/duckdb/tree/main/extension/autocomplete).

--- a/docs/extensions/excel.md
+++ b/docs/extensions/excel.md
@@ -37,3 +37,7 @@ SELECT excel_text(1234567.897, 'h:mm AM/PM') AS timestamp;
 |:--|:---|:--|:-|
 | `text(`*`number`*`, `*`format_string`*`)`       | Format the given `number` per the rules given in the `format_string` | `text(1234567.897, 'h AM/PM')`          | `9 PM`    |
 | `excel_text(`*`number`*`, `*`format_string`*`)` | Alias for `text`.                                                    | `excel_text(1234567.897, 'h:mm AM/PM')` | `9:31 PM` |
+
+## GitHub
+
+The `excel` extension is part of the [main DuckDB repository](https://github.com/duckdb/duckdb/tree/main/extension/excel).

--- a/docs/extensions/full_text_search.md
+++ b/docs/extensions/full_text_search.md
@@ -134,3 +134,7 @@ ORDER BY score DESC;
 
 > The FTS index will not update automatically when input table changes.
 > A workaround of this limitation can be recreating the index to refresh.
+
+## GitHub
+
+The `fts` extension is part of the [main DuckDB repository](https://github.com/duckdb/duckdb/tree/main/extension/fts).

--- a/docs/extensions/httpfs.md
+++ b/docs/extensions/httpfs.md
@@ -245,3 +245,7 @@ Additionally, most of the configuration options can be set via environment varia
 | `s3_session_token`     | `AWS_SESSION_TOKEN`     |                                          |
 | `s3_endpoint`          | `DUCKDB_S3_ENDPOINT`    |                                          |
 | `s3_use_ssl`           | `DUCKDB_S3_USE_SSL`     |                                          |
+
+## GitHub
+
+The `httpfs` extension is part of the [main DuckDB repository](https://github.com/duckdb/duckdb/tree/main/extension/httpfs).

--- a/docs/extensions/icu.md
+++ b/docs/extensions/icu.md
@@ -20,3 +20,7 @@ The `icu` extension introduces the following features:
 
 * [region-dependent collations](../sql/expressions/collations)
 * [time zones](../sql/data_types/timezones), used for [timestamp data types](../sql/data_types/timestamp) and [timestamp functions](../sql/functions/timestamptz)
+
+## GitHub
+
+The `icu` extension is part of the [main DuckDB repository](https://github.com/duckdb/duckdb/tree/main/extension/icu).

--- a/docs/extensions/inet.md
+++ b/docs/extensions/inet.md
@@ -43,3 +43,7 @@ INSERT INTO tbl VALUES (1, '192.168.0.0/16'), (2, '127.0.0.1'), (2, '8.8.8.8');
 │     2 │ 8.8.8.8        │
 └───────┴────────────────┘
 ```
+
+## GitHub
+
+The `inet` extension is part of the [main DuckDB repository](https://github.com/duckdb/duckdb/tree/main/extension/inet).

--- a/docs/extensions/jemalloc.md
+++ b/docs/extensions/jemalloc.md
@@ -9,3 +9,7 @@ The `jemalloc` extension replaces the system's memory allocator with [jemalloc](
 
 The Linux and macOS versions of DuckDB ship with the `jemalloc` extension by default.
 On Windows, this extension is not available.
+
+## GitHub
+
+The `jemalloc` extension is part of the [main DuckDB repository](https://github.com/duckdb/duckdb/tree/main/extension/jemalloc).

--- a/docs/extensions/json.md
+++ b/docs/extensions/json.md
@@ -539,3 +539,7 @@ SELECT * FROM json_execute_serialized_sql(json_serialize_sql('SELECT 1 + 2'));
 SELECT * FROM json_execute_serialized_sql(json_serialize_sql('TOTALLY NOT VALID SQL'));
 -- Error: Parser Error: Error parsing json: parser: syntax error at or near "TOTALLY"
 ```
+
+## GitHub
+
+The `json` extension is part of the [main DuckDB repository](https://github.com/duckdb/duckdb/tree/main/extension/json).

--- a/docs/extensions/tpcds.md
+++ b/docs/extensions/tpcds.md
@@ -45,3 +45,7 @@ PRAGMA tpcds(8);
 
 The `tpchds({query_id})` function runs a fixed TPC-DS query with pre-defined bind parameters (a.k.a. substitution parameters).
 It is not possible to change the query parameters using the `tpcds` extension.
+
+## GitHub
+
+The `tpcds` extension is part of the [main DuckDB repository](https://github.com/duckdb/duckdb/tree/main/extension/tpcds).

--- a/docs/extensions/tpch.md
+++ b/docs/extensions/tpch.md
@@ -109,3 +109,7 @@ CALL dbgen(sf = 300, children = 10, step = 9);
 
 * The data generator function `dbgen` is single-threaded and does not support concurrency. Running multiple steps to parallelize over different partitions is also not supported at the moment.
 * The `tpch({query_id})` function runs a fixed TPC-H query with pre-defined bind parameters (a.k.a. substitution parameters). It is not possible to change the query parameters using the `tpch` extension.
+
+## GitHub
+
+The `tpch` extension is part of the [main DuckDB repository](https://github.com/duckdb/duckdb/tree/main/extension/tpch).


### PR DESCRIPTION
This includes extensions that are in the main DuckDB repository.