### PR TITLE
Reduce font size in pdf

### DIFF
--- a/single-file-document/pandoc-configuration.yaml
+++ b/single-file-document/pandoc-configuration.yaml
@@ -14,6 +14,7 @@ top-level-division: part
 variables:
   book: true
   numbersections: false
+  fontsize: 10pt
   titlepage: true
   titlepage-color: F5F5F5
   titlepage-logo: ../images/duckdb-logo.pdf

--- a/single-file-document/templates/eisvogel2.tex
+++ b/single-file-document/templates/eisvogel2.tex
@@ -49,7 +49,6 @@ $if(CJKmainfont)$
 $endif$
 %
 \documentclass[
-%  landscape,
 $if(fontsize)$
   $fontsize$,
 $endif$


### PR DESCRIPTION
This reduces the page count from 985 pages to 855 pages, i.e., by approx. 13%.

More importantly, this removes from of the overlaps in large tables that describe functions.