### PR TITLE
docs: fix typo in  `working_with_extensions.md`

### DIFF
--- a/docs/extensions/working_with_extensions.md
+++ b/docs/extensions/working_with_extensions.md
@@ -153,7 +153,7 @@ LOAD 'path/to/httpfs.duckdb_extension';
 
 This will skip any currently installed file in the specifed path.
 
-Using remote paths or compressed files is currently not possible.
+Using remote paths for compressed files is currently not possible.
 
 ## Building Extensions
 


### PR DESCRIPTION
Before:
> Using remote paths or compressed files is currently not possible.

After:
> Using remote paths for compressed files is currently not possible.