### PR TITLE
Add warning to issue template

### DIFF
--- a/_layouts/docu.html
+++ b/_layouts/docu.html
@@ -35,7 +35,8 @@
 
 {% capture issue_title %}Issue found on page '{{ page.title }}'{% endcapture %}
 {% capture issue_body %}
-_Please describe the issue on the page and include the "Page URL" link shown below._
+> Please describe the problem you encountered in the DuckDB documentation and include the "Page URL" link shown below.
+> Note: only create an issue if you wish to report a problem with the DuckDB documentation. For questions about DuckDB or the use of certain DuckDB features, use [GitHub Discussions](https://github.com/duckdb/duckdb/discussions/), [Stack Overflow](https://stackoverflow.com/questions/tagged/duckdb), or [Discord](https://discord.duckdb.org/).
 
 Page URL: <https://duckdb.org{{ page.url }}>
 {% endcapture %}


### PR DESCRIPTION
Recently we have received questions (e.g. #1867, #1780) via the "Report Issue" button on our documentation pages. I extended the issue template, which now explains options for asking questions.