### PR TITLE
Performance guide: add note to avoid joining on strings

### DIFF
--- a/docs/guides/performance/overview.md
+++ b/docs/guides/performance/overview.md
@@ -1,6 +1,8 @@
 ---
 layout: docu
 title: Performance Guide
+redirect_from:
+  - /docs/guides/performance
 ---
 
 DuckDB aims to automatically achieve high performance by using well-chosen default configurations and having a forgiving architecture. Of course, there are still opportunities for tuning the system for specific workloads. The Performance Guide's page contain guidelines and tips for achieving good performance when loading and processing data with DuckDB.

--- a/docs/guides/performance/schema.md
+++ b/docs/guides/performance/schema.md
@@ -15,7 +15,7 @@ _**Best Practice:**_ Use the most restrictive types possible when creating colum
 
 ### Microbenchmark: Using Timestamps
 
-We illustrate the difference using the `creationDate` column of the [LDBC Comment table on scale factor 300](https://blobs.duckdb.org/data/ldbc-sf300-comments-creationDate.parquet). This table has approx. 554 million unordered timestamp values. We run a simple aggregation query that returns the average day-of-the month from the timestamps in two configurations.
+We illustrate the difference in aggregation speed using the [`creationDate` column of the LDBC Comment table on scale factor 300](https://blobs.duckdb.org/data/ldbc-sf300-comments-creationDate.parquet). This table has approx. 554 million unordered timestamp values. We run a simple aggregation query that returns the average day-of-the month from the timestamps in two configurations.
 
 First, we use a `DATETIME` to encode the values and run the query using the [`extract` datetime function](../../sql/functions/timestamp):
 
@@ -39,6 +39,27 @@ The results of the microbenchmark are as follows:
 | `VARCHAR` | 5.2 GB | 3.919 s |
 
 The results show that using the `DATETIME` value yields smaller storage sizes and faster processing. 
+
+### Microbenchmark: Joining on Strings
+
+We illustrate the difference in join speed by computing a self-join on the [full LDBC Comment table at scale factor 300](https://blobs.duckdb.org/data/ldbc-sf300-comments.tar.zst):
+
+```sql
+SELECT count(*) AS count
+FROM Comment c1
+JOIN Comment c2 ON c1.ParentCommentId = c2.id
+```
+
+In the first experiment, we use the correct (most restrictive) types, i.e., both the `id` and the `ParentCommentId` columns are defined as `BIGINT`.
+In the second experiment, we define all columns with the `VARCHAR` type.
+While the results are the same, the query runtime varies significantly: joining on `BIGINT` columns is approximately 2.6× faster than performing the same join on `VARCHAR` columns.
+
+<div class="narrow_table"></div>
+
+| Join Column Type | Query Time |
+|---|---|
+| `BIGINT` | 63.3s |
+| `VARCHAR` | 164.0s |
 
 ## Constraints
 

--- a/docs/guides/performance/schema.md
+++ b/docs/guides/performance/schema.md
@@ -5,7 +5,7 @@ title: Schema
 
 ## Types
 
-It is important to use the correct type for encoding columns (e.g., `BIGINT`, `DATE`, `DATETIME`). While it is always possible to use string types (`VARCHAR`, etc.) to encode more specific values, this is not recommended as strings are generally slower to process.
+It is important to use the correct type for encoding columns (e.g., `BIGINT`, `DATE`, `DATETIME`). While it is always possible to use string types (`VARCHAR`, etc.) to encode more specific values, this is not recommended. Strings use more space and are slower to process in operations such as filtering, join, and aggregation.
 
 When loading CSV files, you may leverage the CSV reader's [auto-detection mechanism](../../data/csv/auto_detection) to get the correct types for CSV inputs.
 

--- a/microbenchmarks/README.md
+++ b/microbenchmarks/README.md
@@ -1,0 +1,4 @@
+# Microbenchmarks
+
+This directory contains microbenchmarks used for the [Performance Guide](https://duckdb.org/docs/guides/performance/overview).
+For details, see the [Benchmarks page](https://duckdb.org/docs/guides/performance/benchmarks).

--- a/microbenchmarks/load-comments.sql
+++ b/microbenchmarks/load-comments.sql
@@ -1,0 +1,1 @@
+COPY Comment FROM 'ldbc-sf300-comments/bi-sf300-composite-merged-fk/graphs/csv/bi/composite-merged-fk/initial_snapshot/dynamic/Comment/part-*.csv.gz';

--- a/microbenchmarks/prepare.sql
+++ b/microbenchmarks/prepare.sql
@@ -1,0 +1,11 @@
+CREATE TABLE comment AS FROM 'Comment/part-*.csv.gz';
+
+CREATE TABLE ldbc_comment_datetime AS SELECT creationDate FROM comment;
+CREATE TABLE ldbc_comment_datetime_ordered AS SELECT creationDate FROM ldbc_comment_datetime ORDER BY creationDate;
+CREATE TABLE ldbc_comment_datetime_varchar AS SELECT creationDate::VARCHAR AS creationDate FROM ldbc_comment_datetime;
+CREATE TABLE ldbc_comment_datetime_varchar_ordered AS SELECT creationDate::VARCHAR AS creationDate FROM ldbc_comment_datetime_ordered;
+
+COPY ldbc_comment_datetime_ordered TO 'ldbc_comment_datetime_ordered.parquet';
+COPY ldbc_comment_datetime TO 'ldbc_comment_datetime.parquet';
+COPY ldbc_comment_datetime_varchar_ordered TO 'ldbc_comment_datetime_varchar_ordered.parquet';
+COPY ldbc_comment_datetime_varchar TO 'ldbc_comment_datetime_varchar.parquet';

--- a/microbenchmarks/process-pk-results.sql
+++ b/microbenchmarks/process-pk-results.sql
@@ -1,0 +1,8 @@
+CREATE OR REPLACE TABLE results AS FROM 'pk.csv';
+
+.mode markdown
+
+SELECT operation AS "Operation", median(time) || 's' AS "Execution Time"
+FROM results
+GROUP BY operation
+ORDER BY operation ASC;

--- a/microbenchmarks/process-row-group-size-results.sql
+++ b/microbenchmarks/process-row-group-size-results.sql
@@ -1,0 +1,8 @@
+CREATE OR REPLACE TABLE results AS FROM 'row-group-size-comparison.csv';
+
+.mode markdown
+
+SELECT row_group_size AS "Row Group Size", median(time) || 's' AS "Execution Time"
+FROM results
+GROUP BY row_group_size
+ORDER BY row_group_size ASC;

--- a/microbenchmarks/schema-with-pk.sql
+++ b/microbenchmarks/schema-with-pk.sql
@@ -1,0 +1,12 @@
+CREATE TABLE Comment (
+    creationDate TIMESTAMP WITH TIME ZONE NOT NULL,
+    id BIGINT PRIMARY KEY,
+    locationIP TEXT NOT NULL,
+    browserUsed TEXT NOT NULL,
+    content TEXT NOT NULL,
+    length INT NOT NULL,
+    CreatorPersonId BIGINT NOT NULL,
+    LocationCountryId BIGINT NOT NULL,
+    ParentPostId BIGINT,
+    ParentCommentId BIGINT,
+);

--- a/microbenchmarks/schema-without-pk.sql
+++ b/microbenchmarks/schema-without-pk.sql
@@ -1,0 +1,12 @@
+CREATE TABLE Comment (
+    creationDate TIMESTAMP WITH TIME ZONE NOT NULL,
+    id BIGINT NOT NULL,
+    locationIP TEXT NOT NULL,
+    browserUsed TEXT NOT NULL,
+    content TEXT NOT NULL,
+    length INT NOT NULL,
+    CreatorPersonId BIGINT NOT NULL,
+    LocationCountryId BIGINT NOT NULL,
+    ParentPostId BIGINT,
+    ParentCommentId BIGINT,
+);

--- a/microbenchmarks/ub-comments.sh
+++ b/microbenchmarks/ub-comments.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+DUCKDB=/opt/homebrew/bin/duckdb
+TIMEFORMAT='%3R'
+
+rm -rf *.parquet *.db*
+
+time ~/duckdb/duckdb my.db -c ".read prepare.sql"
+
+time ~/duckdb/duckdb ldbc_comment_datetime.db -c "CREATE TABLE ldbc_comment_datetime AS FROM 'ldbc_comment_datetime.parquet';"
+time ~/duckdb/duckdb ldbc_comment_datetime_ordered.db -c "CREATE TABLE ldbc_comment_datetime_ordered AS FROM 'ldbc_comment_datetime_ordered.parquet';"
+time ~/duckdb/duckdb ldbc_comment_datetime_varchar.db -c "CREATE TABLE ldbc_comment_datetime_varchar AS FROM 'ldbc_comment_datetime_varchar.parquet';"
+time ~/duckdb/duckdb ldbc_comment_datetime_varchar_ordered.db -c "CREATE TABLE ldbc_comment_datetime_varchar_ordered AS FROM 'ldbc_comment_datetime_varchar_ordered.parquet';"
+
+printf "ldbc_comment_datetime: "
+time ~/duckdb/duckdb ldbc_comment_datetime.db -c "SELECT avg(extract('day' FROM creationDate)) FROM ldbc_comment_datetime;" > /dev/null
+
+printf "ldbc_comment_datetime_varchar: "
+time ~/duckdb/duckdb ldbc_comment_datetime_varchar.db -c "SELECT avg(CAST(creationDate[9:10] AS INT)) FROM ldbc_comment_datetime_varchar;" > /dev/null
+
+printf "ldbc_comment_datetime_ordered: "
+time ~/duckdb/duckdb ldbc_comment_datetime_ordered.db -c "SELECT avg(extract('day' FROM creationDate)) FROM ldbc_comment_datetime_ordered;" > /dev/null
+
+printf "ldbc_comment_datetime_varchar_ordered: "
+time ~/duckdb/duckdb ldbc_comment_datetime_varchar_ordered.db -c "SELECT avg(CAST(creationDate[9:10] AS INT)) FROM ldbc_comment_datetime_varchar_ordered;" > /dev/null

--- a/microbenchmarks/ub-load-csv.sh
+++ b/microbenchmarks/ub-load-csv.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+DUCKDB=/opt/homebrew/bin/duckdb
+TIMEFORMAT='%3R'
+
+echo "Load the table from compressed representation (.csv.gz)"
+rm -rf *.db*
+${DUCKDB}      ldbc_comment_csv_test.db -c ".read schema-without-pk.sql"
+time ${DUCKDB} ldbc_comment_csv_test.db -c "COPY Comment FROM '~/ldbc-data/Comment-compressed/part-*.csv.gz' (HEADER true, DELIMITER '|');"
+${DUCKDB}      ldbc_comment_csv_test.db -c "SELECT count(*) AS numComment FROM Comment;"
+
+echo "Load the table from uncompressed representation (.csv)"
+rm -rf *.db*
+${DUCKDB}      ldbc_comment_csv_test.db -c ".read schema-without-pk.sql"
+time ${DUCKDB} ldbc_comment_csv_test.db -c "COPY Comment FROM '~/ldbc-data/Comment-decompressed/part-*.csv' (HEADER true, DELIMITER '|');"
+${DUCKDB}      ldbc_comment_csv_test.db -c "SELECT count(*) AS numComment FROM Comment;"

--- a/microbenchmarks/ub-pk.sh
+++ b/microbenchmarks/ub-pk.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+DUCKDB=/opt/homebrew/bin/duckdb
+TIMEFORMAT='%3R'
+
+echo "operation,iteration,time" > pk.csv
+
+
+for I in `seq 1 5`; do
+
+    echo "Load the table without PK constraint (dry run to fill caches)"
+    rm -rf *.db*
+    ${DUCKDB} ldbc_comment_pk.db -c ".read schema-without-pk.sql"
+    
+    exec 3>&1 4>&2
+    TIME=$( { time ${DUCKDB} ldbc_comment_pk.db -c "COPY Comment FROM 'Comment/part-*.csv.gz' (HEADER true, DELIMITER '|');" 1>&3 2>&4; } 2>&1)
+    exec 3>&- 4>&-
+
+    echo "Load the table without PK constraint (actual run)"
+    rm -rf *.db*
+    ${DUCKDB} ldbc_comment_pk.db -c ".read schema-without-pk.sql"
+
+    exec 3>&1 4>&2
+    TIME=$( { time ${DUCKDB} ldbc_comment_pk.db -c "COPY Comment FROM 'Comment/part-*.csv.gz' (HEADER true, DELIMITER '|');" 1>&3 2>&4; } 2>&1)
+    exec 3>&- 4>&-
+    echo "Creating a unique key index on id"
+    if [ $? == 0 ]; then
+        echo "load without pk,${I},${TIME}" >> pk.csv
+    fi
+
+    exec 3>&1 4>&2
+    TIME=$( { time ${DUCKDB} ldbc_comment_pk.db -c "CREATE UNIQUE INDEX comment_id ON Comment(id);" 1>&3 2>&4; } 2>&1)
+    exec 3>&- 4>&-
+    if [ $? == 0 ]; then
+        echo "create unique index,${I},${TIME}" >> pk.csv
+    fi
+
+    echo "Load the table with PK constraint:"
+    rm -rf *.db*
+    ${DUCKDB} ldbc_comment_pk.db -c ".read schema-with-pk.sql"
+
+    exec 3>&1 4>&2
+    TIME=$( { time ${DUCKDB} ldbc_comment_pk.db -c "COPY Comment FROM 'Comment/part-*.csv.gz' (HEADER true, DELIMITER '|');" 1>&3 2>&4; } 2>&1)
+    exec 3>&- 4>&-
+    if [ $? == 0 ]; then
+        echo "load with pk,${I},${TIME}" >> pk.csv
+    fi
+done
+
+${DUCKDB} -c ".read process-pk-results.sql"

--- a/microbenchmarks/ub-row-group-size.sh
+++ b/microbenchmarks/ub-row-group-size.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+DUCKDB=/opt/homebrew/bin/duckdb
+TIMEFORMAT='%R'
+
+rm -rf *.db
+
+printf "loading the comments to DuckDB"
+time ${DUCKDB} ldbc-comments.db -c "CREATE TABLE comment AS FROM 'Comment/part-*.csv.gz'";
+
+echo "row_group_size,iteration,time" > row-group-size-comparison.csv
+for ROW_GROUP_SIZE in 960 1920 3840 7680 15360 30720 61440 122880 245760 491520 983040 1966080; do
+    rm -rf tmpdb.db
+    rm -rf comment-sf300-parquet
+    ${DUCKDB} ldbc-comments.db -c "SET preserve_insertion_order=false; EXPORT DATABASE 'comment-sf300-parquet' (FORMAT PARQUET, ROW_GROUP_SIZE ${ROW_GROUP_SIZE});" > /dev/null
+
+    printf "Row group size ${ROW_GROUP_SIZE}: "
+    for I in $(seq 1 5); do
+        exec 3>&1 4>&2
+        TIME=$(TIMEFORMAT="%R"; { time ${DUCKDB} tmpdb.db -c "SELECT avg(extract('day' FROM creationDate)) FROM 'comment-sf300-parquet/comment.parquet';" 1>&3 2>&4; } 2>&1)
+        exec 3>&- 4>&-
+        if [ $? == 0 ]; then
+            echo "${ROW_GROUP_SIZE},${I},${TIME}" >> row-group-size-comparison.csv
+        fi
+    done
+done
+
+${DUCKDB} -c ".read process-row-group-size-results.sql"

--- a/microbenchmarks/ub-string-joins-1.py
+++ b/microbenchmarks/ub-string-joins-1.py
@@ -1,0 +1,37 @@
+import duckdb
+import time
+
+print("Benchmark to join on BIGINT field")
+print(f"DuckDB version: {duckdb.__version__}")
+con = duckdb.connect(database = "ldbc.duckdb")
+con.sql("""
+        CREATE TABLE Comment (
+            creationDate TIMESTAMP WITH TIME ZONE NOT NULL,
+            id BIGINT NOT NULL,
+            locationIP TEXT NOT NULL,
+            browserUsed TEXT NOT NULL,
+            content TEXT NOT NULL,
+            length INT NOT NULL,
+            CreatorPersonId BIGINT NOT NULL,
+            LocationCountryId BIGINT NOT NULL,
+            ParentPostId BIGINT,
+            ParentCommentId BIGINT,
+        );
+        """)
+
+print("Loading database")
+con.sql("""
+        INSERT INTO Comment FROM read_csv('ldbc-sf300-comments/*.csv.gz', auto_detect=true, delim='|', header=true)
+        """)
+
+print("Running the join 5 times")
+for i in range(0, 5):
+        start = time.time()
+        con.sql("""
+                SELECT count(*) AS count
+                FROM Comment c1
+                JOIN Comment c2 ON c1.ParentCommentId = c2.id
+                """).show()
+        end = time.time()
+        duration = end - start
+        print(f"{duration}")

--- a/microbenchmarks/ub-string-joins-2.py
+++ b/microbenchmarks/ub-string-joins-2.py
@@ -1,0 +1,23 @@
+import duckdb
+import time
+
+print("Benchmark to join on VARCHAR field")
+print(f"DuckDB version: {duckdb.__version__}")
+con = duckdb.connect(database = "ldbc.duckdb")
+
+print("Loading database")
+con.sql("""
+        CREATE TABLE Comment AS FROM read_csv('ldbc-sf300-comments/*.csv.gz', auto_detect=true, all_varchar=true, delim='|', header=true);
+        """)
+
+print("Running the join 5 times")
+for i in range(0, 5):
+        start = time.time()
+        con.sql("""
+                SELECT count(*) AS count
+                FROM Comment c1
+                JOIN Comment c2 ON c1.ParentCommentId = c2.id
+                """).show()
+        end = time.time()
+        duration = end - start
+        print(f"{duration}")

--- a/microbenchmarks/ub-string-joins.sh
+++ b/microbenchmarks/ub-string-joins.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+rm -rf ldbc.duckdb*
+python3 ub-string-joins-1.py
+du -hd0 ldbc.duckdb
+
+rm -rf ldbc.duckdb*
+python3 ub-string-joins-2.py
+du -hd0 ldbc.duckdb


### PR DESCRIPTION
The claim could use a microbenchmark on e.g. the SF300 data set – "look how much slower it is to join when it's loaded with the CSV reader's `all_varchar` setting set to `true`".

Fixes #1804