### PR TITLE
Update postgres/mysql docs

### DIFF
--- a/docs/archive/0.9.2/extensions/mysql.md
+++ b/docs/archive/0.9.2/extensions/mysql.md
@@ -217,6 +217,7 @@ SELECT * FROM mysql_db.tmp;
 > Note that DDL statements are not transactional in MySQL.
 
 ## Settings
+
 |                name                |                          description                           | default |
 |------------------------------------|----------------------------------------------------------------|---------|
 | mysql_experimental_filter_pushdown | Whether or not to use filter pushdown (currently experimental) | false   |

--- a/docs/archive/0.9.2/extensions/mysql.md
+++ b/docs/archive/0.9.2/extensions/mysql.md
@@ -216,22 +216,22 @@ SELECT * FROM mysql_db.tmp;
 
 > Note that DDL statements are not transactional in MySQL.
 
-## Building & Loading the Extension
+## Settings
+|                name                |                          description                           | default |
+|------------------------------------|----------------------------------------------------------------|---------|
+| mysql_experimental_filter_pushdown | Whether or not to use filter pushdown (currently experimental) | false   |
+| mysql_tinyint1_as_boolean          | Whether or not to convert TINYINT(1) columns to BOOLEAN        | true    |
+| mysql_debug_show_queries           | DEBUG SETTING: print all queries sent to MySQL to stdout       | false   |
+| mysql_bit1_as_boolean              | Whether or not to convert BIT(1) columns to BOOLEAN            | true    |
 
-The extension currently cannot be installed from a binary package. To build it, type:
+## Schema Cache
 
-```bash
-make
-```
-
-To run, run the bundled `duckdb` shell:
-
-```bash
-./build/release/duckdb -unsigned
-```
-
-Then, load the MySQL extension like so:
+To avoid having to continuously fetch schema data from MySQL, DuckDB keeps schema information - such as the names of tables, their columns, etc -  cached. If changes are made to the schema through a different connection to the MySQL instance, such as new columns being added to a table, the cached schema information might be outdated. In this case, the function `mysql_clear_cache` can be executed to clear the internal caches.
 
 ```sql
-LOAD 'build/release/extension/mysql_scanner/mysql_scanner.duckdb_extension';
+CALL mysql_clear_cache();
 ```
+
+## GitHub Repository
+
+[<span class="github">GitHub</span>](https://github.com/duckdb/duckdb_mysql)

--- a/docs/archive/0.9.2/extensions/postgres.md
+++ b/docs/archive/0.9.2/extensions/postgres.md
@@ -232,23 +232,20 @@ The extension exposes the following configuration parameters.
 |              name               |                                description                                 | default |
 |---------------------------------|----------------------------------------------------------------------------|---------|
 | pg_debug_show_queries           | DEBUG SETTING: print all queries sent to Postgres to stdout                | false   |
+| pg_connection_cache             | Whether or not to use the connection cache                                 | true    |
 | pg_experimental_filter_pushdown | Whether or not to use filter pushdown (currently experimental)             | false   |
 | pg_array_as_varchar             | Read Postgres arrays as varchar - enables reading mixed dimensional arrays | false   |
 | pg_connection_limit             | The maximum amount of concurrent Postgres connections                      | 64      |
 | pg_pages_per_task               | The amount of pages per task                                               | 1000    |
 | pg_use_binary_copy              | Whether or not to use BINARY copy to read data                             | true    |
 
-## Querying Individual Tables
+## Schema Cache
 
-If you prefer to not attach all tables, but just query a single table, that is possible using the `postgres_scan` function, e.g.:
+To avoid having to continuously fetch schema data from Postgres, DuckDB keeps schema information - such as the names of tables, their columns, etc -  cached. If changes are made to the schema through a different connection to the Postgres instance, such as new columns being added to a table, the cached schema information might be outdated. In this case, the function `pg_clear_cache` can be executed to clear the internal caches.
 
 ```sql
-SELECT * FROM postgres_scan('', 'public', 'mytable');
+CALL pg_clear_cache();
 ```
-
-The `postgres_scan` function takes three string parameters, the `libpq` connection string (see above), a PostgreSQL schema name and a table name. The schema often used in PostgreSQL is `public`.
-
-To use `filter_pushdown` use the `postgres_scan_pushdown` function.
 
 > The old postgres_attach function is deprecated. It is recommended to switch over to the new ATTACH syntax.
 

--- a/docs/extensions/mysql.md
+++ b/docs/extensions/mysql.md
@@ -217,6 +217,7 @@ SELECT * FROM mysql_db.tmp;
 > Note that DDL statements are not transactional in MySQL.
 
 ## Settings
+
 |                name                |                          description                           | default |
 |------------------------------------|----------------------------------------------------------------|---------|
 | mysql_experimental_filter_pushdown | Whether or not to use filter pushdown (currently experimental) | false   |

--- a/docs/extensions/mysql.md
+++ b/docs/extensions/mysql.md
@@ -216,6 +216,22 @@ SELECT * FROM mysql_db.tmp;
 
 > Note that DDL statements are not transactional in MySQL.
 
+## Settings
+|                name                |                          description                           | default |
+|------------------------------------|----------------------------------------------------------------|---------|
+| mysql_experimental_filter_pushdown | Whether or not to use filter pushdown (currently experimental) | false   |
+| mysql_tinyint1_as_boolean          | Whether or not to convert TINYINT(1) columns to BOOLEAN        | true    |
+| mysql_debug_show_queries           | DEBUG SETTING: print all queries sent to MySQL to stdout       | false   |
+| mysql_bit1_as_boolean              | Whether or not to convert BIT(1) columns to BOOLEAN            | true    |
+
+## Schema Cache
+
+To avoid having to continuously fetch schema data from MySQL, DuckDB keeps schema information - such as the names of tables, their columns, etc -  cached. If changes are made to the schema through a different connection to the MySQL instance, such as new columns being added to a table, the cached schema information might be outdated. In this case, the function `mysql_clear_cache` can be executed to clear the internal caches.
+
+```sql
+CALL mysql_clear_cache();
+```
+
 ## GitHub Repository
 
 [<span class="github">GitHub</span>](https://github.com/duckdb/duckdb_mysql)

--- a/docs/extensions/postgres.md
+++ b/docs/extensions/postgres.md
@@ -232,23 +232,20 @@ The extension exposes the following configuration parameters.
 |              name               |                                description                                 | default |
 |---------------------------------|----------------------------------------------------------------------------|---------|
 | pg_debug_show_queries           | DEBUG SETTING: print all queries sent to Postgres to stdout                | false   |
+| pg_connection_cache             | Whether or not to use the connection cache                                 | true    |
 | pg_experimental_filter_pushdown | Whether or not to use filter pushdown (currently experimental)             | false   |
 | pg_array_as_varchar             | Read Postgres arrays as varchar - enables reading mixed dimensional arrays | false   |
 | pg_connection_limit             | The maximum amount of concurrent Postgres connections                      | 64      |
 | pg_pages_per_task               | The amount of pages per task                                               | 1000    |
 | pg_use_binary_copy              | Whether or not to use BINARY copy to read data                             | true    |
 
-## Querying Individual Tables
+## Schema Cache
 
-If you prefer to not attach all tables, but just query a single table, that is possible using the `postgres_scan` function, e.g.:
+To avoid having to continuously fetch schema data from Postgres, DuckDB keeps schema information - such as the names of tables, their columns, etc -  cached. If changes are made to the schema through a different connection to the Postgres instance, such as new columns being added to a table, the cached schema information might be outdated. In this case, the function `pg_clear_cache` can be executed to clear the internal caches.
 
 ```sql
-SELECT * FROM postgres_scan('', 'public', 'mytable');
+CALL pg_clear_cache();
 ```
-
-The `postgres_scan` function takes three string parameters, the `libpq` connection string (see above), a PostgreSQL schema name and a table name. The schema often used in PostgreSQL is `public`.
-
-To use `filter_pushdown` use the `postgres_scan_pushdown` function.
 
 > The old postgres_attach function is deprecated. It is recommended to switch over to the new ATTACH syntax.
 


### PR DESCRIPTION
* Add settings info to MySQL docs
* Add clear cache info to both MySQL/Postgres docs
* Add new `pg_connection_cache` setting
* Remove documentation for deprecated `postgres_scan` function