### PR TITLE
Postgres connection can be specified in environment variables.

### DIFF
--- a/docs/extensions/postgres.md
+++ b/docs/extensions/postgres.md
@@ -54,16 +54,17 @@ This can be useful in a production environment where the connection information 
 and passed in to the environment.
 
 ```bash
-% export PGPASSWORD="secret"
-% export PGHOST=localhost
-% export PGUSER=owner
-% export PGDATABASE=mydatabase
-% duckdb
-D attach '' as p (type postgres);
+export PGPASSWORD="secret"
+export PGHOST=localhost
+export PGUSER=owner
+export PGDATABASE=mydatabase
+duckdb
+```
+```sql
+ATTACH '' AS p (TYPE postgres);
 ```
 
 ## Usage
-
 
 The tables in the PostgreSQL database can be read as if they were normal DuckDB tables, but the underlying data is read directly from Postgres at query time.
 

--- a/docs/extensions/postgres.md
+++ b/docs/extensions/postgres.md
@@ -21,7 +21,7 @@ The extension is loaded automatically upon first use. If you prefer to load it m
 LOAD postgres;
 ```
 
-## Usage
+## Connecting
 
 To make a PostgreSQL database accessible to DuckDB, use the `ATTACH` command:
 
@@ -48,6 +48,22 @@ host=localhost port=5432 dbname=mydb connect_timeout=10
 | password | Postgres Password                    |                |
 | dbname   | Database Name                        | [user]         |
 | passfile | Name of file passwords are stored in | ~/.pgpass      |
+
+Postgres connection information can also be specified with [environment variables](https://www.postgresql.org/docs/current/libpq-envars.html).
+This can be useful in a production environment where the connection information is managed externally
+and passed in to the environment.
+
+```bash
+% export PGPASSWORD="secret"
+% export PGHOST=localhost
+% export PGUSER=owner
+% export PGDATABASE=mydatabase
+% duckdb
+D attach '' as p (type postgres);
+```
+
+## Usage
+
 
 The tables in the PostgreSQL database can be read as if they were normal DuckDB tables, but the underlying data is read directly from Postgres at query time.
 


### PR DESCRIPTION
Very useful if you are running in a container or other environment where you don't want to manage the connection specification in the application.