### PR TITLE
Adjust lint.sh's -f flag to fix Python scripts with black

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -3,18 +3,18 @@
 set -xeuo pipefail
 
 fix=''
-check=''
+check='--check --diff'
 while getopts "f" opt; do
     case $opt in
         f) fix="--fix"
-           check='--check --diff';;
+           check='';
         *) exit
     esac
 done
 
 npx markdownlint-cli docs/ dev/ _posts/ --config .markdownlint.jsonc --ignore docs/archive $fix || echo 'mdlit failed'
 
-black scripts --skip-string-normalization $check || echo 'black failed'
+black scripts --skip-string-normalization $check  || echo 'black failed'
 
 if ! $(which vale); then
     echo "Vale binary not found, please install it from https://vale.sh/docs/vale-cli/installation/"


### PR DESCRIPTION
`black scripts --skip-string-normalization` runs the fix, the `--check` flag avoids running the fix.

See `tldr black`:
```
- Output whether a file or a directory would have changes made to them if they were to be formatted:
    black --check path/to/file_or_directory
```