### PR TITLE
Use markdownlint-enable/-disable blocks instead of markdownlint-disable-next-line

### DIFF
--- a/docs/api/cli/arguments.md
+++ b/docs/api/cli/arguments.md
@@ -9,6 +9,8 @@ Fot a list of dot commands available in the CLI shell, see the [Dot Commands pag
 
 <div class="narrow_table"></div>
 
+<!-- markdownlint-disable MD056 -->
+
 | Argument | Description |
 |---|-------|
 | `-append`         | Append the database to the end of the file                           |
@@ -38,9 +40,10 @@ Fot a list of dot commands available in the CLI shell, see the [Dot Commands pag
 | `-quote`          | Set [output mode](output-formats) to `quote`                         |
 | `-readonly`       | Open the database read-only                                          |
 | `-s COMMAND`      | Run `COMMAND` and exit                                               |
-<!-- markdownlint-disable-next-line MD056 -->
 | `-separator SEP`  | Set output column separator to SEP. Default: `|`                     |
 | `-stats`          | Print memory stats before each finalize                              |
 | `-table`          | Set [output mode](output-formats) to `table`                         |
 | `-unsigned`       | Allow loading of unsigned extensions                                 |
 | `-version`        | Show DuckDB version                                                  |
+
+<!-- markdownlint-enable MD056 -->

--- a/docs/data/csv/auto_detection.md
+++ b/docs/data/csv/auto_detection.md
@@ -62,12 +62,15 @@ The following dialects are considered for automatic dialect detection.
 
 <div class="narrow_table"></div>
 
+<!-- markdownlint-disable MD056 -->
+
 | Parameters | Considered values     |
 |------------|-----------------------|
-<!-- markdownlint-disable-next-line MD056 -->
 | `delim`    | `,` `|` `;` `\t`      |
 | `quote`    | `"` `'` (empty)       |
 | `escape`   | `"` `'` `\` (empty)   |
+
+<!-- markdownlint-enable MD056 -->
 
 Consider the example file [`flights.csv`](/data/flights.csv):
 

--- a/docs/extensions/full_text_search.md
+++ b/docs/extensions/full_text_search.md
@@ -27,6 +27,8 @@ create_fts_index(input_table, input_id, *input_values, stemmer = 'porter', stopw
 ```
 `PRAGMA` that creates a FTS index for the specified table.
 
+<!-- markdownlint-disable MD056 -->
+
 | Name | Type | Description |
 |:--|:--|:----------|
 |`input_table`|`VARCHAR`|Qualified name of specified table, e.g., `'table_name'` or `'main.table_name'`|
@@ -34,12 +36,13 @@ create_fts_index(input_table, input_id, *input_values, stemmer = 'porter', stopw
 |`input_values…`|`VARCHAR`|Column names of the text fields to be indexed (vararg), e.g., `'text_field_1'`, `'text_field_2'`, ..., `'text_field_N'`, or `'\*'` for all columns in input_table of type `VARCHAR`|
 |`stemmer`|`VARCHAR`|The type of stemmer to be used. One of `'arabic'`, `'basque'`, `'catalan'`, `'danish'`, `'dutch'`, `'english'`, `'finnish'`, `'french'`, `'german'`, `'greek'`, `'hindi'`, `'hungarian'`, `'indonesian'`, `'irish'`, `'italian'`, `'lithuanian'`, `'nepali'`, `'norwegian'`, `'porter'`, `'portuguese'`, `'romanian'`, `'russian'`, `'serbian'`, `'spanish'`, `'swedish'`, `'tamil'`, `'turkish'`, or `'none'` if no stemming is to be used. Defaults to `'porter'`|
 |`stopwords`|`VARCHAR`|Qualified name of table containing a single `VARCHAR` column containing the desired stopwords, or `'none'` if no stopwords are to be used. Defaults to `'english'` for a pre-defined list of 571 English stopwords|
-<!-- markdownlint-disable-next-line MD056 -->
 |`ignore`|`VARCHAR`|Regular expression of patterns to be ignored. Defaults to `'(\\.|[^a-z])+'`, ignoring all escaped and non-alphabetic lowercase characters|
 |`strip_accents`|`BOOLEAN`|Whether to remove accents (e.g., convert `á` to `a`). Defaults to `1`|
 |`lower`|`BOOLEAN`|Whether to convert all text to lowercase. Defaults to `1`|
 |`overwrite`|`BOOLEAN`|Whether to overwrite an existing index on a table. Defaults to `0`|
 
+<!-- markdownlint-enable MD056 -->
+ß
 This `PRAGMA` builds the index under a newly created schema. The schema will be named after the input table: if an index is created on table `'main.table_name'`, then the schema will be named `'fts_main_table_name'`.
 
 ### `PRAGMA drop_fts_index`

--- a/docs/sql/functions/bitstring.md
+++ b/docs/sql/functions/bitstring.md
@@ -12,15 +12,18 @@ The table below shows the available mathematical operators for `BIT` type.
 
 <div class="narrow_table"></div>
 
+<!-- markdownlint-disable MD056 -->
+
 | Operator | Description | Example | Result |
 |:---|:---|:---|:---|
 | `&` | bitwise AND | `'10101'::BIT & '10001'::BIT` | `10001` |
-<!-- markdownlint-disable-next-line MD056 -->
 | `|` | bitwise OR | `'1011'::BIT | '0001'::BIT` | `1011` |
 | `xor` | bitwise XOR | `xor('101'::BIT, '001'::BIT)` | `100` |
 | `~` | bitwise NOT | `~('101'::BIT)` | `010` |
 | `<<` | bitwise shift left | `'1001011'::BIT << 3` | `1011000` |
 | `>>` | bitwise shift right | `'1001011'::BIT >> 3` | `0001001` |
+
+<!-- markdownlint-enable MD056 -->
 
 ## Bitstring Functions
 

--- a/docs/sql/functions/blob.md
+++ b/docs/sql/functions/blob.md
@@ -5,10 +5,13 @@ title: Blob Functions
 
 This section describes functions and operators for examining and manipulating blob values.
 
+<!-- markdownlint-disable MD056 -->
+
 | Function | Description | Example | Result |
 |:-|:--|:---|:-|
-<!-- markdownlint-disable-next-line MD056 -->
 | *`blob`* `||` *`blob`* | Blob concatenation | `'\xAA'::BLOB || '\xBB'::BLOB` | `\xAA\xBB` |
 | `decode(`*`blob`*`)` | Convert blob to varchar. Fails if blob is not valid utf-8. | `decode('\xC3\xBC'::BLOB)` | `ü` |
 | `encode(`*`string`*`)` | Convert varchar to blob. Converts utf-8 characters into literal encoding. | `encode('my_string_with_ü')` | `my_string_with_\xC3\xBC` |
 | `octet_length(`*`blob`*`)` | Number of bytes in blob | `octet_length('\xAA\xBB'::BLOB)` | `2` |
+
+<!-- markdownlint-enable MD056 -->

--- a/docs/sql/functions/char.md
+++ b/docs/sql/functions/char.md
@@ -5,10 +5,11 @@ title: Text Functions
 
 This section describes functions and operators for examining and manipulating string values. The `␣` symbol denotes a space character.
 
+<!-- markdownlint-disable MD056 -->
+
 | Function | Description | Example | Result | Alias |
 |:--|:--|:---|:--|:--|
 | *`string`* `^@` *`search_string`* | Alias for `starts_with`. | `'abc' ^@ 'a'` | `true` | |
-<!-- markdownlint-disable-next-line MD056 -->
 | *`string`* `||` *`string`* | String concatenation | `'Duck' || 'DB'` | `DuckDB` | |
 | *`string`*`[`*`index`*`]` | Alias for `array_extract`. | `'DuckDB'[4]` | `'k'` | |
 | *`string`*`[`*`begin`*`:`*`end`*`]` | Alias for `array_slice`. Missing `begin` or `end` arguments are interpreted as the beginning or end of the list respectively. | `'DuckDB'[:4]` | `'Duck'` |
@@ -81,6 +82,8 @@ This section describes functions and operators for examining and manipulating st
 | `trim(`*`string`*`)`| Removes any spaces from either side of the *string* | `trim('␣␣␣␣test␣␣')` | `test` | |
 | `unicode(`*`string`*`)`| Returns the unicode code of the first character of the *string* | `unicode('ü')` | `252` | |
 | `upper(`*`string`*`)`| Convert *string* to upper case | `upper('Hello')` | `HELLO` | `ucase` |
+
+<!-- markdownlint-enable MD056 -->
 
 ## Text Similarity Functions
 

--- a/docs/sql/functions/numeric.md
+++ b/docs/sql/functions/numeric.md
@@ -9,6 +9,8 @@ The table below shows the available mathematical operators for numeric types.
 
 <div class="narrow_table"></div>
 
+<!-- markdownlint-disable MD056 -->
+
 | Operator | Description | Example | Result |
 |-|-----|--|-|
 | `+`      | addition                  | `2 + 3`   | `5`   |
@@ -20,12 +22,13 @@ The table below shows the available mathematical operators for numeric types.
 | `**`     | exponent                  | `3 ** 4`  | `81`  |
 | `^`      | exponent (alias for `**`) | `3 ^ 4`   | `81`  |
 | `&`      | bitwise AND               | `91 & 15` | `11`  |
-<!-- markdownlint-disable-next-line MD056 -->
 | `|`      | bitwise OR                | `32 | 3`  | `35`  |
 | `<<`     | bitwise shift left        | `1 << 4`  | `16`  |
 | `>>`     | bitwise shift right       | `8 >> 2`  | `2`   |
 | `~`      | bitwise negation          | `~15`     | `-16` |
 | `!`      | factorial of `x`          | `4!`      | `24`  |
+
+<!-- markdownlint-enable MD056 -->
 
 ### Division and Modulo Operators
 


### PR DESCRIPTION
Use markdownlint-enable/-disable blocks instead of markdownlint-disable-next-line

The latter breaks the formatting of tables in Jekyll