### PR TITLE
Use 'excerpt' field for TL;DR

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -69,6 +69,8 @@
 						<div class="singleentry">
 							<div class="infoline"><span>{{ page.date | date: "%Y-%m-%d" }}</span><span>{{ page.author }}</span></div>
 							<h1>{{ page.title }}</h1>
+							{% if page.excerpt != "" %}{{ '_TL;DR: ' | append: page.excerpt | append: '_' | markdownify }}{% endif %}
+
 							{% include anchor_headings.html html=content %}
 							<a href="/news/" class="backtoarchive">back to news archive <span></span></a>
 						</div>

--- a/_posts/2021-01-25-full-text-search.md
+++ b/_posts/2021-01-25-full-text-search.md
@@ -3,11 +3,8 @@
 layout: post
 title:  "Testing out DuckDB's Full Text Search Extension"
 author: Laurens Kuiper
-excerpt_separator: <!--more-->
-
+excerpt: DuckDB now has full-text search functionality, similar to the FTS5 extension in SQLite. The main difference is that our FTS extension is fully formulated in SQL. We tested it out on TREC disks 4 and 5.
 ---
-
-_TL;DR: DuckDB now has full-text search functionality, similar to the FTS5 extension in SQLite. The main difference is that our FTS extension is fully formulated in SQL. We tested it out on TREC disks 4 and 5._
 
 Searching through textual data stored in a database can be cumbersome, as SQL does not provide a good way of formulating questions such as "Give me all the documents about __Mallard Ducks__": string patterns with `LIKE` will only get you so far. Despite SQL's shortcomings here, storing textual data in a database is commonplace. Consider the table `products (id INT, name VARCHAR, description VARCHAR`) - it would be useful to search through the `name` and `description` columns for a website that sells these products.
 

--- a/_posts/2021-05-14-sql-on-pandas.md
+++ b/_posts/2021-05-14-sql-on-pandas.md
@@ -3,11 +3,8 @@
 layout: post
 title:  "Efficient SQL on Pandas with DuckDB"
 author: Mark Raasveldt and Hannes Mühleisen
-excerpt_separator: <!--more-->
-
+excerpt: DuckDB, a free and open source analytical data management system, can efficiently run SQL queries directly on Pandas DataFrames.
 ---
-
-_TL;DR: DuckDB, a free and open source analytical data management system, can efficiently run SQL queries directly on Pandas DataFrames._
 
 Recently, an article was published [advocating for using SQL for Data Analysis](https://hakibenita.com/sql-for-data-analysis). Here at team DuckDB, we are huge fans of [SQL](https://en.wikipedia.org/wiki/SQL). It is a versatile and flexible language that allows the user to efficiently perform a wide variety of data transformations, without having to care about how the data is physically represented or how to do these data transformations in the most optimal way.
 

--- a/_posts/2021-06-25-querying-parquet.md
+++ b/_posts/2021-06-25-querying-parquet.md
@@ -1,13 +1,9 @@
 ---
-
 layout: post
 title:  "Querying Parquet with Precision using DuckDB"
 author: Hannes Mühleisen and Mark Raasveldt
-excerpt_separator: <!--more-->
-
+excerpt: DuckDB, a free and open source analytical data management system, can run SQL queries directly on Parquet files and automatically take advantage of the advanced features of the Parquet format.
 ---
-
-_TL;DR: DuckDB, a free and open source analytical data management system, can run SQL queries directly on Parquet files and automatically take advantage of the advanced features of the Parquet format._
 
 Apache Parquet is the most common "Big Data" storage format for analytics. In Parquet files, data is stored in a columnar-compressed binary format. Each Parquet file stores a single table. The table is partitioned into row groups, which each contain a subset of the rows of the table. Within a row group, the table data is stored in a columnar fashion.
 

--- a/_posts/2021-08-27-external-sorting.md
+++ b/_posts/2021-08-27-external-sorting.md
@@ -1,13 +1,9 @@
 ---
-
 layout: post  
 title:  "Fastest table sort in the West - Redesigning DuckDB’s sort"
 author: Laurens Kuiper  
-excerpt_separator: <!--more-->
-
+excerpt: DuckDB, a free and Open-Source analytical data management system, has a new highly efficient parallel sorting implementation that can sort much more data than fits in main memory.
 ---
-
-_TL;DR: DuckDB, a free and Open-Source analytical data management system, has a new highly efficient parallel sorting implementation that can sort much more data than fits in main memory._
 
 Database systems use sorting for many purposes, the most obvious purpose being when a user adds an `ORDER BY` clause to their query.
 Sorting is also used within operators, such as window functions.

--- a/_posts/2021-10-13-windowing.md
+++ b/_posts/2021-10-13-windowing.md
@@ -1,14 +1,9 @@
 ---
-
 layout: post
 title:  "Windowing in DuckDB"
 author: Richard Wesley
-excerpt_separator: <!--more-->
-
+excerpt: DuckDB, a free and Open-Source analytical data management system, has a state-of-the-art windowing engine that can compute complex moving aggregates like inter-quartile ranges as well as simpler moving averages.
 ---
-
-_TL;DR: DuckDB, a free and Open-Source analytical data management system, has a state-of-the-art windowing engine
-that can compute complex moving aggregates like inter-quartile ranges as well as simpler moving averages._
 
 Window functions (those using the `OVER` clause) are important tools for analysing data series,
 but they can be slow if not implemented carefully.

--- a/_posts/2021-10-29-duckdb-wasm.md
+++ b/_posts/2021-10-29-duckdb-wasm.md
@@ -1,17 +1,9 @@
 ---
-
 layout: post
 title:  "DuckDB-Wasm: Efficient Analytical SQL in the Browser"
 author: André Kohn and Dominik Moritz
-excerpt_separator: <!--more-->
-
+excerpt: "[DuckDB-Wasm](https://github.com/duckdb/duckdb-wasm) is an in-process analytical SQL database for the browser. It is powered by WebAssembly, speaks Arrow fluently, reads Parquet, CSV and JSON files backed by Filesystem APIs or HTTP requests and has been tested with Chrome, Firefox, Safari and Node.js. You can try it in your browser at [shell.duckdb.org](https://shell.duckdb.org) or on [Observable](https://observablehq.com/@cmudig/duckdb)."
 ---
-
-_TL;DR: [DuckDB-Wasm](https://github.com/duckdb/duckdb-wasm) is an in-process analytical SQL database for the browser. 
-It is powered by WebAssembly, speaks Arrow fluently, reads Parquet, CSV and JSON files backed by Filesystem APIs or HTTP requests and has been tested with Chrome, Firefox, Safari and Node.js.
-You can try it in your browser at [shell.duckdb.org](https://shell.duckdb.org) or on [Observable](https://observablehq.com/@cmudig/duckdb)._
-
-<!--more-->
 
 <img src="/images/blog/duckdb_wasm.svg"
      alt="DuckDB-Wasm logo"

--- a/_posts/2021-11-12-moving-holistic.md
+++ b/_posts/2021-11-12-moving-holistic.md
@@ -1,15 +1,9 @@
 ---
-
 layout: post
 title:  "Fast Moving Holistic Aggregates"
 author: Richard Wesley
-excerpt_separator: <!--more-->
-
+excerpt: DuckDB, a free and Open-Source analytical data management system, has a windowing API that can compute complex moving aggregates like interquartile ranges and median absolute deviation much faster than the conventional approaches.
 ---
-
-_TL;DR: DuckDB, a free and Open-Source analytical data management system, has a windowing API
-that can compute complex moving aggregates like interquartile ranges and median absolute deviation
-much faster than the conventional approaches._
 
 In a [previous post](/2021/10/13/windowing.html),
 we described the DuckDB windowing architecture and mentioned the support for

--- a/_posts/2021-11-26-duck-enum.md
+++ b/_posts/2021-11-26-duck-enum.md
@@ -1,10 +1,8 @@
 ---
-
 layout: post  
 title:  "DuckDB - The Lord of Enums: <br> The Fellowship of the Categorical and Factors."
 author: Pedro Holanda
-excerpt_separator: <!--more-->
-
+excerpt: ""
 ---
 
 <img src="/images/blog/duck-lotr.png"

--- a/_posts/2021-12-03-duck-arrow.md
+++ b/_posts/2021-12-03-duck-arrow.md
@@ -1,13 +1,9 @@
 ---
-
 layout: post
 title:  "DuckDB quacks Arrow: A zero-copy data integration between Apache Arrow and DuckDB"
 author: Pedro Holanda and Jonathan Keane
-excerpt_separator: <!--more-->
-
+excerpt: The zero-copy integration between DuckDB and Apache Arrow allows for rapid analysis of larger than memory datasets in Python and R using either SQL or relational APIs.
 ---
-
-_TL;DR: The zero-copy integration between DuckDB and Apache Arrow allows for rapid analysis of larger than memory datasets in Python and R using either SQL or relational APIs._
 
 This post is a collaboration with and cross-posted on [the Arrow blog](https://arrow.apache.org/blog/2021/12/03/arrow-duckdb/).
 <!--more-->

--- a/_posts/2022-01-06-time-zones.md
+++ b/_posts/2022-01-06-time-zones.md
@@ -2,10 +2,8 @@
 layout: post  
 title:  "DuckDB Time Zones: Supporting Calendar Extensions"
 author: Richard Wesley
-excerpt_separator: <!--more-->
+excerpt: The DuckDB ICU extension now provides time zone support.
 ---
-
-_TL;DR: The DuckDB ICU extension now provides time zone support._
 
 Time zone support is a common request for temporal analytics, but the rules are complex and somewhat arbitrary. 
 The most well supported library for locale-specific operations is the [International Components for Unicode (ICU)](https://icu.unicode.org).

--- a/_posts/2022-03-07-aggregate-hashtable.md
+++ b/_posts/2022-03-07-aggregate-hashtable.md
@@ -2,11 +2,8 @@
 layout: post  
 title:  "Parallel Grouped Aggregation in DuckDB"
 author: Hannes Mühleisen and Mark Raasveldt
-excerpt_separator: <!--more-->
+excerpt: DuckDB has a fully parallelized aggregate hash table that can efficiently aggregate over millions of groups.
 ---
-
-_TL;DR: DuckDB has a fully parallelized aggregate hash table that can efficiently aggregate over millions of groups._
-
 
 Grouped aggregations are a core data analysis command. It is particularly important for large-scale data analysis (“OLAP”) because it is useful for  computing statistical summaries of huge tables. DuckDB contains a highly optimized parallel aggregation capability for fast and scalable summarization.
 

--- a/_posts/2022-05-04-friendlier-sql.md
+++ b/_posts/2022-05-04-friendlier-sql.md
@@ -2,11 +2,12 @@
 layout: post  
 title:  "Friendlier SQL with DuckDB"
 author: Alex Monahan
-excerpt_separator: <!--more-->
+excerpt: ""
 ---
+
 <img src="/images/blog/duck_chewbacca.png" alt="Chewbacca_the_duck" title="Chewbacca the duck is pretty friendly" width=200/>
 
-An elegant user experience is a key design goal of DuckDB. This goal guides much of DuckDB's architecture: it is simple to install, seamless to integrate with other data structures like Pandas, Arrow, and R Dataframes, and requires no dependencies. Parallelization occurs automatically, and if a computation exceeds available memory, data is gracefully buffered out to disk. And of course, DuckDB's processing speed makes it easier to get more work accomplished. 
+An elegant user experience is a key design goal of DuckDB. This goal guides much of DuckDB's architecture: it is simple to install, seamless to integrate with other data structures like Pandas, Arrow, and R Dataframes, and requires no dependencies. Parallelization occurs automatically, and if a computation exceeds available memory, data is gracefully buffered out to disk. And of course, DuckDB's processing speed makes it easier to get more work accomplished.
 
 However, SQL is not famous for being user-friendly. DuckDB aims to change that! DuckDB includes both a Relational API for dataframe-style computation, and a highly Postgres-compatible version of SQL. If you prefer dataframe-style computation, we would love your feedback on [our roadmap](https://github.com/duckdb/duckdb/issues/2000). If you are a SQL fan, read on to see how DuckDB is bringing together both innovation and pragmatism to make it easier to write SQL in DuckDB than anywhere else. Please reach out on [GitHub](https://github.com/duckdb/duckdb/discussions) or [Discord](https://discord.gg/vukK4xp7Rd) and let us know what other features would simplify your SQL workflows. Join us as we teach an old dog new tricks!
 <!--more-->

--- a/_posts/2022-05-27-iejoin.md
+++ b/_posts/2022-05-27-iejoin.md
@@ -2,10 +2,8 @@
 layout: post
 title:  "Range Joins in DuckDB"
 author: Richard Wesley
-excerpt_separator: <!--more-->
+excerpt: DuckDB has fully parallelised range joins that can efficiently join millions of range predicates.
 ---
-
-_TL;DR: DuckDB has fully parallelised range joins that can efficiently join millions of range predicates._
 
 Range intersection joins are an important operation in areas such as
 [temporal analytics](https://www2.cs.arizona.edu/~rts/tdbbook.pdf),

--- a/_posts/2022-07-27-art-storage.md
+++ b/_posts/2022-07-27-art-storage.md
@@ -2,16 +2,14 @@
 layout: post
 title:  "Persistent Storage of Adaptive Radix Trees in DuckDB"
 author: Pedro Holanda
-excerpt_separator: <!--more-->
+excerpt: DuckDB uses Adaptive Radix Tree (ART) Indexes to enforce constraints and to speed up query filters. Up to this point, indexes were not persisted, causing issues like loss of indexing information and high reload times for tables with data constraints. We now persist ART Indexes to disk, drastically diminishing database loading times (up to orders of magnitude), and we no longer lose track of existing indexes. This blog post contains a deep dive into the implementation of ART storage, benchmarks, and future work. Finally, to better understand how our indexes are used, I'm asking you to answer the following [survey](https://forms.gle/eSboTEp9qpP7ybz98). It will guide us when defining our future roadmap.
+
 ---
 
 <img src="/images/blog/ART/pedro-art.jpg"
      alt="DuckDB ART"
      width=200
  />
- 
-
-_TL;DR: DuckDB uses Adaptive Radix Tree (ART) Indexes to enforce constraints and to speed up query filters. Up to this point, indexes were not persisted, causing issues like loss of indexing information and high reload times for tables with data constraints. We now persist ART Indexes to disk, drastically diminishing database loading times (up to orders of magnitude), and we no longer lose track of existing indexes. This blog post contains a deep dive into the implementation of ART storage, benchmarks, and future work. Finally, to better understand how our indexes are used, I'm asking you to answer the following [survey](https://forms.gle/eSboTEp9qpP7ybz98). It will guide us when defining our future roadmap._
 
 <!--more-->
 

--- a/_posts/2022-09-30-postgres-scanner.md
+++ b/_posts/2022-09-30-postgres-scanner.md
@@ -2,19 +2,13 @@
 layout: post
 title:  "Querying Postgres Tables Directly From DuckDB"
 author: Hannes Mühleisen
-excerpt_separator: <!--more-->
+excerpt: DuckDB can now directly query tables stored in PostgreSQL and speed up complex analytical queries without duplicating data.
 ---
-
-
-_TL;DR: DuckDB can now directly query tables stored in PostgreSQL and speed up complex analytical queries without duplicating data._
-
-<!--more-->
 
 <img src="/images/blog/elephant-duck.jpg"
      alt="DuckDB goes Postgres"
      width=200
  />
-
 
 ## Introduction
 

--- a/_posts/2022-10-12-modern-data-stack-in-a-box.md
+++ b/_posts/2022-10-12-modern-data-stack-in-a-box.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "Modern Data Stack in a Box with DuckDB"
 author: Guest post by Jacob Matson
-excerpt_separator: <!--more-->
+excerpt: A fast, free, and open-source Modern Data Stack (MDS) can now be fully deployed on your laptop or to a single machine using the combination of [DuckDB](https://duckdb.org/), [Meltano](https://meltano.com/), [dbt](https://www.getdbt.com/), and [Apache Superset](https://superset.apache.org/).
 ---
 
 <!-- https://www.ebay.com/itm/185408133658 -->
@@ -10,8 +10,6 @@ excerpt_separator: <!--more-->
      alt="Duck on a box"
      width=200
  />
-
-_TL;DR: A fast, free, and open-source Modern Data Stack (MDS) can now be fully deployed on your laptop or to a single machine using the combination of [DuckDB](https://duckdb.org/), [Meltano](https://meltano.com/), [dbt](https://www.getdbt.com/), and [Apache Superset](https://superset.apache.org/)._
 
 This post is a collaboration with Jacob Matson and cross-posted on [dataduel.co](https://www.dataduel.co/modern-data-stack-in-a-box-with-duckdb/).
 

--- a/_posts/2022-10-28-lightweight-compression.md
+++ b/_posts/2022-10-28-lightweight-compression.md
@@ -2,15 +2,13 @@
 layout: post
 title:  "Lightweight Compression in DuckDB"
 author: Mark Raasveldt
-excerpt_separator: <!--more-->
+excerpt: DuckDB supports efficient lightweight compression that is automatically used to keep data size down without incurring high costs for compression and decompression.
 ---
 
 <img src="/images/compression/matroshka-duck.png"
      alt="Matroshka Ducks (ducks going from big to small)"
      width=200px
      />
-
-_TL;DR: DuckDB supports efficient lightweight compression that is automatically used to keep data size down without incurring high costs for compression and decompression._
 
 When working with large amounts of data, compression is critical for reducing storage size and egress costs. Compression algorithms typically reduce data set size by **75-95%**, depending on how compressible the data is. Compression not only reduces the storage footprint of a data set, but also often **improves performance** as less data has to be read from disk or over a network connection.
 

--- a/_posts/2022-11-14-announcing-duckdb-060.md
+++ b/_posts/2022-11-14-announcing-duckdb-060.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "Announcing DuckDB 0.6.0"
 author: Mark Raasveldt
-excerpt_separator: <!--more-->
+excerpt: ""
 ---
 
 <img src="/images/blog/white-headed-duck.jpeg"

--- a/_posts/2022-11-25-duckcon.md
+++ b/_posts/2022-11-25-duckcon.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "DuckCon 2023 - 2nd edition"
 author: Pedro Holanda
-excerpt_separator: <!--more-->
+excerpt: ""
 ---
 
 The DuckDB team is excited to invite you all for our second [DuckCon](https://www.meetup.com/duckdb/events/289021740/) user group meeting. It will take place the day before [FOSDEM](https://archive.fosdem.org/2023/) in Brussels on Feb 3rd, 2023, at the [Hilton Hotel](https://www.google.com/maps/search/?api=1&query=50.845947%2C%204.356138).

--- a/_posts/2023-02-13-announcing-duckdb-070.md
+++ b/_posts/2023-02-13-announcing-duckdb-070.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "Announcing DuckDB 0.7.0"
 author: Mark Raasveldt
-excerpt_separator: <!--more-->
+excerpt: ""
 ---
 
 <img src="/images/blog/labrador_duck.png"

--- a/_posts/2023-02-24-jupysql.md
+++ b/_posts/2023-02-24-jupysql.md
@@ -2,8 +2,8 @@
 layout: post
 title:  "JupySQL Plotting with DuckDB"
 author: Guest post by Eduardo Blancas
-excerpt_separator: <!--more-->
 description: duckdb-post
+excerpt: "[JupySQL](https://github.com/ploomber/jupysql) provides a seamless SQL experience in Jupyter and uses DuckDB to visualize larger than memory datasets in matplotlib."
 images:
 - /images/blog/jupysql/serialized/8-0.png
 jupyblog:
@@ -22,9 +22,6 @@ jupyter:
     name: python3
 ---
 
-_TL;DR: [JupySQL](https://github.com/ploomber/jupysql) provides a seamless SQL experience in Jupyter and uses DuckDB to visualize larger than memory datasets in matplotlib._
-
-<!--more-->
 ## Introduction
 
 Data visualization is essential for every data practitioner since it allows us to find patterns that otherwise would be hard to see. The typical approach for plotting tabular datasets involves Pandas and Matplotlib. However, this technique quickly falls short as our data grows, given that Pandas introduces a significant memory overhead, making it challenging even to plot a medium-sized dataset.

--- a/_posts/2023-03-03-json.md
+++ b/_posts/2023-03-03-json.md
@@ -2,10 +2,8 @@
 layout: post
 title:  "Shredding Deeply Nested JSON, One Vector at a Time"
 author: Laurens Kuiper
-excerpt_separator: <!--more-->
+excerpt: We've recently improved DuckDB's JSON extension so JSON files can be directly queried as if they were tables.
 ---
-
-_TL;DR: We've recently improved DuckDB's JSON extension so JSON files can be directly queried as if they were tables._
 
 <img src="/images/blog/jason-duck.jpg" alt="JSON is not scary anymore! Jason IS scary though, even as a duck." width=180/>
 

--- a/_posts/2023-04-14-h2oai.md
+++ b/_posts/2023-04-14-h2oai.md
@@ -2,11 +2,8 @@
 layout: post
 title:  "The Return of the H2O.ai Database-like Ops Benchmark"
 author: Tom Ebergen
-excerpt_separator: <!--more-->
+excerpt: We've resurrected the H2O.ai database-like ops benchmark with up to date libraries and plan to keep re-running it.
 ---
-
-_TL;DR: We've resurrected the H2O.ai database-like ops benchmark with up to date libraries and plan to keep re-running it._
-
 
 [Skip directly to the results](#results)
 

--- a/_posts/2023-04-21-swift.md
+++ b/_posts/2023-04-21-swift.md
@@ -2,11 +2,8 @@
 layout: post
 title:  "Introducing DuckDB for Swift"
 author: Tristan Celder
-excerpt_separator: <!--more-->
+excerpt: DuckDB now has a native Swift API. DuckDB on mobile here we go!
 ---
-
-_TL;DR: DuckDB now has a native Swift API. DuckDB on mobile here we go!_
-
 
 Today we’re excited to announce the [DuckDB API for Swift](https://github.com/duckdb/duckdb-swift). It enables developers on Swift platforms to harness the full power of DuckDB using a native Swift interface with support for great Swift features such as strong typing and concurrency. The API is available not only on Apple platforms, but on Linux too, opening up new opportunities for the growing Swift on Server ecosystem.
 

--- a/_posts/2023-04-28-duckcon3.md
+++ b/_posts/2023-04-28-duckcon3.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "DuckCon #3 in San Francisco"
 author: Hannes Mühleisen
-excerpt_separator: <!--more-->
+excerpt: ""
 ---
 
 We are excited to hold our first "DuckCon" DuckDB user group meeting outside of Europe in **San Francisco**. The meeting will take place in the afternoon of *June 29th*. The meeting will be held at the [San Francisco Museum of Modern Art (SFMOMA)](https://www.sfmoma.org), in the Phyllis Wattis Theater.

--- a/_posts/2023-04-28-spatial.md
+++ b/_posts/2023-04-28-spatial.md
@@ -2,11 +2,8 @@
 layout: post
 title:  "PostGEESE? Introducing The DuckDB Spatial Extension"
 author: Max Gabrielsson
-excerpt_separator: <!--more-->
+excerpt: DuckDB now has an official [Spatial extension](https://github.com/duckdb/duckdb_spatial) to enable geospatial processing.
 ---
-
-_TL;DR: DuckDB now has an official [Spatial extension](https://github.com/duckdb/duckdb_spatial) to enable geospatial processing._
-
 
 Geospatial data has become increasingly important and prevalent in modern-day applications and data engineering workflows, with use-cases ranging from location-based services to environmental monitoring.
 

--- a/_posts/2023-05-12-github-10k-stars.md
+++ b/_posts/2023-05-12-github-10k-stars.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "10 000 Stars on GitHub"
 author: Mark Raasveldt and Hannes Mühleisen
-excerpt_separator: <!--more-->
+excerpt: ""
 ---
 
 Today, DuckDB reached 10 000 stars on [GitHub](https://github.com/duckdb/duckdb). We would like to pause for a second to express our gratitude to [everyone who contributed](https://github.com/duckdb/duckdb/graphs/contributors) to DuckDB and of course all its users. When we started working on DuckDB back in 2018, we would have never dreamt of getting this kind of adoption in such a short time.

--- a/_posts/2023-05-17-announcing-duckdb-080.md
+++ b/_posts/2023-05-17-announcing-duckdb-080.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "Announcing DuckDB 0.8.0"
 author: Mark Raasveldt and Hannes Mühleisen
-excerpt_separator: <!--more-->
+excerpt: ""
 ---
 
 <img src="/images/blog/mottled_duck.jpg"

--- a/_posts/2023-05-26-correlated-subqueries-in-sql.md
+++ b/_posts/2023-05-26-correlated-subqueries-in-sql.md
@@ -2,9 +2,8 @@
 layout: post
 title:  "Correlated Subqueries in SQL"
 author: Mark Raasveldt
-excerpt_separator: <!--more-->
+excerpt: ""
 ---
-
 
 Subqueries in SQL are a powerful abstraction that allow simple queries to be used as composable building blocks. They allow you to break down complex problems into smaller parts, and subsequently make it easier to write, understand and maintain large and complex queries.
 

--- a/_posts/2023-07-07-python-udf.md
+++ b/_posts/2023-07-07-python-udf.md
@@ -1,18 +1,14 @@
 ---
-
 layout: post
 title:  "From Waddle to Flying: Quickly expanding DuckDB's functionality with Scalar Python UDFs"
 author: Pedro Holanda, Thijs Bruineman and Phillip Cloud
-excerpt_separator: <!--more-->
-
+excerpt: DuckDB now supports vectorized Scalar Python User Defined Functions (UDFs). By implementing Python UDFs, users can easily expand the functionality of DuckDB while taking advantage of DuckDB's fast execution model, SQL and data safety.
 ---
 
 <img src="/images/blog/bird-dance.gif"
      alt="DuckDB-Waddle-fly"
      width=100
      />
-
-_TL;DR: DuckDB now supports vectorized Scalar Python User Defined Functions (UDFs). By implementing Python UDFs, users can easily expand the functionality of DuckDB while taking advantage of DuckDB's fast execution model, SQL and data safety._
 
 User Defined Functions (UDFs) enable users to extend the functionality of a Database Management System (DBMS) to perform domain-specific tasks that are not implemented as built-in functions. For instance, users who frequently need to export private data can benefit from an anonymization function that masks the local part of an email while preserving the domain. Ideally, this function would be executed directly in the DBMS. This approach offers several advantages:
 

--- a/_posts/2023-08-04-adbc.md
+++ b/_posts/2023-08-04-adbc.md
@@ -3,16 +3,13 @@
 layout: post
 title:  "DuckDB ADBC - Zero-Copy data transfer via Arrow Database Connectivity"
 author: Pedro Holanda
-excerpt_separator: <!--more-->
-
+excerpt: DuckDB has added support for [Arrow Database Connectivity (ADBC)](https://arrow.apache.org/adbc/0.5.1/index.html), an API standard that enables efficient data ingestion and retrieval from database systems, similar to [Open Database Connectivity (ODBC)](https://learn.microsoft.com/en-us/sql/odbc/microsoft-open-database-connectivity-odbc?view=sql-server-ver16) interface. However, unlike ODBC, ADBC specifically caters to the columnar storage model, facilitating fast data transfers between a columnar database and an external application.
 ---
 
 <img src="/images/blog/adbc/duck-arrow.jpg"
      alt="DuckDB-Arrow"
      width=100
 />
-
-_TL;DR: DuckDB has added support for [Arrow Database Connectivity (ADBC)](https://arrow.apache.org/adbc/0.5.1/index.html), an API standard that enables efficient data ingestion and retrieval from database systems, similar to [Open Database Connectivity (ODBC)](https://learn.microsoft.com/en-us/sql/odbc/microsoft-open-database-connectivity-odbc?view=sql-server-ver16) interface. However, unlike ODBC, ADBC specifically caters to the columnar storage model, facilitating fast data transfers between a columnar database and an external application._
 
 Database interface standards allow developers to write application code that is independent of the underlying database management system (DBMS) being used. DuckDB has supported two standards that have gained popularity in the past few decades: [the core interface of ODBC](https://learn.microsoft.com/en-us/sql/odbc/reference/develop-app/interface-conformance-levels?view=sql-server-ver16) and [Java Database Connectivity (JDBC)](https://en.wikipedia.org/wiki/Java_Database_Connectivity). Both interfaces are designed to fully support database connectivity and management, with JDBC being catered for the Java environment. With these APIs, developers can query DBMS agnostically, retrieve query results, run prepared statements, and manage connections.
 

--- a/_posts/2023-08-23-even-friendlier-sql.md
+++ b/_posts/2023-08-23-even-friendlier-sql.md
@@ -3,6 +3,7 @@
 layout: post
 title:  "Even Friendlier SQL with DuckDB"
 author: Alex Monahan
+excerpt: DuckDB continues to push the boundaries of SQL syntax to both simplify queries and make more advanced analyses possible. Highlights include dynamic column selection, queries that start with the FROM clause, function chaining, and list comprehensions. We boldly go where no SQL engine has gone before!
 ---
 
 <img src="/images/blog/ai_generated_star_trek_rubber_duck.png"
@@ -10,13 +11,11 @@ author: Alex Monahan
      width=200
 />
 
-_TL;DR: DuckDB continues to push the boundaries of SQL syntax to both simplify queries and make more advanced analyses possible. Highlights include dynamic column selection, queries that start with the FROM clause, function chaining, and list comprehensions. We boldly go where no SQL engine has gone before!_
-
-Who says that SQL should stay frozen in time, chained to a 1999 version of the specification? As a comparison, do folks remember what JavaScript felt like before Promises? Those didn’t launch until 2012! It’s clear that innovation at the programming syntax layer can have a profoundly positive impact on an entire language ecosystem. 
+Who says that SQL should stay frozen in time, chained to a 1999 version of the specification? As a comparison, do folks remember what JavaScript felt like before Promises? Those didn’t launch until 2012! It’s clear that innovation at the programming syntax layer can have a profoundly positive impact on an entire language ecosystem.
 
 We believe there are many valid reasons for innovation in the SQL language, among them opportunities to simplify basic queries and also to make more dynamic analyses possible. Many of these features arose from community suggestions! Please let us know your SQL pain points on [Discord](https://discord.duckdb.org/) or [GitHub](https://github.com/duckdb/duckdb/discussions) and join us as we change what it feels like to write SQL!
 
-If you have not had a chance to read the first installment in this series, please take a quick look [here](https://duckdb.org/2022/05/04/friendlier-sql.html). 
+If you have not had a chance to read the first installment in this series, please take a quick look [here](https://duckdb.org/2022/05/04/friendlier-sql.html).
 
 ## The future is now
 

--- a/_posts/2023-09-15-asof-joins-fuzzy-temporal-lookups.md
+++ b/_posts/2023-09-15-asof-joins-fuzzy-temporal-lookups.md
@@ -2,9 +2,8 @@
 layout: post
 title: "DuckDB's AsOf Joins: Fuzzy Temporal Lookups"
 author: Richard Wesley
+excerpt: DuckDB supports AsOf Joins – a way to match nearby values. They are especially useful for searching event tables for temporal analytics.
 ---
-
-_TL;DR: DuckDB supports AsOf Joins – a way to match nearby values. They are especially useful for searching event tables for temporal analytics._
 
 Do you have time series data that you want to join,
 but the timestamps don't quite match?

--- a/_posts/2023-09-26-announcing-duckdb-090.md
+++ b/_posts/2023-09-26-announcing-duckdb-090.md
@@ -3,6 +3,7 @@ layout: post
 title:  "Announcing DuckDB 0.9.0"
 author: Mark Raasveldt and Hannes Mühleisen
 excerpt_separator: <!--more-->
+excerpt: ""
 ---
 
 <img src="/images/blog/yellow-billed-duck.jpg"

--- a/_posts/2023-10-06-duckcon4.md
+++ b/_posts/2023-10-06-duckcon4.md
@@ -2,7 +2,7 @@
 layout: post
 title: "DuckCon #4 in Amsterdam"
 author: Mark Raasveldt, Hannes Mühleisen, Gabor Szarnyas
-excerpt_separator: <!--more-->
+excerpt: ""
 ---
 
 <img src="/images/duckcon4-splashscreen.png"

--- a/_posts/2023-10-27-csv-sniffer.md
+++ b/_posts/2023-10-27-csv-sniffer.md
@@ -3,17 +3,14 @@
 layout: post
 title:  "DuckDB's CSV Sniffer: Automatic Detection of Types and Dialects"
 author: Pedro Holanda
-excerpt_separator: <!--more-->
 thumb: "/images/blog/csv-sniffer/ducktetive.jpg"
-
+excerpt: DuckDB is primarily focused on performance, leveraging the capabilities of modern file formats. At the same time, we also pay attention to flexible, non-performance-driven formats like CSV files. To create a nice and pleasant experience when reading from CSV files, DuckDB implements a CSV sniffer that automatically detects CSV dialect options, column types, and even skips dirty data. The sniffing process allows users to efficiently explore CSV files without needing to provide any input about the file format.
 ---
 
 <img src="/images/blog/csv-sniffer/ducktetive.jpg"
      alt="ducktetive"
      width="300"
      />
-
-_TL;DR: DuckDB is primarily focused on performance, leveraging the capabilities of modern file formats. At the same time, we also pay attention to flexible, non-performance-driven formats like CSV files. To create a nice and pleasant experience when reading from CSV files, DuckDB implements a CSV sniffer that automatically detects CSV dialect options, column types, and even skips dirty data. The sniffing process allows users to efficiently explore CSV files without needing to provide any input about the file format._
 
 There are many different file formats that users can choose from when storing their data. For example, there are performance-oriented binary formats like Parquet, where data is stored in a columnar format, partitioned into row-groups, and heavily compressed. However, Parquet is known for its rigidity, requiring specialized systems to read and write these files.
 

--- a/_posts/2023-11-03-db-benchmark-update.md
+++ b/_posts/2023-11-03-db-benchmark-update.md
@@ -2,12 +2,8 @@
 layout: post
 title:  "Updates to the H2O.ai db-benchmark!"
 author: Tom Ebergen
-excerpt_separator: <!--more-->
+excerpt: The H2O.ai db-benchmark has been updated with new results. In addition, the AWS EC2 instance used for benchmarking has been changed to a c6id.metal for improved repeatability and fairness across libraries. DuckDB is the fastest library for both join and group by queries at almost every data size.
 ---
-
-
-_TL;DR: the H2O.ai db-benchmark has been updated with new results. In addition, the AWS EC2 instance used for benchmarking has been changed to a c6id.metal for improved repeatability and fairness across libraries. DuckDB is the fastest library for both join and group by queries at almost every data size._
-
 
 [Skip directly to the results](#results)
 
@@ -17,23 +13,19 @@ In April, DuckDB Labs published a [blog post reporting updated H2O.ai db-benchma
 
 ## New Benchmark Environment: c6id.metal Instance
 
-
 Initially, updating the results to the benchmark showed strange results. Even using the same library versions from the prior update, some solutions regressed and others improved. We believe this variance came from the AWS EC2 instance we chose: an m4.10xlarge. The m4.10xlarge has 40 virtual CPUs and EBS storage. EBS storage is highly available network block storage for EC2 instances. When running compute-heavy benchmarks, a machine like the m4.10xlarge can suffer from the following issues: 
 
 * **Network storage** is an issue for benchmarking solutions that interact with storage frequently. For the 500MB and 5GB workloads, network storage was not an issue on the m4.10xlarge since all solutions could execute the queries in memory. For the 50GB workload, however, network storage was an issue for the solutions that could not execute queries in memory. While the m4.10xlarge has dedicated EBS bandwidth, any read/write from storage is still happening over the network, which is usually slower than physically mounted storage. Solutions that frequently read and write to storage for the 50GB queries end up doing this over the network. This network time becomes a chunk of the execution time of the query. If the network has variable performance, the query performance is then also variable.
 
-* **Noisy neighbors** is a common issue when benchmarking on virtual CPUs. The previous machine most likely shared its compute hardware with other (neighboring) AWS EC2 instances. If these neighbors are also running compute heavy workloads, the physical CPU caches are repeatedly invalidated/flushed by the neighboring instance and the benchmark instance. When the CPU cache is shared between two workloads on two instances, both workloads require extra reads from memory for data that would already be in CPU cache on a non-virtual machine. 
-	
+* **Noisy neighbors** is a common issue when benchmarking on virtual CPUs. The previous machine most likely shared its compute hardware with other (neighboring) AWS EC2 instances. If these neighbors are also running compute heavy workloads, the physical CPU caches are repeatedly invalidated/flushed by the neighboring instance and the benchmark instance. When the CPU cache is shared between two workloads on two instances, both workloads require extra reads from memory for data that would already be in CPU cache on a non-virtual machine.
 
 In order to be fair to all solutions, we decided to change the instance type to a metal instance with local storage. Metal instance types negate any noisy neighbor problems because the hardware is physical and not shared with any other AWS users/instances. Network storage problems are also fixed because solutions can read and write data to the local instance storage, which is physically mounted on the hardware.
 
 Another benefit of the the c6id.metal box is that it stresses parallel performance. There are 128 cores on the c6id.metal. Performance differences between solutions that can effectively use every core and solutions that cannot are clearly visible.
 
-
 See the [updated settings](#updated-settings) section on how settings were change for each solution when run on the new machine.
 
 ## Updating the Benchmark
-
 
 Moving forward we will update the benchmark when PRs with new performance numbers are provided. The PR should include a description of the changes to a solution script or a version update and new entries in the `time.csv` and `logs.csv` files. These entries will be verified using a different c6id.metal instance, and if there is limited variance, the PR will be merged and the results will be updated!
 
@@ -59,4 +51,3 @@ The team at DuckDB Labs has been hard at work improving the performance of the o
 
 [Link to result page](https://DuckDBlabs.github.io/db-benchmark/)
 <iframe src="https://DuckDBlabs.github.io/db-benchmark/"  title="h2oai db benchmmark" height=500 width=600></iframe>
-

--- a/_posts/2023-12-18-duckdb-extensions-in-wasm.md
+++ b/_posts/2023-12-18-duckdb-extensions-in-wasm.md
@@ -2,10 +2,8 @@
 layout: post
 title:  "Extensions for DuckDB-Wasm"
 author: Carlo Piovesan
-excerpt_separator: <!--more-->
+excerpt: DuckDB-Wasm users can now load DuckDB extensions, allowing them to run extensions in the browser.
 ---
-
-_TL;DR: DuckDB-Wasm users can now load DuckDB extensions, allowing them to run extensions in the browser._
 
 In this blog post, we will go over two exciting DuckDB features: the DuckDB-Wasm client and DuckDB extensions. I will discuss how these disjoint features have now been adapted to work together. These features are now available for DuckDB-Wasm users and you can try them out at [shell.duckdb.org](https://shell.duckdb.org).
 

--- a/_posts/2024-01-26-multi-database-support-in-duckdb.md
+++ b/_posts/2024-01-26-multi-database-support-in-duckdb.md
@@ -2,15 +2,13 @@
 layout: post
 title:  "Multi-Database Support in DuckDB"
 author: Mark Raasveldt
-excerpt_separator: <!--more-->
+excerpt: DuckDB can attach MySQL, Postgres, and SQLite databases in addition to databases stored in its own format. This allows data to be read into DuckDB and moved between these systems in a convenient manner.
 ---
 
 <img src="/images/blog/duckdb-multidb-support.png"
      alt="DuckDB supports reading and writing to MySQL, Postgres, and SQLite"
      width=700
 />
-
-_TL;DR: DuckDB can attach MySQL, Postgres, and SQLite databases in addition to databases stored in its own format. This allows data to be read into DuckDB and moved between these systems in a convenient manner._
 
 In modern data analysis, data must often be combined from a wide variety of different sources. Data might sit in CSV files on your machine, in Parquet files in a data lake, or in an operational database. DuckDB has strong support for moving data between many different data sources. However, this support has previously been limited to reading data and writing data to files.
 


### PR DESCRIPTION
Followup of #2044. This adds the tldr text as the description meta tag and `og:description` property. For some old posts, I left it empty as it would require some effort to write TL;DRs for all of them.