### PR TITLE
fix wrong output quotes + binder error in json_extract examples

### DIFF
--- a/docs/extensions/json.md
+++ b/docs/extensions/json.md
@@ -418,11 +418,13 @@ SELECT j->'$.family' FROM example;
 -- "anatidae"
 SELECT j->'$.species[0]' FROM example;
 -- "duck"
-SELECT j->>'$.species[*]' FROM example;
+SELECT j->'$.species[*]' FROM example;
 -- ["duck", "goose", "swan", null]
+SELECT j->>'$.species[*]' FROM example;
+-- [duck, goose, swan, null]
 SELECT j->'$.species'->0 FROM example;
 -- "duck"
-SELECT j->'species'->>[0,1] FROM example;
+SELECT j->'species'->['0','1'] FROM example;
 -- ["duck", "goose"]
 SELECT json_extract_string(j, '$.family') FROM example;
 -- anatidae


### PR DESCRIPTION
Hi,

I discovered an inconsistency in the json_extract examples and ran all the example queries. I corrected a bug (one query resulted in a binder error) and the given output of one query (wrong quotation marks). I added another example to emphasise the difference between `->` and `->>`.