### PR TITLE
Duplicate href for Live Demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@ body_class: landing nowrap
 							<option value="sql-spatial-extension">Spatial Extension</option>
 						</select>
 					</div>
-					<a class="button arrow-right livedemo" href="#">Live Demo</a>
+					<a class="button arrow-right livedemo" href="https://shell.duckdb.org/#queries=v0,%20%20-Create-table-from-Parquet-file%0ACREATE-TABLE-train_services-AS%0A----FROM-'s3%3A%2F%2Fduckdb%20blobs%2Ftrain_services.parquet'~,%20%20-Get-the-top%203-busiest-train-stations%0ASELECT-station_name%2C-count(*)-AS-num_services%0AFROM-train_services%0AGROUP-BY-ALL%0AORDER-BY-num_services-DESC%0ALIMIT-3~">Live Demo</a>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
If you land on the website, 'Live Demo' button points to "#".
This PR duplicate the href of the first demo, since I was lazy and didn't want to look for a more proper solution.