### PR TITLE
temporarily hide JSON's "Pages in This Section"

### DIFF
--- a/docs/data/json/overview.md
+++ b/docs/data/json/overview.md
@@ -274,4 +274,4 @@ SELECT * FROM todos LIMIT 5;
 
 For more details, see the [page on the `COPY` statement](../../sql/statements/copy).
 
-## Pages in This Section
+<!-- ## Pages in This Section -->


### PR DESCRIPTION
there currently aren't any other pages in this section.  I left it hidden to prompt people to add to it if any additional JSON pages are added to the documentation.

The blank section looks a little funny at the bottom of the page.

![image](https://github.com/duckdb/duckdb-web/assets/1372890/def113b1-0f12-45a1-a3c2-eb5d6eedca96)
