### PR TITLE
Clarify temp_directory is a dir and not a file

### DIFF
--- a/docs/guides/performance/how_to_tune_workloads.md
+++ b/docs/guides/performance/how_to_tune_workloads.md
@@ -31,7 +31,7 @@ When running in in-memory mode, DuckDB cannot use disk to offload data if it doe
 To enable offloading in the absence of a persistent database file, use the [`SET temp_directory` statement](../../sql/pragmas#temp-directory-for-spilling-data-to-disk):
 
 ```sql
-SET temp_directory = '/path/to/temp.tmp'
+SET temp_directory = '/path/to/temp/dir/'
 ```
 
 ### Operators

--- a/docs/sql/pragmas.md
+++ b/docs/sql/pragmas.md
@@ -360,7 +360,7 @@ PRAGMA disable_print_progress_bar;
 By default, DuckDB uses the `.tmp` directory to spill to disk. To change this, use:
 
 ```sql
-SET temp_directory = '/path/to/temp.tmp'
+SET temp_directory = '/path/to/temp/dir/'
 ```
 
 ### Storage Information


### PR DESCRIPTION
Should the wording of "By default, DuckDB uses the `.tmp` directory to spill to disk" also be updated?

The other documentation leads me to believe that this is outdated info:

1. The default on the [configuration page](https://duckdb.org/docs/sql/configuration) is null 
2. The [tuning workloads](https://duckdb.org/docs/guides/performance/how_to_tune_workloads.html#prerequisites) page implies it's set automatically IFF the database is persistent (to where?, a new file in the same location as the DB file i would guess?)
3. The [pragma](https://duckdb.org/docs/sql/pragmas#temp-directory-for-spilling-data-to-disk) documentation implies it's always set to /tmp


