### PR TITLE
Document that config options functionality exists in JDBC

### DIFF
--- a/docs/api/c/config.md
+++ b/docs/api/c/config.md
@@ -4,7 +4,7 @@ title: C API - Configuration
 ---
 
 Configuration options can be provided to change different settings of the database system. Note that many of these
-settings can be changed later on using [PRAGMA statements](../../sql/pragmas) as well. The configuration object
+settings can be changed later on using [`PRAGMA` statements](../../sql/pragmas) as well. The configuration object
 should be created, filled with values and passed to `duckdb_open_ext`.
 
 ## Example

--- a/docs/api/java.md
+++ b/docs/api/java.md
@@ -59,9 +59,10 @@ Connection conn2 = ((DuckDBConnection) conn).duplicate();
 
 Multiple connections are allowed, but mixing read-write and read-only connections is unsupported.
 
-### Configuring Connections 
+### Configuring Connections
+
 Configuration options can be provided to change different settings of the database system. Note that many of these
-settings can be changed later on using [PRAGMA statements](../sql/pragmas) as well.
+settings can be changed later on using [`PRAGMA` statements](../sql/pragmas) as well.
 
 ```java
 Properties connectionProperties = new Properties();

--- a/docs/api/java.md
+++ b/docs/api/java.md
@@ -59,6 +59,16 @@ Connection conn2 = ((DuckDBConnection) conn).duplicate();
 
 Multiple connections are allowed, but mixing read-write and read-only connections is unsupported.
 
+### Configuring Connections 
+Configuration options can be provided to change different settings of the database system. Note that many of these
+settings can be changed later on using [PRAGMA statements](../sql/pragmas) as well.
+
+```java
+Properties connectionProperties = new Properties();
+connectionProperties.setProperty("temp_directory", "/path/to/temp/dir/");
+Connection conn = DriverManager.getConnection("jdbc:duckdb:/tmp/my_database", connectionProperties);
+```
+
 ### Querying
 
 DuckDB supports the standard JDBC methods to send queries and retrieve result sets. First a `Statement` object has to be created from the `Connection`, this object can then be used to send queries using `execute` and `executeQuery`. `execute()` is meant for queries where no results are expected like `CREATE TABLE` or `UPDATE` etc. and `executeQuery()` is meant to be used for queries that produce results (e.g., `SELECT`). Below two examples. See also the JDBC [`Statement`](https://docs.oracle.com/javase/7/docs/api/java/sql/Statement.html) and [`ResultSet`](https://docs.oracle.com/javase/7/docs/api/java/sql/ResultSet.html) documentations.


### PR DESCRIPTION
The functionality exists in the [JNI code](https://github.com/duckdb/duckdb/blob/main/tools/jdbc/src/jni/duckdb_java.cpp#L407) but is not documented.

Wording copied from the [C documentation](https://duckdb.org/docs/api/c/config)