### PR TITLE
Streamline railroad diagrams

### DIFF
--- a/docs/sql/statements/export.md
+++ b/docs/sql/statements/export.md
@@ -25,9 +25,7 @@ PRAGMA import_database('db_name');
 
 For details regarding the writing of Parquet files, see the [Parquet Files page in the Data Import section](../../data/parquet/overview#writing-to-parquet-files), and the [`COPY` Statement page](copy).
 
-## Syntax
-
-<div id="rrdiagram"></div>
+## `EXPORT DATABASE`
 
 The `EXPORT DATABASE` command exports the full contents of the database - including schema information, tables, views and sequences - to a specific directory that can then be loaded again. The created directory will be structured as follows:
 
@@ -43,4 +41,14 @@ The `schema.sql` file contains the schema statements that are found in the datab
 
 The `load.sql` file contains a set of `COPY` statements that can be used to read the data from the CSV files again. The file contains a single `COPY` statement for every table found in the schema.
 
+### Syntax
+
+<div id="rrdiagram1"></div>
+
+## `IMPORT DATABASE`
+
 The database can be reloaded by using the `IMPORT DATABASE` command again, or manually by running `schema.sql` followed by `load.sql` to re-load the data.
+
+### Syntax
+
+<div id="rrdiagram2"></div>

--- a/js/railroad.js
+++ b/js/railroad.js
@@ -1400,18 +1400,15 @@ function GenerateTemporary(options) {
 }
 
 function GenerateIfNotExists(options) {
-	return Optional(Sequence([
-		Keyword("IF"),
-		Keyword("NOT"),
-		Keyword("EXISTS")
-	]), "skip");
+	return Optional(Keyword("IF NOT EXISTS"), "skip");
+}
+
+function GenerateIfExists(options) {
+	return Optional(Keyword("IF EXISTS"), "skip");
 }
 
 function GenerateOrReplace(options) {
-	return Optional(Sequence([
-		Keyword("OR"),
-		Keyword("REPLACE")
-	]), "skip");
+	return Optional(Keyword("OR REPLACE"), "skip");
 }
 
 function GenerateOptionalColumnList(options) {
@@ -1435,11 +1432,10 @@ function GenerateOrderTerms(options) {
 				Skip(),
 				Sequence([
 					Keyword("NULLS"),
-					Keyword("FIRST")
-				]),
-				Sequence([
-					Keyword("NULLS"),
-					Keyword("LAST")
+					Choice(0, [
+						Keyword("FIRST"),
+						Keyword("LAST"),
+					]),
 				])
 			])
 		]), ","),
@@ -1454,11 +1450,10 @@ function GenerateOrderTerms(options) {
 				Skip(),
 				Sequence([
 					Keyword("NULLS"),
-					Keyword("FIRST")
-				]),
-				Sequence([
-					Keyword("NULLS"),
-					Keyword("LAST")
+					Choice(0, [
+						Keyword("FIRST"),
+						Keyword("LAST"),
+					]),
 				])
 			])
 		]),
@@ -1477,16 +1472,14 @@ function GenerateFrameSpec(options) {
 				Keyword("BETWEEN"),
 				Choice(0, [
 					Sequence([
-						Keyword("UNBOUNDED"),
-						Keyword("PRECEDING")
+						Keyword("UNBOUNDED PRECEDING")
 					]),
 					Sequence([
 						Expression(),
 						Keyword("PRECEDING")
 					]),
 					Sequence([
-						Keyword("CURRENT"),
-						Keyword("ROW")
+						Keyword("CURRENT ROW")
 					]),
 					Sequence([
 						Expression(),
@@ -1500,30 +1493,26 @@ function GenerateFrameSpec(options) {
 						Keyword("PRECEDING")
 					]),
 					Sequence([
-						Keyword("CURRENT"),
-						Keyword("ROW")
+						Keyword("CURRENT ROW")
 					]),
 					Sequence([
 						Expression(),
 						Keyword("FOLLOWING")
 					]),
 					Sequence([
-						Keyword("UNBOUNDED"),
-						Keyword("FOLLOWING")
+						Keyword("UNBOUNDED FOLLOWING")
 					])
 				]),
 			]),
 			Sequence([
-				Keyword("UNBOUNDED"),
-				Keyword("PRECEDING")
+				Keyword("UNBOUNDED PRECEDING")
 			]),
 			Sequence([
 				Expression(),
 				Keyword("PRECEDING")
 			]),
 			Sequence([
-				Keyword("CURRENT"),
-				Keyword("ROW")
+				Keyword("CURRENT ROW")
 			])
 		])
 	]
@@ -1534,13 +1523,11 @@ function GenerateWindowSpec(options) {
 		Optional(Expression("base-window-name"), "skip"),
 		Stack([
 			Optional(Sequence([
-				Keyword("PARTITION"),
-				Keyword("BY"),
+				Keyword("PARTITION BY"),
 				OneOrMore(Expression(), ",")
 			])),
 			Optional(Sequence([
-				Keyword("ORDER"),
-				Keyword("BY"),
+				Keyword("ORDER BY"),
 				GenerateOrderTerms()
 			])),
 			Expandable("frame-spec", options, "frame-spec", GenerateFrameSpec),
@@ -1552,8 +1539,7 @@ function GenerateWindowSpec(options) {
 function GenerateColumnConstraints(options) {
 	return [ZeroOrMore(Choice(0, [
 		Sequence([
-			Keyword("PRIMARY"),
-			Keyword("KEY")
+			Keyword("PRIMARY KEY")
 		]),
 		Sequence([
 			Optional(Keyword("NOT")),
@@ -1699,10 +1685,7 @@ function GenerateSample(options) {
 
 function GenerateSampleClause(options) {
 	return [
-		Sequence([
-			Keyword("USING"),
-			Keyword("SAMPLE")
-		].concat(GenerateSample(options)))
+		Sequence([Keyword("USING SAMPLE")].concat(GenerateSample(options)))
 	]
 }
 
@@ -1885,8 +1868,7 @@ function GenerateCommonTableExpression(options) {
 
 function GenerateOrderBy(options) {
 	return [
-		Keyword("ORDER"),
-		Keyword("BY"),
+		Keyword("ORDER BY"),
 		GenerateOrderTerms()
 	]
 }
@@ -1965,15 +1947,13 @@ function GenerateFromClause(options) {
 function GenerateGroupByClause(options) {
 	return [
 		Optional(Sequence([
-			Keyword("GROUP"),
-			Keyword("BY"),
+			Keyword("GROUP BY"),
 			Choice(0,[
 				OneOrMore(
 					Choice(0, [
 					Expression(),
 					Sequence([
-						Keyword("GROUPING"),
-						Keyword("SETS"),
+						Keyword("GROUPING SETS"),
 						Keyword("("),
 						OneOrMore(Sequence([
 							Keyword("("),
@@ -2015,7 +1995,7 @@ function GenerateLimitAndOrderBy(options) {
 		Sequence(GenerateOrderBy(options)),
 		Optional(Sequence([
 			Keyword("LIMIT"),
-			Expression()
+			Expression(),
 		])),
 		Optional(Sequence([
 			Keyword("OFFSET"),

--- a/js/statements/alter.js
+++ b/js/statements/alter.js
@@ -4,8 +4,7 @@ function GenerateAlterColumnOptions(options) {
 		Choice(0, [
 			Sequence([
 				Optional(Sequence([
-					Keyword("SET"),
-					Keyword("DATA")
+					Keyword("SET DATA")
 				])),
 				Keyword("TYPE"),
 				Expression("data-type"),
@@ -23,13 +22,11 @@ function GenerateAlterColumnOptions(options) {
 				)
 			]),
 			Sequence([
-				Keyword("SET"),
-				Keyword("DEFAULT"),
+				Keyword("SET DEFAULT"),
 				Expression()
 			]),
 			Sequence([
-				Keyword("DROP"),
-				Keyword("DEFAULT")
+				Keyword("DROP DEFAULT")
 			])
 		])
 	]
@@ -38,18 +35,13 @@ function GenerateAlterColumnOptions(options) {
 function GenerateAlterTable(options = {}) {
 	return Diagram([
 		AutomaticStack([
-			Keyword("ALTER"),
-			Keyword("TABLE"),
+			Keyword("ALTER TABLE"),
 			Expression("table-name"),
 			Choice(0, [
 				Sequence([
 					Keyword("ADD"),
 					Optional("COLUMN"),
-					Optional(Sequence([
-						Keyword("IF"),
-						Keyword("NOT"),
-						Keyword("EXISTS")
-					]), "skip"),
+					GenerateIfNotExists(),
 					Expression("column-name"),
 					Expression("type-name"),
 					Expandable("column-constraints", options, "column-constraints", GenerateColumnConstraints)
@@ -57,10 +49,7 @@ function GenerateAlterTable(options = {}) {
 				Sequence([
 					Keyword("DROP"),
 					Optional("COLUMN"),
-					Optional(Sequence([
-						Keyword("IF"),
-						Keyword("EXISTS")
-					]), "skip"),
+					GenerateIfExists(),
 					Expression("column-name")
 				]),
 				Sequence([
@@ -77,8 +66,7 @@ function GenerateAlterTable(options = {}) {
 					Expression("new-column")
 				]),
 				Sequence([
-					Keyword("RENAME"),
-					Keyword("TO"),
+					Keyword("RENAME TO"),
 					Expression("new-name")
 				])
 			])

--- a/js/statements/attach.js
+++ b/js/statements/attach.js
@@ -17,7 +17,7 @@ function GenerateAttach(options = {}) {
 		AutomaticStack([
 			Keyword("ATTACH"),
 			Optional(Keyword("DATABASE"), "skip"),
-			Optional(Sequence([Keyword("IF"), Keyword("NOT"), Keyword("EXISTS")]), "skip"),
+			Optional(Sequence([Keyword("IF NOT EXISTS")]), "skip"),
 			Expression("database-path"),
 			Optional(Sequence([
 				Keyword("AS"),
@@ -34,7 +34,7 @@ function GenerateDetach(options = {}) {
 			Keyword("DETACH"),
 			Optional(Sequence([
 				Keyword("DATABASE"),
-				Optional(Sequence([Keyword("IF"), Keyword("EXISTS")]), "skip"),
+				Optional(Sequence([Keyword("IF EXISTS")]), "skip"),
 			]), "skip"),
 			Expression("database")
 		])

--- a/js/statements/comment.js
+++ b/js/statements/comment.js
@@ -2,10 +2,7 @@
 function GenerateCommentOn(options = {}) {
 	return Diagram([
 		AutomaticStack([
-			Sequence([
-				Keyword("COMMENT"),
-				Keyword("ON"),
-			]),
+			Keyword("COMMENT ON"),
 			Choice(0, [
 				Keyword("TABLE"),
 				Keyword("COLUMN"),

--- a/js/statements/createschema.js
+++ b/js/statements/createschema.js
@@ -2,8 +2,7 @@ function GenerateCreateSchema(options = {}) {
 	return Diagram([
 		AutomaticStack([
 			Sequence([
-				Keyword("CREATE"),
-				Keyword("SCHEMA"),
+				Keyword("CREATE SCHEMA"),
 				Expression("schema-name")
 			]),
 			GenerateIfNotExists()

--- a/js/statements/createsequence.js
+++ b/js/statements/createsequence.js
@@ -16,12 +16,12 @@ function GenerateCreateSequence(options = {}) {
 			]), "skip"),
 			Choice(0, [
 				new Skip(),
-				Sequence([Keyword("NO"), Keyword("MINVALUE")]),
+				Keyword("NO MINVALUE"),
 				Sequence([Keyword("MINVALUE"), Expression("minvalue")])
 			]),
 			Choice(0, [
 				new Skip(),
-				Sequence([Keyword("NO"), Keyword("MAXVALUE")]),
+				Keyword("NO MAXVALUE"),
 				Sequence([Keyword("MAXVALUE"), Expression("maxvalue")])
 			]),
 			Optional(Sequence([

--- a/js/statements/createtable.js
+++ b/js/statements/createtable.js
@@ -3,10 +3,7 @@ function GenerateTableConstraints(options) {
 	return [ZeroOrMore(Choice(0, [
 		Sequence([
 			Choice(0, [
-				Sequence([
-					Keyword("PRIMARY"),
-					Keyword("KEY")
-				]),
+				Keyword("PRIMARY KEY"),
 				Keyword("UNIQUE")
 			]),
 			Keyword("("),
@@ -20,8 +17,7 @@ function GenerateTableConstraints(options) {
 			Keyword(")")
 		]),
 		Sequence([
-			Keyword("FOREIGN"),
-			Keyword("KEY"),
+			Keyword("FOREIGN KEY"),
 			Keyword("("),
 			OneOrMore(Expression("column-name"), ","),
 			Keyword(")"),
@@ -59,10 +55,7 @@ function GenerateOptionalType(options) {
 
 function GenerateGeneratedColumnSyntax(options) {
 	return Sequence([
-		Optional(Sequence([
-			Keyword("GENERATED"),
-			Keyword("ALWAYS"),
-		]), "skip"),
+		Optional(Keyword("GENERATED ALWAYS"), "skip"),
 		Keyword("AS")
 	]);
 }

--- a/js/statements/createtype.js
+++ b/js/statements/createtype.js
@@ -4,8 +4,7 @@ function GenerateCreateType(options = {}) {
 	return Diagram([
 		AutomaticStack([
 			Sequence([
-				Keyword("CREATE"),
-				Keyword("TYPE"),
+				Keyword("CREATE TYPE"),
 				Expression("type-name"),
 				Keyword("AS"),
 			]),

--- a/js/statements/delete.js
+++ b/js/statements/delete.js
@@ -1,8 +1,7 @@
 function GenerateDelete(options = {}) {
 	return Diagram([
 		AutomaticStack([
-			Keyword("DELETE"),
-			Keyword("FROM"),
+			Keyword("DELETE FROM"),
 			GenerateQualifiedTableName(),
 			Optional(Sequence([
 				Keyword("USING"),

--- a/js/statements/drop.js
+++ b/js/statements/drop.js
@@ -17,10 +17,7 @@ function GenerateDrop(options = {}) {
 				Keyword("VIEW"),
 				Keyword("TYPE"),
 			]),
-			Optional(Sequence([
-				Keyword("IF"),
-				Keyword("EXISTS")
-			]), "skip"),
+			GenerateIfExists(),
 			GenerateQualifiedTableName(options, "entry-name"),
 			Choice(0, [
 				new Skip(),

--- a/js/statements/export.js
+++ b/js/statements/export.js
@@ -2,17 +2,27 @@
 function GenerateExport(options = {}) {
 	return Diagram([
 		AutomaticStack([
-			Keyword("EXPORT"),
-			Keyword("DATABASE"),
+			Keyword("EXPORT DATABASE"),
 			Expression("directory-name"),
 			Expandable("copy-to-options", options, "copy-from-options", GenerateCopyToOptions)
 		])
 	])
 }
 
+function GenerateImport(options = {}) {
+	return Diagram([
+		AutomaticStack([
+			Keyword("IMPORT DATABASE"),
+			Expression("directory-name"),
+		])
+	])
+}
+
 function Initialize(options = {}) {
-	document.getElementById("rrdiagram").classList.add("limit-width");
-	document.getElementById("rrdiagram").innerHTML = GenerateExport(options).toString()
+	document.getElementById("rrdiagram1").classList.add("limit-width");
+	document.getElementById("rrdiagram1").innerHTML = GenerateExport(options).toString()
+	document.getElementById("rrdiagram2").classList.add("limit-width");
+	document.getElementById("rrdiagram2").innerHTML = GenerateImport(options).toString()
 }
 
 function Refresh(node_name, set_node) {

--- a/js/statements/indexes.js
+++ b/js/statements/indexes.js
@@ -28,9 +28,8 @@ function GenerateCreateIndex(options = {}) {
 function GenerateDropIndex(options = {}) {
 	return Diagram([
 		Sequence([
-			Keyword("DROP"),
-			Keyword("INDEX"),
-			Optional(Sequence([Keyword("IF"), Keyword("EXISTS")]), "skip"),
+			Keyword("DROP INDEX"),
+			Optional(Sequence([Keyword("IF EXISTS")]), "skip"),
 			Expression("name")
 		]),
 	])

--- a/js/statements/insert.js
+++ b/js/statements/insert.js
@@ -26,10 +26,7 @@ function GenerateInsert(options = {}) {
 			Choice(0, [
 				Sequence(GenerateValues(options)),
 				Expression("select-node"),
-				Sequence([
-					Keyword("DEFAULT"),
-					Keyword("VALUES")
-				])
+				Keyword("DEFAULT VALUES"),
 			]),
 			Optional(
 				Expandable("on-conflict-clause", options, "on-confict-clause", GenerateOnConflict),

--- a/js/statements/secrets.js
+++ b/js/statements/secrets.js
@@ -29,11 +29,11 @@ function GenerateDropSecret(options = {}) {
 				Keyword("DROP"),
 				Optional(Choice(0, [Keyword("PERSISTENT"), Keyword("TEMPORARY")]), "skip"),
 				Keyword("SECRET"),
-				Optional(Sequence([Keyword("IF"), Keyword("EXISTS")]), "skip")
+				GenerateIfExists(),
 			]),
 			Sequence([
 				Expression("secret_name"),
-				Optional(Sequence([Keyword("FROM"), Expression("storage_specifier")]), "skip")
+				Optional(Sequence([Keyword("FROM"), Expression("storage_specifier")]), "skip"),
 			]),
 		])
 	])

--- a/js/statements/unpivot.js
+++ b/js/statements/unpivot.js
@@ -83,8 +83,7 @@ function GenerateUnpivot(options) {
 				]),
 			Optional(
 				Sequence([
-					Keyword("INTO"),
-					Keyword("NAME"),
+					Keyword("INTO NAME"),
 					Expression("name-column-name"),
 					Keyword("VALUE"),
 					OneOrMore(


### PR DESCRIPTION
Merge subsequent keywords to one term (e.g. `IF` `NOT` `EXISTS` => `IF NOT EXISTS`), remove redundant entities, add syntax for `IMPORT DATABASE` statement.