### PR TITLE
DuckDB 0.10.0 release uses ADBC version 0.7 

### DIFF
--- a/docs/api/adbc.md
+++ b/docs/api/adbc.md
@@ -7,7 +7,7 @@ title: ADBC API
 
 DuckDB's ADBC driver currently supports version 0.7 of ADBC.
 
-Please refer to the [ADBC documentation page](https://arrow.apache.org/adbc/0.5.1/cpp/index.html) for a more extensive discussion on ADBC and a detailed API explanation.
+Please refer to the [ADBC documentation page](https://arrow.apache.org/adbc/0.7.0/cpp/index.html) for a more extensive discussion on ADBC and a detailed API explanation.
 
 ## Implemented Functionality
 

--- a/docs/api/adbc.md
+++ b/docs/api/adbc.md
@@ -5,7 +5,7 @@ title: ADBC API
 
 [Arrow Database Connectivity (ADBC)](https://arrow.apache.org/adbc/), similarly to ODBC and JDBC, is a C-style API that enables code portability between different database systems. This allows developers to effortlessly build applications that communicate with database systems without using code specific to that system. The main difference between ADBC and ODBC/JDBC is that ADBC uses [Arrow](https://arrow.apache.org/) to transfer data between the database system and the application. DuckDB has an ADBC driver, which takes advantage of the [zero-copy integration between DuckDB and Arrow](/2021/12/03/duck-arrow) to efficiently transfer data.
 
-DuckDB's ADBC driver currently supports version 0.5.1 of ADBC.
+DuckDB's ADBC driver currently supports version 0.7 of ADBC.
 
 Please refer to the [ADBC documentation page](https://arrow.apache.org/adbc/0.5.1/cpp/index.html) for a more extensive discussion on ADBC and a detailed API explanation.
 


### PR DESCRIPTION
According to the [release notes for DuckDB 0.10.0](https://github.com/duckdb/duckdb/releases/tag/v0.10.0), the ADBC driver has been updated to version 0.7. The ADBC documentation `docs/api/adbc.md` hasn't been updated to reflect this ADBC version bump, and still references ADBC 0.5.1.

This PR includes:
1. Statement that DuckDB 0.10.0 now uses ADBC version 0.7.0
1. Updated link to ADBC version 0.7.0 documentation
