### PR TITLE
Update patternmatching.md

### DIFF
--- a/docs/sql/functions/patternmatching.md
+++ b/docs/sql/functions/patternmatching.md
@@ -191,7 +191,7 @@ regexp_matches('abcd', 'ABC', 'c')-- false
 regexp_matches('abcd', 'ABC', 'i') -- true
 regexp_matches('ab^/$cd', '^/$', 'l') -- true
 regexp_matches('hello\nworld', 'hello.world', 'p') -- false
-regexp_matches('hello\nworld', 'hello.world', 's') -- true
+regexp_matches('hello\nworld', 'hello.world', 's') -- false
 ```
 
 ### Using `regexp_matches`
@@ -202,10 +202,10 @@ The `regexp_matches` operator will be optimized to the `LIKE` operator when poss
 
 | Original | Optimized equivalent |
 |:---|:---|
-|`regexp_matches('hello world', '^hello', 's')`|`prefix('hello world', 'hello')`|
-|`regexp_matches('hello world', 'world$', 's')`|`suffix('hello world', 'world')`|
-|`regexp_matches('hello world', 'hello.world', 's')`|`LIKE 'hello_world'`|
-|`regexp_matches('hello world', 'he.*rld', 's')`|`LIKE '%he%rld'`|
+|`regexp_matches('hello world', '^hello', 'c')`|`prefix('hello world', 'hello')`|
+|`regexp_matches('hello world', 'world$', 'c')`|`suffix('hello world', 'world')`|
+|`regexp_matches('hello world', 'hello.world', 'c')`|`LIKE 'hello_world'`|
+|`regexp_matches('hello world', 'he.*rld', 'c')`|`LIKE '%he%rld'`|
 
 ### Using `regexp_replace`
 


### PR DESCRIPTION
fix the wrong doc; or can someone correct this?

am still new learning from the https://duckdb.org/docs/sql/functions/patternmatching#options-for-regular-expression-functions doc , but am confused:
[this section](https://duckdb.org/docs/sql/functions/patternmatching#options-for-regular-expression-functions) just said `'c' for case-sensitive matching`, then next section says use `the 's' option (case-sensitive matching)`
```
Option	Description
'c'	case-sensitive matching
```

```
To achieve best performance, the 's' option (case-sensitive matching) should be passed if applicable...
```

then what is `'s'` option: non-newline sensitive matching for? then i tried this example from live code, it tells false:
![image](https://github.com/duckdb/duckdb-web/assets/49542456/d1981829-d68b-4722-a560-10d375a02d2f)