### PR TITLE
Fix typo in COI headers example

### DIFF
--- a/_posts/2021-10-29-duckdb-wasm.md
+++ b/_posts/2021-10-29-duckdb-wasm.md
@@ -238,7 +238,7 @@ In 2018, the Spectre and Meltdown vulnerabilities sent crippling shockwaves thro
 Without `SharedArrayBuffers`, WebAssembly modules can run in a dedicated web worker to unblock the main event loop but won't be able to spawn additional workers for parallel computations within the same instance. By default, we therefore cannot unleash the parallel query execution of DuckDB in the web. However, browser vendors have recently started to reenable `SharedArrayBuffers` for websites that are [cross-origin-isolated](https://web.dev/coop-coep/). A website is cross-origin-isolated if it ships the main document with the following HTTP headers:
 
 ```text
-Cross-Origin-Embedded-Policy: require-corp
+Cross-Origin-Embedder-Policy: require-corp
 Cross-Origin-Opener-Policy: same-origin
 ```
 


### PR DESCRIPTION
Changes are happening in DuckDB-WASM that will make the COI conversation and this blog post more visible to users. If a user tries to implement the COI headers referencing the headers in the example here it would fail to enable COI and `SharedArrayBuffer` needed for DuckDB-WASM to leverage POSIX threads in the browser. The typo is subtle for a user that is new to these concepts, and they might fail to find the issue even when referring to the web.dev documentation linked.

I'm not sure what the process is for updating a block post that has been published for a while now, but it seems prudent to update this for the users who find and try to use this as a reference in the future.

Besides the web.dev article, I also verified the change after reviewing https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy.