### PR TITLE
CSS: Use the same color for property names and keywords

### DIFF
--- a/css/syntax_highlighting.scss
+++ b/css/syntax_highlighting.scss
@@ -11,8 +11,8 @@
 	font-family: $fontMonoItalic;
 }
 
-// keywords
-.highlight :is(.k, .kc, .kd, .kn, .kr, .kt, .kv){
+// keywords and properties
+.highlight :is(.k, .kc, .kd, .kn, .kr, .kt, .kv, .py){
 	color: #0098dd;
 	font-family: $fontMonoBold;
 }
@@ -42,12 +42,6 @@
 // class names
 .highlight :is(.nc, .nv){
 	color: #d52753;
-}
-
-// property names
-.highlight :is(.py){
-	color: #a05a48;
-	font-family: $fontMonoBold;
 }
 
 // punctuation


### PR DESCRIPTION
Should we add an extra color, brown, for properties? I've been going back-and-forth on this formatting detail for a week but ultimately I think it does not make the code more readable or look better.

It's also difficult to differentiate reliable between properties and keywords, e.g. currently the secrets manager's `REGION S3` property is two keywords but the Parquet writer's `COMPRESSION ZSTD` is a property-keyword pair. Let's just color everything as a keyword.

# Before this PR

![Screenshot 2024-03-02 at 14 57 24](https://github.com/duckdb/duckdb-web/assets/1402801/44fbe44a-1311-46c2-859d-e4c8282186c9)

# After this PR

![Screenshot 2024-03-02 at 14 58 20](https://github.com/duckdb/duckdb-web/assets/1402801/7884642b-13e7-4462-969b-dc6677ddcf3d)
