### PR TITLE
Add CORS tips in s3api

### DIFF
--- a/docs/api/wasm/data_ingestion.md
+++ b/docs/api/wasm/data_ingestion.md
@@ -150,6 +150,27 @@ await c.query(`
 `);
 ```
 
+> Tip If you encounter a Network Error `("Failed to execute 'send' on 'XMLHttpRequest')"` when you try to query files from S3, configure the S3 permission CORS header. For example:
+```
+[
+    {
+        "AllowedHeaders": [
+            "*"
+        ],
+        "AllowedMethods": [
+            "GET",
+            "HEAD"
+        ],
+        "AllowedOrigins": [
+            "*"
+        ],
+        "ExposeHeaders": [],
+        "MaxAgeSeconds": 3000
+    }
+]
+```
+
+
 ### Insert Statement
 
 ```ts

--- a/docs/extensions/httpfs/s3api.md
+++ b/docs/extensions/httpfs/s3api.md
@@ -170,6 +170,26 @@ FROM read_parquet([
 ]);
 ```
 
+> Tip If you encounter a Network Error `("Failed to execute 'send' on 'XMLHttpRequest')`, configure the S3 permission CORS header. For example:
+```
+[
+    {
+        "AllowedHeaders": [
+            "*"
+        ],
+        "AllowedMethods": [
+            "GET",
+            "HEAD"
+        ],
+        "AllowedOrigins": [
+            "*"
+        ],
+        "ExposeHeaders": [],
+        "MaxAgeSeconds": 3000
+    }
+]
+```
+
 ### Glob
 
 File globbing is implemented using the ListObjectV2 API call and allows to use filesystem-like glob patterns to match multiple files, for example:

--- a/docs/extensions/httpfs/s3api.md
+++ b/docs/extensions/httpfs/s3api.md
@@ -170,26 +170,6 @@ FROM read_parquet([
 ]);
 ```
 
-> Tip If you encounter a Network Error `("Failed to execute 'send' on 'XMLHttpRequest')`, configure the S3 permission CORS header. For example:
-```
-[
-    {
-        "AllowedHeaders": [
-            "*"
-        ],
-        "AllowedMethods": [
-            "GET",
-            "HEAD"
-        ],
-        "AllowedOrigins": [
-            "*"
-        ],
-        "ExposeHeaders": [],
-        "MaxAgeSeconds": 3000
-    }
-]
-```
-
 ### Glob
 
 File globbing is implemented using the ListObjectV2 API call and allows to use filesystem-like glob patterns to match multiple files, for example:


### PR DESCRIPTION
Sometimes, even after correctly setting up all the credentials for an S3 bucket, a browser may not send requests to the S3 bucket. This issue often arises if you haven't set the correct CORS (Cross-Origin Resource Sharing) headers.


Open the [DuckDB WASM Shell](https://shell.duckdb.org/)

### With CORS Header Setting in the Bucket
```sql
FROM 'https://ducket-with-cors-header.s3.ap-northeast-1.amazonaws.com/d1.parquet';
```
### Without CORS Header Setting in the Bucket
```sql
FROM 'https://ducket-without-cors-header.s3.ap-northeast-1.amazonaws.com/d1.parquet';
```

You can download the parquet file directly from both URLs. However, only the bucket with the proper CORS header settings can be queried in the DuckDB WASM.


**We should add tips for setting the CORS header in an S3 bucket.**

<img width="952" alt="截圖 2024-03-07 凌晨12 24 12" src="https://github.com/duckdb/duckdb-web/assets/103009868/de759386-8d26-49a4-a8d9-668073740181">


