### PR TITLE
Correct inferred database name in `ATTACH` query

### DIFF
--- a/docs/sql/statements/attach.md
+++ b/docs/sql/statements/attach.md
@@ -17,7 +17,7 @@ ATTACH 'file.db' AS file_db;
 ATTACH 'file.db' (READ_ONLY);
 -- attach a SQLite database for reading and writing (see the sqlite extension for more information)
 ATTACH 'sqlite_file.db' AS sqlite_db (TYPE SQLITE);
--- attach the database "file.db" if inferred database alias "file_db" does not yet exist
+-- attach the database "file.db" if inferred database alias "file" does not yet exist
 ATTACH IF NOT EXISTS 'file.db';
 -- attach the database "file.db" if explicit database alias "file_db" does not yet exist
 ATTACH IF NOT EXISTS 'file.db' AS file_db;


### PR DESCRIPTION
Small fix in the `ATTACH` docs: The inferred database name for 'file.db' is "file", not "file_db".