### PR TITLE
Revert "Set current Java version to v0.10.0"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,9 +22,9 @@ url: "https://duckdb.org" # the base hostname & protocol for your site, e.g. htt
 # Set current Version of DuckDB
 currentshortduckdbversion: "0.10"
 currentduckdbversion: 0.10.1
+currentjavaversion: 0.10.1
 currentsnapshotversion: 0.10.2-dev
-currentjavaversion: 0.10.0
-nextjavaversion: 0.10.1  # for java snapshots
+nextjavaversion: 0.10.2  # for java snapshots
 livereload: true
 highlighter: rouge
 incremental: false


### PR DESCRIPTION
Reverts duckdb/duckdb-web#2538 – merge once the JARs deployed successfully to https://mvnrepository.com/artifact/org.duckdb/duckdb_jdbc