### PR TITLE
Reformat function tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,4 @@ To build the site with Jekyll (installed locally or run via Docker), check out o
 ## Contributing
 
 Please consult the [contributor's guide](CONTRIBUTING.md) for instructions on how to contribute to the documentation.
+

--- a/docs/guides/import/read_file.md
+++ b/docs/guides/import/read_file.md
@@ -32,12 +32,12 @@ SELECT size, content, filename
 FROM read_blob('test/sql/table_function/files/*');
 ```
 
-| size |                                             content                                              |                filename                 |
-|-----:|--------------------------------------------------------------------------------------------------|-----------------------------------------|
-| 178  |  PK\x03\x04\x0A\x00\x00\x00\x00\x00\xACi=X\x14t\xCE\xC7\x0A\x00\x00\x00\x0A\x00\x00\x00\x09\x00… | test/sql/table_function/files/four.blob |
-| 12   | Hello World!                                                                                     | test/sql/table_function/files/one.txt   |
-| 2    | 42                                                                                               | test/sql/table_function/files/three.txt |
-| 10   | F\xC3\xB6\xC3\xB6 B\xC3\xA4r                                                                     | test/sql/table_function/files/two.txt   |
+| size |                              content                         |                filename                 |
+|-----:|--------------------------------------------------------------|-----------------------------------------|
+| 178  |  PK\x03\x04\x0A\x00\x00\x00\x00\x00\xACi=X\x14t\xCE\xC7\x0A… | test/sql/table_function/files/four.blob |
+| 12   | Hello World!                                                 | test/sql/table_function/files/one.txt   |
+| 2    | 42                                                           | test/sql/table_function/files/three.txt |
+| 10   | F\xC3\xB6\xC3\xB6 B\xC3\xA4r                                 | test/sql/table_function/files/two.txt   |
 
 ## Schema
 

--- a/docs/sql/functions/bitstring.md
+++ b/docs/sql/functions/bitstring.md
@@ -16,12 +16,12 @@ The table below shows the available mathematical operators for `BIT` type.
 
 | Operator | Description | Example | Result |
 |:---|:---|:---|:---|
-| `&` | bitwise AND | `'10101'::BIT & '10001'::BIT` | `10001` |
-| `|` | bitwise OR | `'1011'::BIT | '0001'::BIT` | `1011` |
-| `xor` | bitwise XOR | `xor('101'::BIT, '001'::BIT)` | `100` |
-| `~` | bitwise NOT | `~('101'::BIT)` | `010` |
-| `<<` | bitwise shift left | `'1001011'::BIT << 3` | `1011000` |
-| `>>` | bitwise shift right | `'1001011'::BIT >> 3` | `0001001` |
+| `&` | Bitwise AND | `'10101'::BIT & '10001'::BIT` | `10001` |
+| `|` | Bitwise OR | `'1011'::BIT | '0001'::BIT` | `1011` |
+| `xor` | Bitwise XOR | `xor('101'::BIT, '001'::BIT)` | `100` |
+| `~` | Bitwise NOT | `~('101'::BIT)` | `010` |
+| `<<` | Bitwise shift left | `'1001011'::BIT << 3` | `1011000` |
+| `>>` | Bitwise shift right | `'1001011'::BIT >> 3` | `0001001` |
 
 <!-- markdownlint-enable MD056 -->
 
@@ -29,32 +29,126 @@ The table below shows the available mathematical operators for `BIT` type.
 
 The table below shows the available scalar functions for `BIT` type.
 
-| Function | Description | Example | Result |
-|:--|:----|:----|:-|
-| `bit_count(`*`bitstring`*`)` | Returns the number of set bits in the bitstring. | `bit_count('1101011'::BIT)` | `5` |
-| `bit_length(`*`bitstring`*`)` | Returns the number of bits in the bitstring. | `bit_length('1101011'::BIT)` | `7` |
-| `bit_position(`*`substring`*`, `*`bitstring`*`)` | Returns first starting index of the specified substring within bits, or zero if it's not present. The first (leftmost) bit is indexed 1 | `bit_position('010'::BIT, '1110101'::BIT)` | `4` |
-| `bitstring(`*`bitstring`*`, `*`length`*`)` | Returns a bitstring of determined length. | `bitstring('1010'::BIT, 7)` | `0001010` |
-| `get_bit(`*`bitstring`*`, `*`index`*`)` | Extracts the nth bit from bitstring; the first (leftmost) bit is indexed 0. | `get_bit('0110010'::BIT, 2)` | `1` |
-| `length(`*`bitstring`*`)` | Alias for `bit_length`. | `length('1101011'::BIT)` | `7` |
-| `octet_length(`*`bitstring`*`)` | Returns the number of bytes in the bitstring. | `octet_length('1101011'::BIT)` | `1` |
-| `set_bit(`*`bitstring`*`, `*`index`*`, `*`new_value`*`)` | Sets the nth bit in bitstring to newvalue; the first (leftmost) bit is indexed 0. Returns a new bitstring. | `set_bit('0110010'::BIT, 2, 0)` | `0100010` |
+| Name | Description |
+|:--|:-------|
+| [`bit_count(`*`bitstring`*`)`](#bit_countbitstring) | Returns the number of set bits in the bitstring. |
+| [`bit_length(`*`bitstring`*`)`](#bit_lengthbitstring) | Returns the number of bits in the bitstring. |
+| [`bit_position(`*`substring`*`, `*`bitstring`*`)`](#bit_positionsubstring-bitstring) | Returns first starting index of the specified substring within bits, or zero if it's not present. The first (leftmost) bit is indexed 1. |
+| [`bitstring(`*`bitstring`*`, `*`length`*`)`](#bitstringbitstring-length) | Returns a bitstring of determined length. |
+| [`get_bit(`*`bitstring`*`, `*`index`*`)`](#get_bitbitstring-index) | Extracts the nth bit from bitstring; the first (leftmost) bit is indexed 0. |
+| [`length(`*`bitstring`*`)`](#lengthbitstring) | Alias for `bit_length`. |
+| [`octet_length(`*`bitstring`*`)`](#octet_lengthbitstring) | Returns the number of bytes in the bitstring. |
+| [`set_bit(`*`bitstring`*`, `*`index`*`, `*`new_value`*`)`](#set_bitbitstring-index-new_value) | Sets the nth bit in bitstring to newvalue; the first (leftmost) bit is indexed 0. Returns a new bitstring. |
+
+### `bit_count(`*`bitstring`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns the number of set bits in the bitstring. |
+| **Example** | `bit_count('1101011'::BIT)` |
+| **Result** | `5` |
+
+### `bit_length(`*`bitstring`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns the number of bits in the bitstring. |
+| **Example** | `bit_length('1101011'::BIT)` |
+| **Result** | `7` |
+
+### `bit_position(`*`substring`*`, `*`bitstring`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns first starting index of the specified substring within bits, or zero if it's not present. The first (leftmost) bit is indexed 1 |
+| **Example** | `bit_position('010'::BIT, '1110101'::BIT)` |
+| **Result** | `4` |
+
+### `bitstring(`*`bitstring`*`, `*`length`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns a bitstring of determined length. |
+| **Example** | `bitstring('1010'::BIT, 7)` |
+| **Result** | `0001010` |
+
+### `get_bit(`*`bitstring`*`, `*`index`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Extracts the nth bit from bitstring; the first (leftmost) bit is indexed 0. |
+| **Example** | `get_bit('0110010'::BIT, 2)` |
+| **Result** | `1` |
+
+### `length(`*`bitstring`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Alias for `bit_length`. |
+| **Example** | `length('1101011'::BIT)` |
+| **Result** | `7` |
+
+### `octet_length(`*`bitstring`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns the number of bytes in the bitstring. |
+| **Example** | `octet_length('1101011'::BIT)` |
+| **Result** | `1` |
+
+### `set_bit(`*`bitstring`*`, `*`index`*`, `*`new_value`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Sets the nth bit in bitstring to newvalue; the first (leftmost) bit is indexed 0. Returns a new bitstring. |
+| **Example** | `set_bit('0110010'::BIT, 2, 0)` |
+| **Result** | `0100010` |
 
 ## Bitstring Aggregate Functions
 
 These aggregate functions are available for `BIT` type.
 
-| Function | Description | Example |
-|:---|:----|:--|
-| `bit_and(arg)` |Returns the bitwise AND operation performed on all bitstrings in a given expression. | `bit_and(A)` |
-| `bit_or(arg)` |Returns the bitwise OR operation performed on all bitstrings in a given expression.  | `bit_or(A)` |
-| `bit_xor(arg)` |Returns the bitwise XOR operation performed on all bitstrings in a given expression. | `bit_xor(A)` |
-| `bitstring_agg(arg, min, max)` |Returns a bitstring with bits set for each distinct position defined in `arg`. All positions must be within the range [`min`, `max`] or an "Out of Range Error" will be thrown. | `bitstring_agg(A, 1, 42)` |
-| `bitstring_agg(arg)` |Returns a bitstring with bits set for each distinct position defined in `arg`. | `bitstring_agg(A)` |
+| Name | Description |
+|:--|:-------|
+| [`bit_and(arg)`](#bit_andarg) | Returns the bitwise AND operation performed on all bitstrings in a given expression. |
+| [`bit_or(arg)`](#bit_orarg) | Returns the bitwise OR operation performed on all bitstrings in a given expression. |
+| [`bit_xor(arg)`](#bit_xorarg) | Returns the bitwise XOR operation performed on all bitstrings in a given expression. |
+| [`bitstring_agg(arg)`](#bitstring_aggarg) | Returns a bitstring with bits set for each distinct position defined in `arg`. |
+| [`bitstring_agg(arg, min, max)`](#bitstring_aggarg-min-max) | Returns a bitstring with bits set for each distinct position defined in `arg`. All positions must be within the range [`min`, `max`] or an "Out of Range Error" will be thrown. |
 
-### Bitstring Aggregation
+### `bit_and(arg)`
 
-The `bitstring_agg` function takes any integer type as input and returns a bitstring with bits set for each distinct value.
-The left-most bit represents the smallest value in the column and the right-most bit the maximum value. If possible, the min and max are retrieved from the column statistics. Otherwise, it is also possible to provide the min and max values.
+<div class="nostroke_table"></div>
 
-The combination of `bit_count` and `bitstring_agg` could be used as an alternative to `count(DISTINCT ...)`, with possible performance improvements in cases of low cardinality and dense values.
+| **Description** | Returns the bitwise AND operation performed on all bitstrings in a given expression. |
+| **Example** | `bit_and(A)` |
+
+### `bit_or(arg)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns the bitwise OR operation performed on all bitstrings in a given expression. |
+| **Example** | `bit_or(A)` |
+
+### `bit_xor(arg)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns the bitwise XOR operation performed on all bitstrings in a given expression. |
+| **Example** | `bit_xor(A)` |
+
+### `bitstring_agg(arg)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The `bitstring_agg` function takes any integer type as input and returns a bitstring with bits set for each distinct value. The left-most bit represents the smallest value in the column and the right-most bit the maximum value. If possible, the min and max are retrieved from the column statistics. Otherwise, it is also possible to provide the min and max values. |
+| **Example** | `bitstring_agg(A)` |
+
+> Tip The combination of `bit_count` and `bitstring_agg` could be used as an alternative to `count(DISTINCT ...)`, with possible performance improvements in cases of low cardinality and dense values.
+
+### `bitstring_agg(arg, min, max)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns a bitstring with bits set for each distinct position defined in `arg`. All positions must be within the range [`min`, `max`] or an "Out of Range Error" will be thrown. |
+| **Example** | `bitstring_agg(A, 1, 42)` |

--- a/docs/sql/functions/blob.md
+++ b/docs/sql/functions/blob.md
@@ -7,12 +7,52 @@ This section describes functions and operators for examining and manipulating bl
 
 <!-- markdownlint-disable MD056 -->
 
-| Function | Description | Example | Result |
-|:-|:--|:---|:-|
-| *`blob`* `||` *`blob`* | Blob concatenation | `'\xAA'::BLOB || '\xBB'::BLOB` | `\xAA\xBB` |
-| `decode(`*`blob`*`)` | Convert blob to varchar. Fails if blob is not valid UTF-8. | `decode('\xC3\xBC'::BLOB)` | `ü` |
-| `encode(`*`string`*`)` | Convert varchar to blob. Converts UTF-8 characters into literal encoding. | `encode('my_string_with_ü')` | `my_string_with_\xC3\xBC` |
-| `octet_length(`*`blob`*`)` | Number of bytes in blob | `octet_length('\xAA\xBB'::BLOB)` | `2` |
-| `read_blob(`*`source`*`)` | Returns the content from *`source`* (a filename, a list of filenames, or a glob pattern) as a `BLOB`. See the [`read_blob` guide](../../guides/import/read_file#read_blob) for more details. | `read_blob('hello.bin')` | `hello\x0A` |
+| Name | Description |
+|:--|:-------|
+| [*`blob`* `||` *`blob`*](#blob--blob) | Blob concatenation. |
+| [`decode(`*`blob`*`)`](#decodeblob) | Converts `BLOB` to `VARCHAR`. Fails if blob is not valid UTF-8. |
+| [`encode(`*`string`*`)`](#encodestring) | Converts `VARCHAR` to `BLOB`. Converts UTF-8 characters into literal encoding. |
+| [`octet_length(`*`blob`*`)`](#octet_lengthblob) | Number of bytes in `BLOB`. |
+| [`read_blob(`*`source`*`)`](#read_blobsource) | Returns the content from *`source`* (a filename, a list of filenames, or a glob pattern) as a `BLOB`. See the [`read_blob` guide](../../guides/import/read_file#read_blob) for more details. |
 
 <!-- markdownlint-enable MD056 -->
+
+### *`blob`* `||` *`blob`*
+
+<div class="nostroke_table"></div>
+
+| **Description** | `BLOB` concatenation. |
+| **Example** | `'\xAA'::BLOB || '\xBB'::BLOB` |
+| **Result** | `\xAA\xBB` |
+
+### `decode(`*`blob`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Convert `BLOB` to `VARCHAR`. Fails if blob is not valid UTF-8. |
+| **Example** | `decode('\xC3\xBC'::BLOB)` |
+| **Result** | `ü` |
+
+### `encode(`*`string`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Convert `VARCHAR` to `BLOB`. Converts UTF-8 characters into literal encoding. |
+| **Example** | `encode('my_string_with_ü')` |
+| **Result** | `my_string_with_\xC3\xBC` |
+
+### `octet_length(`*`blob`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Number of bytes in `VARCHAR`. |
+| **Example** | `octet_length('\xAA\xBB'::BLOB)` |
+| **Result** | `2` |
+
+### `read_blob(`*`source`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns the content from *`source`* (a filename, a list of filenames, or a glob pattern) as a `BLOB`. See the [`read_blob` guide](../../guides/import/read_file#read_blob) for more details. |
+| **Example** | `read_blob('hello.bin')` |
+| **Result** | `hello\x0A` |

--- a/docs/sql/functions/char.md
+++ b/docs/sql/functions/char.md
@@ -7,103 +7,804 @@ This section describes functions and operators for examining and manipulating st
 
 <!-- markdownlint-disable MD056 -->
 
-| Function | Description | Example | Result | Alias |
-|:--|:--|:---|:--|:--|
-| *`string`* `^@` *`search_string`* | Return true if *string* begins with *search_string*. | `'abc' ^@ 'a'` | `true` | `starts_with` |
-| *`string`* `||` *`string`* | String concatenation | `'Duck' || 'DB'` | `DuckDB` | |
-| *`string`*`[`*`index`*`]` | Extract a single character using a (1-based) index. | `'DuckDB'[4]` | `k` | `array_extract` |
-| *`string`*`[`*`begin`*`:`*`end`*`]` | Extract a string using slice conventions. Missing `begin` or `end` arguments are interpreted as the beginning or end of the list respectively. Negative values are accepted. | `'DuckDB'[:4]` | `Duck` | `array_slice` |
-| *`string`* `LIKE` *`target`* | Returns true if the *string* matches the like specifier (see [Pattern Matching](../../sql/functions/patternmatching)) | `'hello' LIKE '%lo'` | `true` | |
-| *`string`* `SIMILAR TO` *`regex`* | Returns `true` if the *string* matches the *regex*; identical to `regexp_full_match` (see [Pattern Matching](../../sql/functions/patternmatching)) | `'hello' SIMILAR TO 'l+'` | `false` | |
-| `array_extract(`*`list`*`, `*`index`*`)` | Extract a single character using a (1-based) index. | `array_extract('DuckDB', 2)` | `u` | `list_element`, `list_extract` | |
-| `array_slice(`*`list`*`, `*`begin`*`, `*`end`*`)` | Extract a string using slice conventions. Negative values are accepted. | `array_slice('DuckDB', 5, NULL)` | `DB` | |
-| `ascii(`*`string`*`)`| Returns an integer that represents the Unicode code point of the first character of the *string* | `ascii('Ω')` | `937` | |
-| `bar(`*`x`*`, `*`min`*`, `*`max`*`[, `*`width`*`])` | Draw a band whose width is proportional to (*x* - *min*) and equal to *width* characters when *x* = *max*. *width* defaults to 80. | `bar(5, 0, 20, 10)` | `██▌` | |
-| `bit_length(`*`string`*`)`| Number of bits in a string. | `bit_length('abc')` | `24` | |
-| `chr(`*`x`*`)` | Returns a character which is corresponding the ASCII code value or Unicode code point | `chr(65)` | A | |
-| `concat_ws(`*`separator`*`, `*`string`*`,...)` | Concatenate strings together separated by the specified separator | `concat_ws(', ', 'Banana', 'Apple', 'Melon')` | `Banana, Apple, Melon` | |
-| `concat(`*`string`*`,...)` | Concatenate many strings together | `concat('Hello', ' ', 'World')` | `Hello World` | |
-| `contains(`*`string`*`, `*`search_string`*`)` | Return true if *search_string* is found within *string* | `contains('abc', 'a')` | `true` | |
-| `ends_with(`*`string`*`, `*`search_string`*`)`| Return true if *string* ends with *search_string* | `ends_with('abc', 'c')` | `true` | `suffix` |
-| `format_bytes(`*`bytes`*`)` | Converts bytes to a human-readable representation using units based on powers of 2 (KiB, MiB, GiB, etc.). | `format_bytes(16384)` | `16.0 KiB` | |
-| `format(`*`format`*`, `*`parameters`*`...)` | Formats a string using the [fmt syntax](#fmt-syntax) | `format('Benchmark "{}" took {} seconds', 'CSV', 42)` | `Benchmark "CSV" took 42 seconds` | |
-| `from_base64(`*`string`*`)`| Convert a base64 encoded string to a character string. | `from_base64('QQ==')` | `'A'` | |
-| `greatest(`*`x1`*`, `*`x2`*`, `*` ...)` | Selects the largest value using lexicographical ordering. Note that lowercase characters are considered "larger" than uppercase characters and [collations](../expressions/collations) are not supported. | `greatest('abc', 'bcd', 'cde', 'EFG')` | `'cde'` | |
-| `hash(`*`value`*`)` | Returns a `UBIGINT` with the hash of the *value* | `hash('🦆')` | `259...` | |
-| `ilike_escape(`*`string`*`, `*`like_specifier`*`, `*`escape_character`*`)` | Returns true if the *string* matches the *like_specifier* (see [Pattern Matching](../../sql/functions/patternmatching)) using case-insensitive matching. *escape_character* is used to search for wildcard characters in the *string*. | `ilike_escape('A%c', 'a$%C', '$')` | `true` | |
-| `instr(`*`string`*`, `*`search_string`*`)`| Return location of first occurrence of `search_string` in `string`, counting from 1. Returns 0 if no match found. | `instr('test test', 'es')` | 2 | |
-| `least(`*`x1`*`, `*`x2`*`, `*` ...)` | Selects the smallest value using lexicographical ordering. Note that uppercase characters are considered "smaller" than uppercase characters, and [collations](../expressions/collations) are not supported. | `least('abc', 'BCD', 'cde', 'EFG')` | `'BCD'` | |
-| `left_grapheme(`*`string`*`, `*`count`*`)`| Extract the left-most grapheme clusters | `left_grapheme('🤦🏼‍♂️🤦🏽‍♀️', 1)` | `🤦🏼‍♂️` | |
-| `left(`*`string`*`, `*`count`*`)`| Extract the left-most count characters | `left('Hello🦆', 2)` | `He` | |
-| `length_grapheme(` *`string`*`)` | Number of grapheme clusters in *string* | `length_grapheme('🤦🏼‍♂️🤦🏽‍♀️')` | `2` | |
-| `length(`*`string`*`)` | Number of characters in *string* | `length('Hello🦆')` | `6` | |
-| `like_escape(`*`string`*`, ` *`like_specifier`*`, `*`escape_character`*`)` | Returns true if the *string* matches the *like_specifier* (see [Pattern Matching](../../sql/functions/patternmatching)) using case-sensitive matching. *escape_character* is used to search for wildcard characters in the *string*. | `like_escape('a%c', 'a$%c', '$')` | `true` | |
-| `lower(`*`string`*`)` | Convert *string* to lower case | `lower('Hello')` | `hello` | `lcase` |
-| `lpad(`*`string`*`, `*`count`*`, `*`character`*`)`| Pads the *string*  with the character from the left until it has count characters | `lpad('hello', 8, '>')` | `>>>hello` | |
-| `ltrim(`*`string`*`, `*`characters`*`)`| Removes any occurrences of any of the *characters* from the left side of the *string* | `ltrim('>>>>test<<', '><')` | `test<<` | |
-| `ltrim(`*`string`*`)`| Removes any spaces from the left side of the *string* | `ltrim('␣␣␣␣test␣␣')` | `test␣␣` | |
-| `md5(`*`value`*`)` | Returns the [MD5 hash](https://en.wikipedia.org/wiki/MD5) of the *value*  | `md5('123')` | `202c...` | |
-| `nfc_normalize(`*`string`*`)`| Convert string to Unicode NFC normalized string. Useful for comparisons and ordering if text data is mixed between NFC normalized and not. | `nfc_normalize('ardèch')` | `ardèch` | |
-| `not_ilike_escape(` *`string`*`, ` *`like_specifier`*`, `*`escape_character`*`)` | Returns false if the *string* matches the *like_specifier* (see [Pattern Matching](../../sql/functions/patternmatching)) using case-sensitive matching. *escape_character* is used to search for wildcard characters in the *string*. | `not_ilike_escape('A%c', 'a$%C', '$')` | `false` | |
-| `not_like_escape(` *`string`*`, ` *`like_specifier`*`, `*`escape_character`*`)` | Returns false if the *string* matches the *like_specifier* (see [Pattern Matching](../../sql/functions/patternmatching)) using case-insensitive matching. *escape_character* is used to search for wildcard characters in the *string*. | `not_like_escape('a%c', 'a$%c', '$')` | `false` | |
-| `ord(`*`string`*`)`| Return ASCII character code of the leftmost character in a string.  | `ord('ü')` | `252` | |
-| `parse_dirname(`*`path`*`, `*`separator`*`)`| Returns the top-level directory name from the given path. *`separator`* options: `system`, `both_slash` (default), `forward_slash`, `backslash`.  | `parse_dirname( 'path/to/file.csv', 'system')` | `path` | |
-| `parse_dirpath(`*`path`*`, `*`separator`*`)`| Returns the head of the path (the pathname until the last slash) similarly to Python's [`os.path.dirname`](https://docs.python.org/3.7/library/os.path.html#os.path.dirname) function. *`separator`* options: `system`, `both_slash` (default), `forward_slash`, `backslash`.  | `parse_dirpath( '/path/to/file.csv', 'forward_slash')` | `/path/to` | |
-| `parse_filename(`*`path`*`, `*`trim_extension`*`, `*`separator`*`)`| Returns the last component of the path similarly to Python's [`os.path.basename`](https://docs.python.org/3.7/library/os.path.html#os.path.basename) function. If *`trim_extension`* is true, the file extension will be removed (defaults to `false`). *`separator`* options: `system`, `both_slash` (default), `forward_slash`, `backslash`.  | `parse_filename( 'path/to/file.csv', true, 'system')` | `file` | |
-| `parse_path(`*`path`*`, `*`separator`*`)`| Returns a list of the components (directories and filename) in the path similarly to Python's [`pathlib.parts`](https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.parts) function. *`separator`* options: `system`, `both_slash` (default), `forward_slash`, `backslash`.  | `parse_path( '/path/to/file.csv', 'system')` | `[/, path, to, file.csv]` | |
-| `position(` *`search_string`*` in `*`string`*`)` | Return location of first occurrence of `search_string` in `string`, counting from 1. Returns 0 if no match found. | `position('b' in 'abc')` | `2` | |
-| `printf(`*`format`*`, `*`parameters`*`...)` | Formats a *string* using [printf syntax](#printf-syntax) | `printf('Benchmark "%s" took %d seconds', 'CSV', 42)` | `Benchmark "CSV" took 42 seconds` | |
-| `read_text(`*`source`*`)` | Returns the content from *`source`* (a filename, a list of filenames, or a glob pattern) as a `VARCHAR`. The file content is first validated to be valid UTF-8. If `read_text` attempts to read a file with invalid UTF-8 an error is thrown suggesting to use `read_blob` instead. See the [`read_text` guide](../../guides/import/read_file#read_text) for more details. | `read_text('hello.txt')` | `hello\n` | |
-| `regexp_escape(`*`string`*`)` | Escapes special patterns to turn *string* into a regular expression similarly to Python's [`re.escape` function](https://docs.python.org/3/library/re.html#re.escape) | `regexp_escape( 'http://d.org')` | `http\:\/\/d\.org` | |
-| `regexp_extract_all(` *`string`*`, `*`regex`*`[, `*`group`*` = 0])` | Split the *string* along the *regex* and extract all occurrences of *group* | `regexp_extract_all( 'hello_world', '([a-z ]+)_?', 1)` | `[hello, world]` | |
-| `regexp_extract(` *`string`*`, `*`pattern `*`, `*`name_list`*`)`; | If *string* contains the regexp *pattern*, returns the capturing groups as a struct with corresponding names from *name_list* (see [Pattern Matching](patternmatching#using-regexp_extract)) | `regexp_extract( '2023-04-15', '(\d+)-(\d+)-(\d+)', ['y', 'm', 'd'])` | `{'y':'2023', 'm':'04', 'd':'15'}` | |
-| `regexp_extract(` *`string`*`, `*`pattern `*`[, `*`idx`*`])`; | If *string* contains the regexp *pattern*, returns the capturing group specified by optional parameter *idx* (see [Pattern Matching](patternmatching#using-regexp_extract))| `regexp_extract( 'hello_world', '([a-z ]+)_?', 1)` | `hello` | |
-| `regexp_full_match(` *`string`*`, `*`regex`*`)`| Returns `true` if the entire *string* matches the *regex* (see [Pattern Matching](patternmatching)) | `regexp_full_match( 'anabanana', '(an)*')` | `false` | |
-| `regexp_matches(`*`string`*`, `*`pattern`*`)` | Returns `true` if  *string* contains the regexp *pattern*, `false` otherwise (see [Pattern Matching](patternmatching#using-regexp_matches))| `regexp_matches( 'anabanana', '(an)*')` | `true` | |
-| `regexp_replace(`*`string`*`, `*`pattern`*`, `*`replacement`*`)` | If *string* contains the regexp *pattern*, replaces the matching part with *replacement* (see [Pattern Matching](patternmatching#using-regexp_replace))| `regexp_replace( 'hello', '[lo]', '-')` | `he-lo` | |
-| `regexp_split_to_array(` *`string`*`, `*`regex`*`)` | Splits the *string* along the *regex* | `regexp_split_to_array( 'hello␣world; 42', ';?␣')` | `['hello', 'world', '42']` | `string_split_regex`, `str_split_regex`| |
-| `regexp_split_to_table(` *`string`*`, `*`regex`*`)` | Splits the *string* along the *regex* and returns a row for each part | `regexp_split_to_array( 'hello␣world; 42', ';?␣')` | Two rows: `'hello'`, `'world'` | |
-| `repeat(`*`string`*`, `*`count`*`)`| Repeats the *string* *count* number of times | `repeat('A', 5)` | `AAAAA` | |
-| `replace(`*`string`*`, `*`source`*`, `*`target`*`)`| Replaces any occurrences of the *source* with *target* in *string* | `replace('hello', 'l', '-')` | `he--o` | |
-| `reverse(`*`string`*`)`| Reverses the *string* | `reverse('hello')` | `olleh` | |
-| `right_grapheme(`*`string`*`, `*`count`*`)`| Extract the right-most *count* grapheme clusters | `right_grapheme('🤦🏼‍♂️🤦🏽‍♀️', 1)` | `🤦🏽‍♀️` | |
-| `right(`*`string`*`, `*`count`*`)`| Extract the right-most *count* characters | `right('Hello🦆', 3)` | `lo🦆` | |
-| `rpad(`*`string`*`, `*`count`*`, `*`character`*`)`| Pads the *string* with the character from the right until it has *count* characters | `rpad('hello', 10, '<')` | `hello<<<<<` | |
-| `rtrim(`*`string`*`, `*`characters`*`)`| Removes any occurrences of any of the *characters* from the right side of the *string* | `rtrim('>>>>test<<', '><')` | `>>>>test` | |
-| `rtrim(`*`string`*`)`| Removes any spaces from the right side of the *string* | `rtrim('␣␣␣␣test␣␣')` | `␣␣␣␣test` | |
-| `sha256(`*`value`*`)` | Returns a `VARCHAR` with the SHA-256 hash of the *`value`*| `sha-256('🦆')` | `d7a5...` | |
-| `split_part(` *`string`*`, `*`separator`*`, `*`index`*`)` | Split the *string* along the *separator* and return the data at the (1-based) *index* of the list. If the *index* is outside the bounds of the list, return an empty string (to match PostgreSQL's behavior). | `split_part('a|b|c', '|', 2)` | `b` | |
-| `starts_with(` *`string`*`, `*`search_string`*`)`| Return true if *string* begins with *search_string* | `starts_with('abc', 'a')` | `true` | |
-| `str_split_regex(` *`string`*`, `*`regex`*`)` | Splits the *string* along the *regex* | `str_split_regex( 'hello␣world; 42', ';?␣')` | `['hello', 'world', '42']` | `string_split_regex`, `regexp_split_to_array` |
-| `string_split_regex(` *`string`*`, `*`regex`*`)` | Splits the *string* along the *regex* | `string_split_regex( 'hello␣world; 42', ';?␣')` | `['hello', 'world', '42']` | `str_split_regex`, `regexp_split_to_array` |
-| `string_split(` *`string`*`, `*`separator`*`)` | Splits the *string* along the *separator* | `string_split( 'hello␣world', '␣')` | `['hello', 'world']` | `str_split`, `string_to_array` |
-| `strip_accents(` *`string`*`)`| Strips accents from *string* | `strip_accents( 'mühleisen')` | `muhleisen` | |
-| `strlen(`*`string`*`)` | Number of bytes in *string* | `strlen('🦆')` | `4` | |
-| `strpos(`*`string`*`, `*`search_string`*`)`| Return location of first occurrence of *search_string* in *string*, counting from 1. Returns 0 if no match found. | `strpos('test test', 'es')` | 2 | `instr` |
-| `substring(`*`string`*`, `*`start`*`, `*`length`*`)` | Extract substring of *length* characters starting from character *start*. Note that a *start* value of `1` refers to the *first* character of the string. | `substring('Hello', 2, 2)` | `el` | `substr` |
-| `substring_grapheme(` *`string`*`, `*`start`*`, `*`length`*`)` | Extract substring of *length* grapheme clusters starting from character *start*. Note that a *start* value of `1` refers to the *first* character of the string. | `substring_grapheme('🦆🤦🏼‍♂️🤦🏽‍♀️🦆', 3, 2)` | `🤦🏽‍♀️🦆` | |
-| `to_base64(`*`blob`*`)`| Convert a blob to a base64 encoded string. | `to_base64('A'::blob)` | `QQ==` | `base64` |
-| `trim(`*`string`*`, `*`characters`*`)`| Removes any occurrences of any of the *characters* from either side of the *string* | `trim('>>>>test<<', '><')` | `test` | |
-| `trim(`*`string`*`)`| Removes any spaces from either side of the *string* | `trim('␣␣␣␣test␣␣')` | `test` | |
-| `unicode(`*`string`*`)`| Returns the unicode code of the first character of the *string* | `unicode('ü')` | `252` | |
-| `upper(`*`string`*`)`| Convert *string* to upper case | `upper('Hello')` | `HELLO` | `ucase` |
+| Name | Description |
+|:--|:-------|
+| [*`string`* `^@` *`search_string`*](#string--search_string) | Return true if *string* begins with *search_string*. |
+| [*`string`* `||` *`string`*](#string--string) | String concatenation |
+| [*`string`*`[`*`index`*`]`](#stringindex) | Extract a single character using a (1-based) index. |
+| [*`string`*`[`*`begin`*`:`*`end`*`]`](#stringbeginend) | Extract a string using slice conventions. Missing `begin` or `end` arguments are interpreted as the beginning or end of the list respectively. Negative values are accepted. |
+| [*`string`* `LIKE` *`target`*](#string-like-target) | Returns true if the *string* matches the like specifier (see [Pattern Matching](../../sql/functions/patternmatching)). |
+| [*`string`* `SIMILAR TO` *`regex`*](#string-similar-to-regex) | Returns `true` if the *string* matches the *regex*; identical to `regexp_full_match` (see [Pattern Matching](../../sql/functions/patternmatching)). |
+| [`array_extract(`*`list`*`, `*`index`*`)`](#array_extractlist-index) | Extract a single character using a (1-based) index. |
+| [`array_slice(`*`list`*`, `*`begin`*`, `*`end`*`)`](#array_slicelist-begin-end) | Extract a string using slice conventions. Negative values are accepted. |
+| [`ascii(`*`string`*`)`](#asciistring) | Returns an integer that represents the Unicode code point of the first character of the *string*. |
+| [`bar(`*`x`*`, `*`min`*`, `*`max`*`[, `*`width`*`])`](#barx-min-max-width) | Draw a band whose width is proportional to (*x* - *min*) and equal to *width* characters when *x* = *max*. *width* defaults to 80. |
+| [`bit_length(`*`string`*`)`](#bit_lengthstring) | Number of bits in a string. |
+| [`chr(`*`x`*`)`](#chrx) | Returns a character which is corresponding the ASCII code value or Unicode code point. |
+| [`concat_ws(`*`separator`*`, `*`string`*`,...)`](#concat_wsseparator-string-) | Concatenate strings together separated by the specified separator. |
+| [`concat(`*`string`*`,...)`](#concatstring-) | Concatenate many strings together. |
+| [`contains(`*`string`*`, `*`search_string`*`)`](#containsstring-search_string) | Return true if *search_string* is found within *string*. |
+| [`ends_with(`*`string`*`, `*`search_string`*`)`](#ends_withstring-search_string) | Return true if *string* ends with *search_string*. |
+| [`format_bytes(`*`bytes`*`)`](#format_bytesbytes) | Converts bytes to a human-readable representation using units based on powers of 2 (KiB, MiB, GiB, etc.). |
+| [`format(`*`format`*`, `*`parameters`*`, `*`...`*`)`](#formatformat-parameters) | Formats a string using the [fmt syntax](#fmt-syntax). |
+| [`from_base64(`*`string`*`)`](#from_base64string) | Convert a base64 encoded string to a character string. |
+| [`greatest(`*`x1`*`, `*`x2`*`, `*`...`*`)`](#greatestx1-x2) | Selects the largest value using lexicographical ordering. Note that lowercase characters are considered "larger" than uppercase characters and [collations](../expressions/collations) are not supported. |
+| [`hash(`*`value`*`)`](#hashvalue) | Returns a `UBIGINT` with the hash of the *value*. |
+| [`ilike_escape(`*`string`*`, `*`like_specifier`*`, `*`escape_character`*`)`](#ilike_escapestring-like_specifier-escape_character) | Returns true if the *string* matches the *like_specifier* (see [Pattern Matching](../../sql/functions/patternmatching)) using case-insensitive matching. *escape_character* is used to search for wildcard characters in the *string*. |
+| [`instr(`*`string`*`, `*`search_string`*`)`](#instrstring-search_string) | Return location of first occurrence of `search_string` in `string`, counting from 1. Returns 0 if no match found. |
+| [`least(`*`x1`*`, `*`x2`*`, `*`...`*`)`](#leastx1-x2-) | Selects the smallest value using lexicographical ordering. Note that uppercase characters are considered "smaller" than uppercase characters, and [collations](../expressions/collations) are not supported. |
+| [`left_grapheme(`*`string`*`, `*`count`*`)`](#left_graphemestring-count) | Extract the left-most grapheme clusters. |
+| [`left(`*`string`*`, `*`count`*`)`](#leftstring-count) | Extract the left-most count characters. |
+| [`length_grapheme(`*`string`*`)`](#length_graphemestring) | Number of grapheme clusters in *string*. |
+| [`length(`*`string`*`)`](#lengthstring) | Number of characters in *string*. |
+| [`like_escape(`*`string`*`, ` *`like_specifier`*`, `*`escape_character`*`)`](#like_escapestring-like_specifier-escape_character) | Returns true if the *string* matches the *like_specifier* (see [Pattern Matching](../../sql/functions/patternmatching)) using case-sensitive matching. *escape_character* is used to search for wildcard characters in the *string*. |
+| [`lower(`*`string`*`)`](#lowerstring) | Convert *string* to lower case. |
+| [`lpad(`*`string`*`, `*`count`*`, `*`character`*`)`](#lpadstring-count-character) | Pads the *string*  with the character from the left until it has count characters. |
+| [`ltrim(`*`string`*`, `*`characters`*`)`](#ltrimstring-characters) | Removes any occurrences of any of the *characters* from the left side of the *string*. |
+| [`ltrim(`*`string`*`)`](#ltrimstring) | Removes any spaces from the left side of the *string*. |
+| [`md5(`*`value`*`)`](#md5value) | Returns the [MD5 hash](https://en.wikipedia.org/wiki/MD5) of the *value*. |
+| [`nfc_normalize(`*`string`*`)`](#nfc_normalizestring) | Convert string to Unicode NFC normalized string. Useful for comparisons and ordering if text data is mixed between NFC normalized and not. |
+| [`not_ilike_escape(`*`string`*`, ` *`like_specifier`*`, `*`escape_character`*`)`](#not_ilike_escapestring-like_specifier-escape_character) | Returns false if the *string* matches the *like_specifier* (see [Pattern Matching](../../sql/functions/patternmatching)) using case-sensitive matching. *escape_character* is used to search for wildcard characters in the *string*. |
+| [`not_like_escape(`*`string`*`, ` *`like_specifier`*`, `*`escape_character`*`)`](#not_like_escapestring-like_specifier-escape_character) | Returns false if the *string* matches the *like_specifier* (see [Pattern Matching](../../sql/functions/patternmatching)) using case-insensitive matching. *escape_character* is used to search for wildcard characters in the *string*. |
+| [`ord(`*`string`*`)`](#ordstring) | Return ASCII character code of the leftmost character in a string. |
+| [`parse_dirname(`*`path`*`, `*`separator`*`)`](#parse_dirnamepath-separator) | Returns the top-level directory name from the given path. *`separator`* options: `system`, `both_slash` (default), `forward_slash`, `backslash`. |
+| [`parse_dirpath(`*`path`*`, `*`separator`*`)`](#parse_dirpathpath-separator) | Returns the head of the path (the pathname until the last slash) similarly to Python's [`os.path.dirname`](https://docs.python.org/3.7/library/os.path.html#os.path.dirname) function. *`separator`* options: `system`, `both_slash` (default), `forward_slash`, `backslash`. |
+| [`parse_filename(`*`path`*`, `*`trim_extension`*`, `*`separator`*`)`](#parse_filenamepath-trim_extension-separator) | Returns the last component of the path similarly to Python's [`os.path.basename`](https://docs.python.org/3.7/library/os.path.html#os.path.basename) function. If *`trim_extension`* is true, the file extension will be removed (defaults to `false`). *`separator`* options: `system`, `both_slash` (default), `forward_slash`, `backslash`. |
+| [`parse_path(`*`path`*`, `*`separator`*`)`](#parse_pathpath-separator) | Returns a list of the components (directories and filename) in the path similarly to Python's [`pathlib.parts`](https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.parts) function. *`separator`* options: `system`, `both_slash` (default), `forward_slash`, `backslash`. |
+| [`position(`*`search_string`*` in `*`string`*`)`](#positionsearch_stringinstring) | Return location of first occurrence of `search_string` in `string`, counting from 1. Returns 0 if no match found. |
+| [`printf(`*`format`*`, `*`parameters`*`...)`](#printfformat-parameters) | Formats a *string* using [printf syntax](#printf-syntax). |
+| [`read_text(`*`source`*`)`](#read_textsource) | Returns the content from *`source`* (a filename, a list of filenames, or a glob pattern) as a `VARCHAR`. The file content is first validated to be valid UTF-8. If `read_text` attempts to read a file with invalid UTF-8 an error is thrown suggesting to use `read_blob` instead. See the [`read_text` guide](../../guides/import/read_file#read_text) for more details. |
+| [`regexp_escape(`*`string`*`)`](#regexp_escapestring) | Escapes special patterns to turn *string* into a regular expression similarly to Python's [`re.escape` function](https://docs.python.org/3/library/re.html#re.escape). |
+| [`regexp_extract_all(`*`string`*`, `*`regex`*`[, `*`group`*` = 0])`](#regexp_extract_allstring-regex-group0) | Split the *string* along the *regex* and extract all occurrences of *group*. |
+| [`regexp_extract(`*`string`*`, `*`pattern `*`, `*`name_list`*`)`;](#regexp_extractstring-pattern-name_list) | If *string* contains the regexp *pattern*, returns the capturing groups as a struct with corresponding names from *name_list* (see [Pattern Matching](patternmatching#using-regexp_extract)). |
+| [`regexp_extract(`*`string`*`, `*`pattern `*`[, `*`idx`*`])`;](#regexp_extractstring-pattern-idx) | If *string* contains the regexp *pattern*, returns the capturing group specified by optional parameter *idx* (see [Pattern Matching](patternmatching#using-regexp_extract)). |
+| [`regexp_full_match(`*`string`*`, `*`regex`*`)`](#regexp_full_matchstring-regex) | Returns `true` if the entire *string* matches the *regex* (see [Pattern Matching](patternmatching)). |
+| [`regexp_matches(`*`string`*`, `*`pattern`*`)`](#regexp_matchesstring-pattern) | Returns `true` if  *string* contains the regexp *pattern*, `false` otherwise (see [Pattern Matching](patternmatching#using-regexp_matches)). |
+| [`regexp_replace(`*`string`*`, `*`pattern`*`, `*`replacement`*`)`](#regexp_replacestring-pattern-replacement) | If *string* contains the regexp *pattern*, replaces the matching part with *replacement* (see [Pattern Matching](patternmatching#using-regexp_replace)). |
+| [`regexp_split_to_array(`*`string`*`, `*`regex`*`)`](#regexp_split_to_arraystring-regex) | Splits the *string* along the *regex*. |
+| [`regexp_split_to_table(`*`string`*`, `*`regex`*`)`](#regexp_split_to_tablestring-regex) | Splits the *string* along the *regex* and returns a row for each part. |
+| [`repeat(`*`string`*`, `*`count`*`)`](#repeatstring-count) | Repeats the *string* *count* number of times. |
+| [`replace(`*`string`*`, `*`source`*`, `*`target`*`)`](#replacestring-source-target) | Replaces any occurrences of the *source* with *target* in *string*. |
+| [`reverse(`*`string`*`)`](#reversestring) | Reverses the *string*. |
+| [`right_grapheme(`*`string`*`, `*`count`*`)`](#right_graphemestring-count) | Extract the right-most *count* grapheme clusters. |
+| [`right(`*`string`*`, `*`count`*`)`](#rightstring-count) | Extract the right-most *count* characters. |
+| [`rpad(`*`string`*`, `*`count`*`, `*`character`*`)`](#rpadstring-count-character) | Pads the *string* with the character from the right until it has *count* characters. |
+| [`rtrim(`*`string`*`, `*`characters`*`)`](#rtrimstring-characters) | Removes any occurrences of any of the *characters* from the right side of the *string*. |
+| [`rtrim(`*`string`*`)`](#rtrimstring) | Removes any spaces from the right side of the *string*. |
+| [`sha256(`*`value`*`)`](#sha256value) | Returns a `VARCHAR` with the SHA-256 hash of the *`value`*. |
+| [`split_part(`*`string`*`, `*`separator`*`, `*`index`*`)`](#split_partstring-separator-index) | Split the *string* along the *separator* and return the data at the (1-based) *index* of the list. If the *index* is outside the bounds of the list, return an empty string (to match PostgreSQL's behavior). |
+| [`starts_with(`*`string`*`, `*`search_string`*`)`](#starts_withstring-search_string) | Return true if *string* begins with *search_string*. |
+| [`str_split_regex(`*`string`*`, `*`regex`*`)`](#str_split_regexstring-regex) | Splits the *string* along the *regex*. |
+| [`string_split_regex(`*`string`*`, `*`regex`*`)`](#string_split_regexstring-regex) | Splits the *string* along the *regex*. |
+| [`string_split(`*`string`*`, `*`separator`*`)`](#string_splitstring-separator) | Splits the *string* along the *separator*. |
+| [`strip_accents(`*`string`*`)`](#strip_accentsstring) | Strips accents from *string*. |
+| [`strlen(`*`string`*`)`](#strlenstring) | Number of bytes in *string*. |
+| [`strpos(`*`string`*`, `*`search_string`*`)`](#strposstring-search_string) | Return location of first occurrence of *search_string* in *string*, counting from 1. Returns 0 if no match found. |
+| [`substring(`*`string`*`, `*`start`*`, `*`length`*`)`](#substringstring-start-length) | Extract substring of *length* characters starting from character *start*. Note that a *start* value of `1` refers to the *first* character of the string. |
+| [`substring_grapheme(`*`string`*`, `*`start`*`, `*`length`*`)`](#substring_graphemestring-start-length) | Extract substring of *length* grapheme clusters starting from character *start*. Note that a *start* value of `1` refers to the *first* character of the string. |
+| [`to_base64(`*`blob`*`)`](#to_base64blob) | Convert a blob to a base64 encoded string. |
+| [`trim(`*`string`*`, `*`characters`*`)`](#trimstring-characters) | Removes any occurrences of any of the *characters* from either side of the *string*. |
+| [`trim(`*`string`*`)`](#trimstring) | Removes any spaces from either side of the *string*. |
+| [`unicode(`*`string`*`)`](#unicodestring) | Returns the unicode code of the first character of the *string*. |
+| [`upper(`*`string`*`)`](#upperstring) | Convert *string* to upper case. |
 
 <!-- markdownlint-enable MD056 -->
+
+### *`string`* `^@` *`search_string`*
+
+<div class="nostroke_table"></div>
+
+| **Description** | Return true if *string* begins with *search_string*. |
+| **Example** | `'abc' ^@ 'a'` |
+| **Result** | `true` |
+| **Alias** | `starts_with` |
+
+### *`string`* `||` *`string`*
+
+| **Description** | String concatenation. |
+| **Example** | `'Duck' || 'DB'` |
+| **Result** | `DuckDB` |
+| **Alias** | `concat` |
+
+### *`string`*`[`*`index`*`]`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Extract a single character using a (1-based) index. |
+| **Example** | `'DuckDB'[4]` |
+| **Result** | `k` |
+| **Alias** | `array_extract` |
+
+### *`string`*`[`*`begin`*`:`*`end`*`]`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Extract a string using slice conventions. Missing `begin` or `end` arguments are interpreted as the beginning or end of the list respectively. Negative values are accepted. |
+| **Example** | `'DuckDB'[:4]` |
+| **Result** | `Duck` |
+| **Alias** | `array_slice` |
+
+### *`string`* `LIKE` *`target`*
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns true if the *string* matches the like specifier (see [Pattern Matching](../../sql/functions/patternmatching)) |
+| **Example** | `'hello' LIKE '%lo'` |
+| **Result** | `true` |
+
+### *`string`* `SIMILAR TO` *`regex`*
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns `true` if the *string* matches the *regex*; identical to `regexp_full_match` (see [Pattern Matching](../../sql/functions/patternmatching)) |
+| **Example** | `'hello' SIMILAR TO 'l+'` |
+| **Result** | `false` |
+
+### `array_extract(`*`list`*`, `*`index`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Extract a single character using a (1-based) index. |
+| **Example** | `array_extract('DuckDB', 2)` |
+| **Result** | `u` |
+| **Aliases** | `list_element`, `list_extract` |
+
+### `array_slice(`*`list`*`, `*`begin`*`, `*`end`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Extract a string using slice conventions. Negative values are accepted. |
+| **Example** | `array_slice('DuckDB', 5, NULL)` |
+| **Result** | `DB` |
+
+### `ascii(`*`string`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns an integer that represents the Unicode code point of the first character of the *string* |
+| **Example** | `ascii('Ω')` |
+| **Result** | `937` |
+
+### `bar(`*`x`*`, `*`min`*`, `*`max`*`[, `*`width`*`])`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Draw a band whose width is proportional to (*x* - *min*) and equal to *width* characters when *x* = *max*. *width* defaults to 80. |
+| **Example** | `bar(5, 0, 20, 10)` |
+| **Result** | `██▌` |
+
+### `bit_length(`*`string`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Number of bits in a string. |
+| **Example** | `bit_length('abc')` |
+| **Result** | `24` |
+
+### `chr(`*`x`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns a character which is corresponding the ASCII code value or Unicode code point |
+| **Example** | `chr(65)` |
+| **Result** | A |
+
+### `concat_ws(`*`separator`*`, `*`string`*`, ...*`)`*
+
+<div class="nostroke_table"></div>
+
+| **Description** | Concatenate strings together separated by the specified separator |
+| **Example** | `concat_ws(', ', 'Banana', 'Apple', 'Melon')` |
+| **Result** | `Banana, Apple, Melon` |
+
+### `concat(`*`string`*`,...)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Concatenate many strings together |
+| **Example** | `concat('Hello', ' ', 'World')` |
+| **Result** | `Hello World` |
+
+### `contains(`*`string`*`, `*`search_string`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Return true if *search_string* is found within *string* |
+| **Example** | `contains('abc', 'a')` |
+| **Result** | `true` |
+
+### `ends_with(`*`string`*`, `*`search_string`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Return true if *string* ends with *search_string* |
+| **Example** | `ends_with('abc', 'c')` |
+| **Result** | `true` |
+| **Alias** | `suffix` |
+
+### `format_bytes(`*`bytes`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Converts bytes to a human-readable representation using units based on powers of 2 (KiB, MiB, GiB, etc.). |
+| **Example** | `format_bytes(16384)` |
+| **Result** | `16.0 KiB` |
+
+### `format(`*`format`*`, `*`parameters`*`, `*`...`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Formats a string using the [fmt syntax](#fmt-syntax). |
+| **Example** | `format('Benchmark "{}" took {} seconds', 'CSV', 42)` |
+| **Result** | `Benchmark "CSV" took 42 seconds` |
+
+### `from_base64(`*`string`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Convert a base64 encoded string to a character string. |
+| **Example** | `from_base64('QQ==')` |
+| **Result** | `'A'` |
+
+### `greatest(`*`x1`*`, `*`x2`*`, `*`...`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Selects the largest value using lexicographical ordering. Note that lowercase characters are considered "larger" than uppercase characters and [collations](../expressions/collations) are not supported. |
+| **Example** | `greatest('abc', 'bcd', 'cde', 'EFG')` |
+| **Result** | `'cde'` |
+
+### `hash(`*`value`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns a `UBIGINT` with the hash of the *value*. |
+| **Example** | `hash('🦆')` |
+| **Result** | `259...` |
+
+### `ilike_escape(`*`string`*`, `*`like_specifier`*`, `*`escape_character`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns true if the *string* matches the *like_specifier* (see [Pattern Matching](../../sql/functions/patternmatching)) using case-insensitive matching. *escape_character* is used to search for wildcard characters in the *string*. |
+| **Example** | `ilike_escape('A%c', 'a$%C', '$')` |
+| **Result** | `true` |
+
+### `instr(`*`string`*`, `*`search_string`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Return location of first occurrence of `search_string` in `string`, counting from 1. Returns 0 if no match found. |
+| **Example** | `instr('test test', 'es')` |
+| **Result** | 2 |
+
+### `least(`*`x1`*`, `*`x2`*`, `*` ... `*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Selects the smallest value using lexicographical ordering. Note that uppercase characters are considered "smaller" than uppercase characters, and [collations](../expressions/collations) are not supported. |
+| **Example** | `least('abc', 'BCD', 'cde', 'EFG')` |
+| **Result** | `'BCD'` |
+
+### `left_grapheme(`*`string`*`, `*`count`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Extract the left-most grapheme clusters. |
+| **Example** | `left_grapheme('🤦🏼‍♂️🤦🏽‍♀️', 1)` |
+| **Result** | `🤦🏼‍♂️` |
+
+### `left(`*`string`*`, `*`count`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Extract the left-most count characters. |
+| **Example** | `left('Hello🦆', 2)` |
+| **Result** | `He` |
+
+### `length_grapheme(`*`string`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Number of grapheme clusters in *string*. |
+| **Example** | `length_grapheme('🤦🏼‍♂️🤦🏽‍♀️')` |
+| **Result** | `2` |
+
+### `length(`*`string`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Number of characters in *string*. |
+| **Example** | `length('Hello🦆')` |
+| **Result** | `6` |
+
+### `like_escape(`*`string`*`, ` *`like_specifier`*`, `*`escape_character`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns true if the *string* matches the *like_specifier* (see [Pattern Matching](../../sql/functions/patternmatching)) using case-sensitive matching. *escape_character* is used to search for wildcard characters in the *string*. |
+| **Example** | `like_escape('a%c', 'a$%c', '$')` |
+| **Result** | `true` |
+
+### `lower(`*`string`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Convert *string* to lower case. |
+| **Example** | `lower('Hello')` |
+| **Result** | `hello` |
+| **Alias** | `lcase` |
+
+### `lpad(`*`string`*`, `*`count`*`, `*`character`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Pads the *string*  with the character from the left until it has count characters. |
+| **Example** | `lpad('hello', 8, '>')` |
+| **Result** | `>>>hello` |
+
+### `ltrim(`*`string`*`, `*`characters`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Removes any occurrences of any of the *characters* from the left side of the *string*. |
+| **Example** | `ltrim('>>>>test<<', '><')` |
+| **Result** | `test<<` |
+
+### `ltrim(`*`string`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Removes any spaces from the left side of the *string*. |
+| **Example** | `ltrim('␣␣␣␣test␣␣')` |
+| **Result** | `test␣␣` |
+
+### `md5(`*`value`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns the [MD5 hash](https://en.wikipedia.org/wiki/MD5) of the *value*. |
+| **Example** | `md5('123')` |
+| **Result** | `202cb962ac59075b964b07152d234b70` |
+
+### `nfc_normalize(`*`string`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Convert string to Unicode NFC normalized string. Useful for comparisons and ordering if text data is mixed between NFC normalized and not. |
+| **Example** | `nfc_normalize('ardèch')` |
+| **Result** | `ardèch` |
+
+### `not_ilike_escape(`*`string`*`, ` *`like_specifier`*`, `*`escape_character`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns false if the *string* matches the *like_specifier* (see [Pattern Matching](../../sql/functions/patternmatching)) using case-sensitive matching. *escape_character* is used to search for wildcard characters in the *string*. |
+| **Example** | `not_ilike_escape('A%c', 'a$%C', '$')` |
+| **Result** | `false` |
+
+### `not_like_escape(`*`string`*`, ` *`like_specifier`*`, `*`escape_character`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns false if the *string* matches the *like_specifier* (see [Pattern Matching](../../sql/functions/patternmatching)) using case-insensitive matching. *escape_character* is used to search for wildcard characters in the *string*. |
+| **Example** | `not_like_escape('a%c', 'a$%c', '$')` |
+| **Result** | `false` |
+
+### `ord(`*`string`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Return ASCII character code of the leftmost character in a string. |
+| **Example** | `ord('ü')` |
+| **Result** | `252` |
+
+### `parse_dirname(`*`path`*`, `*`separator`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns the top-level directory name from the given path. *`separator`* options: `system`, `both_slash` (default), `forward_slash`, `backslash`. |
+| **Example** | `parse_dirname( 'path/to/file.csv', 'system')` |
+| **Result** | `path` |
+
+### `parse_dirpath(`*`path`*`, `*`separator`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns the head of the path (the pathname until the last slash) similarly to Python's [`os.path.dirname`](https://docs.python.org/3.7/library/os.path.html#os.path.dirname) function. *`separator`* options: `system`, `both_slash` (default), `forward_slash`, `backslash`. |
+| **Example** | `parse_dirpath( '/path/to/file.csv', 'forward_slash')` |
+| **Result** | `/path/to` |
+
+### `parse_filename(`*`path`*`, `*`trim_extension`*`, `*`separator`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns the last component of the path similarly to Python's [`os.path.basename`](https://docs.python.org/3.7/library/os.path.html#os.path.basename) function. If *`trim_extension`* is true, the file extension will be removed (defaults to `false`). *`separator`* options: `system`, `both_slash` (default), `forward_slash`, `backslash`. |
+| **Example** | `parse_filename( 'path/to/file.csv', true, 'system')` |
+| **Result** | `file` |
+
+### `parse_path(`*`path`*`, `*`separator`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns a list of the components (directories and filename) in the path similarly to Python's [`pathlib.parts`](https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.parts) function. *`separator`* options: `system`, `both_slash` (default), `forward_slash`, `backslash`. |
+| **Example** | `parse_path( '/path/to/file.csv', 'system')` |
+| **Result** | `[/, path, to, file.csv]` |
+
+### `position(`*`search_string`*` in `*`string`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Return location of first occurrence of `search_string` in `string`, counting from 1. Returns 0 if no match found. |
+| **Example** | `position('b' in 'abc')` |
+| **Result** | `2` |
+
+### `printf(`*`format`*`, `*`parameters`*`...)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Formats a *string* using [printf syntax](#printf-syntax). |
+| **Example** | `printf('Benchmark "%s" took %d seconds', 'CSV', 42)` |
+| **Result** | `Benchmark "CSV" took 42 seconds` |
+
+### `read_text(`*`source`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns the content from *`source`* (a filename, a list of filenames, or a glob pattern) as a `VARCHAR`. The file content is first validated to be valid UTF-8. If `read_text` attempts to read a file with invalid UTF-8 an error is thrown suggesting to use `read_blob` instead. See the [`read_text` guide](../../guides/import/read_file#read_text) for more details. |
+| **Example** | `read_text('hello.txt')` |
+| **Result** | `hello\n` |
+
+### `regexp_escape(`*`string`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Escapes special patterns to turn *string* into a regular expression similarly to Python's [`re.escape` function](https://docs.python.org/3/library/re.html#re.escape). |
+| **Example** | `regexp_escape( 'http://d.org')` |
+| **Result** | `http\:\/\/d\.org` |
+
+### `regexp_extract_all(`*`string`*`, `*`regex`*`[, `*`group`*` = 0])`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Split the *string* along the *regex* and extract all occurrences of *group*. |
+| **Example** | `regexp_extract_all( 'hello_world', '([a-z ]+)_?', 1)` |
+| **Result** | `[hello, world]` |
+
+### `regexp_extract(`*`string`*`, `*`pattern `*`, `*`name_list`*`)`;
+
+<div class="nostroke_table"></div>
+
+| **Description** | If *string* contains the regexp *pattern*, returns the capturing groups as a struct with corresponding names from *name_list* (see [Pattern Matching](patternmatching#using-regexp_extract)). |
+| **Example** | `regexp_extract( '2023-04-15', '(\d+)-(\d+)-(\d+)', ['y', 'm', 'd'])` |
+| **Result** | `{'y':'2023', 'm':'04', 'd':'15'}` |
+
+### `regexp_extract(`*`string`*`, `*`pattern `*`[, `*`idx`*`])`;
+
+<div class="nostroke_table"></div>
+
+| **Description** | If *string* contains the regexp *pattern*, returns the capturing group specified by optional parameter *idx* (see [Pattern Matching](patternmatching#using-regexp_extract)). |
+| **Example** | `regexp_extract( 'hello_world', '([a-z ]+)_?', 1)` |
+| **Result** | `hello` |
+
+### `regexp_full_match(`*`string`*`, `*`regex`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns `true` if the entire *string* matches the *regex* (see [Pattern Matching](patternmatching)). |
+| **Example** | `regexp_full_match( 'anabanana', '(an)*')` |
+| **Result** | `false` |
+
+### `regexp_matches(`*`string`*`, `*`pattern`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns `true` if  *string* contains the regexp *pattern*, `false` otherwise (see [Pattern Matching](patternmatching#using-regexp_matches)). |
+| **Example** | `regexp_matches( 'anabanana', '(an)*')` |
+| **Result** | `true` |
+
+### `regexp_replace(`*`string`*`, `*`pattern`*`, `*`replacement`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | If *string* contains the regexp *pattern*, replaces the matching part with *replacement* (see [Pattern Matching](patternmatching#using-regexp_replace)). |
+| **Example** | `regexp_replace( 'hello', '[lo]', '-')` |
+| **Result** | `he-lo` |
+
+### `regexp_split_to_array(`*`string`*`, `*`regex`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Splits the *string* along the *regex*. |
+| **Example** | `regexp_split_to_array( 'hello␣world; 42', ';?␣')` |
+| **Result** | `['hello', 'world', '42']` |
+| **Aliases** | `string_split_regex`, `str_split_regex` |
+
+### `regexp_split_to_table(`*`string`*`, `*`regex`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Splits the *string* along the *regex* and returns a row for each part. |
+| **Example** | `regexp_split_to_array( 'hello␣world; 42', ';?␣')` |
+| **Result** | Two rows: `'hello'`, `'world'` |
+
+### `repeat(`*`string`*`, `*`count`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Repeats the *string* *count* number of times. |
+| **Example** | `repeat('A', 5)` |
+| **Result** | `AAAAA` |
+
+### `replace(`*`string`*`, `*`source`*`, `*`target`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Replaces any occurrences of the *source* with *target* in *string*. |
+| **Example** | `replace('hello', 'l', '-')` |
+| **Result** | `he--o` |
+
+### `reverse(`*`string`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Reverses the *string*. |
+| **Example** | `reverse('hello')` |
+| **Result** | `olleh` |
+
+### `right_grapheme(`*`string`*`, `*`count`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Extract the right-most *count* grapheme clusters. |
+| **Example** | `right_grapheme('🤦🏼‍♂️🤦🏽‍♀️', 1)` |
+| **Result** | `🤦🏽‍♀️` |
+
+### `right(`*`string`*`, `*`count`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Extract the right-most *count* characters. |
+| **Example** | `right('Hello🦆', 3)` |
+| **Result** | `lo🦆` |
+
+### `rpad(`*`string`*`, `*`count`*`, `*`character`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Pads the *string* with the character from the right until it has *count* characters. |
+| **Example** | `rpad('hello', 10, '<')` |
+| **Result** | `hello<<<<<` |
+
+### `rtrim(`*`string`*`, `*`characters`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Removes any occurrences of any of the *characters* from the right side of the *string*. |
+| **Example** | `rtrim('>>>>test<<', '><')` |
+| **Result** | `>>>>test` |
+
+### `rtrim(`*`string`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Removes any spaces from the right side of the *string*. |
+| **Example** | `rtrim('␣␣␣␣test␣␣')` |
+| **Result** | `␣␣␣␣test` |
+
+### `sha256(`*`value`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns a `VARCHAR` with the SHA-256 hash of the *`value`*. |
+| **Example** | `sha256('🦆')` |
+| **Result** | `d7a5c5e0d1d94c32218539e7e47d4ba9c3c7b77d61332fb60d633dde89e473fb` |
+
+### `split_part(`*`string`*`, `*`separator`*`, `*`index`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Split the *string* along the *separator* and return the data at the (1-based) *index* of the list. If the *index* is outside the bounds of the list, return an empty string (to match PostgreSQL's behavior). |
+| **Example** | `split_part('a;b;c', ';', 2)` |
+| **Result** | `b` |
+
+### `starts_with(`*`string`*`, `*`search_string`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Return true if *string* begins with *search_string*. |
+| **Example** | `starts_with('abc', 'a')` |
+| **Result** | `true` |
+
+### `str_split_regex(`*`string`*`, `*`regex`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Splits the *string* along the *regex*. |
+| **Example** | `str_split_regex( 'hello␣world; 42', ';?␣')` |
+| **Result** | `['hello', 'world', '42']` |
+| **Aliases** | `string_split_regex`, `regexp_split_to_array` |
+
+### `string_split_regex(`*`string`*`, `*`regex`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Splits the *string* along the *regex*. |
+| **Example** | `string_split_regex( 'hello␣world; 42', ';?␣')` |
+| **Result** | `['hello', 'world', '42']` |
+| **Aliases** | `str_split_regex`, `regexp_split_to_array` |
+
+### `string_split(`*`string`*`, `*`separator`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Splits the *string* along the *separator*. |
+| **Example** | `string_split( 'hello␣world', '␣')` |
+| **Result** | `['hello', 'world']` |
+| **Aliases** | `str_split`, `string_to_array` |
+
+### `strip_accents(`*`string`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Strips accents from *string*. |
+| **Example** | `strip_accents( 'mühleisen')` |
+| **Result** | `muhleisen` |
+
+### `strlen(`*`string`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Number of bytes in *string*. |
+| **Example** | `strlen('🦆')` |
+| **Result** | `4` |
+
+### `strpos(`*`string`*`, `*`search_string`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Return location of first occurrence of *search_string* in *string*, counting from 1. Returns 0 if no match found. |
+| **Example** | `strpos('test test', 'es')` |
+| **Result** | 2 |
+| **Alias** | `instr` |
+
+### `substring(`*`string`*`, `*`start`*`, `*`length`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Extract substring of *length* characters starting from character *start*. Note that a *start* value of `1` refers to the *first* character of the string. |
+| **Example** | `substring('Hello', 2, 2)` |
+| **Result** | `el` |
+| **Alias** | `substr` |
+
+### `substring_grapheme(`*`string`*`, `*`start`*`, `*`length`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Extract substring of *length* grapheme clusters starting from character *start*. Note that a *start* value of `1` refers to the *first* character of the string. |
+| **Example** | `substring_grapheme('🦆🤦🏼‍♂️🤦🏽‍♀️🦆', 3, 2)` |
+| **Result** | `🤦🏽‍♀️🦆` |
+
+### `to_base64(`*`blob`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Convert a blob to a base64 encoded string. |
+| **Example** | `to_base64('A'::blob)` |
+| **Result** | `QQ==` |
+| **Alias** | `base64` |
+
+### `trim(`*`string`*`, `*`characters`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Removes any occurrences of any of the *characters* from either side of the *string* |
+| **Example** | `trim('>>>>test<<', '><')` |
+| **Result** | `test` |
+
+### `trim(`*`string`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Removes any spaces from either side of the *string* |
+| **Example** | `trim('␣␣␣␣test␣␣')` |
+| **Result** | `test` |
+
+### `unicode(`*`string`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns the unicode code of the first character of the *string* |
+| **Example** | `unicode('ü')` |
+| **Result** | `252` |
+
+### `upper(`*`string`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Convert *string* to upper case |
+| **Example** | `upper('Hello')` |
+| **Result** | `HELLO` |
+| **Alias** | `ucase` |
 
 ## Text Similarity Functions
 
 These functions are used to measure the similarity of two strings using various [similarity measures](https://en.wikipedia.org/wiki/Similarity_measure).
 
-| Function | Description | Example | Result |
-|:--|:--|:---|:-|
-| `damerau_levenshtein(`*`s1`*`,` *`s2`*`)` | Extension of Levenshtein distance to also include transposition of adjacent characters as an allowed edit operation. In other words, the minimum number of edit operations (insertions, deletions, substitutions or transpositions) required to change one string to another. Characters of different cases (e.g., `a` and `A`) are considered different. | `damerau_levenshtein('duckdb', 'udckbd')` | `2` |
-| `editdist3(`*`s1`*`,` *`s2`*`)` | Alias of `levenshtein` for SQLite compatibility. The minimum number of single-character edits (insertions, deletions or substitutions) required to change one string to the other. Characters of different cases (e.g., `a` and `A`) are considered different. | `editdist3('duck', 'db')` | `3` |
-| `hamming(`*`s1`*`,` *`s2`*`)` | The Hamming distance between to strings, i.e., the number of positions with different characters for two strings of equal length. Strings must be of equal length. Characters of different cases (e.g., `a` and `A`) are considered different. | `hamming('duck', 'luck')` | `1` |
-| `jaccard(`*`s1`*`,` *`s2`*`)` | The Jaccard similarity between two strings. Characters of different cases (e.g., `a` and `A`) are considered different. Returns a number between 0 and 1. | `jaccard('duck', 'luck')` | `0.6` |
-| `jaro_similarity(`*`s1`*`,` *`s2`*`)` | The Jaro similarity between two strings. Characters of different cases (e.g., `a` and `A`) are considered different. Returns a number between 0 and 1. | `jaro_similarity('duck', 'duckdb')` | `0.88` |
-| `jaro_winkler_similarity(`*`s1`*`,` *`s2`*`)` | The Jaro-Winkler similarity between two strings. Characters of different cases (e.g., `a` and `A`) are considered different. Returns a number between 0 and 1. | `jaro_winkler_similarity('duck', 'duckdb')` | `0.93` |
-| `levenshtein(`*`s1`*`,` *`s2`*`)` | The minimum number of single-character edits (insertions, deletions or substitutions) required to change one string to the other. Characters of different cases (e.g., `a` and `A`) are considered different. | `levenshtein('duck', 'db')` | `3` |
-| `mismatches(`*`s1`*`,` *`s2`*`)` | Alias for `hamming(`*`s1`*`,` *`s2`*`)`. The number of positions with different characters for two strings of equal length. Strings must be of equal length. Characters of different cases (e.g., `a` and `A`) are considered different. | `mismatches('duck', 'luck')` | `1` |
+| Name | Description |
+|:--|:-------|
+| [`damerau_levenshtein(`*`s1`*`,` *`s2`*`)`](#damerau_levenshteins1-s2) | Extension of Levenshtein distance to also include transposition of adjacent characters as an allowed edit operation. In other words, the minimum number of edit operations (insertions, deletions, substitutions or transpositions) required to change one string to another. Characters of different cases (e.g., `a` and `A`) are considered different. |
+| [`editdist3(`*`s1`*`,` *`s2`*`)`](#editdist3s1-s2) | Alias of `levenshtein` for SQLite compatibility. The minimum number of single-character edits (insertions, deletions or substitutions) required to change one string to the other. Characters of different cases (e.g., `a` and `A`) are considered different. |
+| [`hamming(`*`s1`*`,` *`s2`*`)`](#hammings1-s2) | The Hamming distance between to strings, i.e., the number of positions with different characters for two strings of equal length. Strings must be of equal length. Characters of different cases (e.g., `a` and `A`) are considered different. |
+| [`jaccard(`*`s1`*`,` *`s2`*`)`](#jaccards1-s2) | The Jaccard similarity between two strings. Characters of different cases (e.g., `a` and `A`) are considered different. Returns a number between 0 and 1. |
+| [`jaro_similarity(`*`s1`*`,` *`s2`*`)`](#jaro_similaritys1-s2) | The Jaro similarity between two strings. Characters of different cases (e.g., `a` and `A`) are considered different. Returns a number between 0 and 1. |
+| [`jaro_winkler_similarity(`*`s1`*`,` *`s2`*`)`](#jaro_winkler_similaritys1-s2) | The Jaro-Winkler similarity between two strings. Characters of different cases (e.g., `a` and `A`) are considered different. Returns a number between 0 and 1. |
+| [`levenshtein(`*`s1`*`,` *`s2`*`)`](#levenshteins1-s2) | The minimum number of single-character edits (insertions, deletions or substitutions) required to change one string to the other. Characters of different cases (e.g., `a` and `A`) are considered different. |
+| [`mismatches(`*`s1`*`,` *`s2`*`)`](#mismatchess1-s2) | Alias for `hamming(`*`s1`*`,` *`s2`*`)`. The number of positions with different characters for two strings of equal length. Strings must be of equal length. Characters of different cases (e.g., `a` and `A`) are considered different. |
+
+### `damerau_levenshtein(`*`s1`*`,` *`s2`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Extension of Levenshtein distance to also include transposition of adjacent characters as an allowed edit operation. In other words, the minimum number of edit operations (insertions, deletions, substitutions or transpositions) required to change one string to another. Characters of different cases (e.g., `a` and `A`) are considered different. |
+| **Example** | `damerau_levenshtein('duckdb', 'udckbd')` |
+| **Result** | `2` |
+
+### `editdist3(`*`s1`*`,` *`s2`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Alias of `levenshtein` for SQLite compatibility. The minimum number of single-character edits (insertions, deletions or substitutions) required to change one string to the other. Characters of different cases (e.g., `a` and `A`) are considered different. |
+| **Example** | `editdist3('duck', 'db')` |
+| **Result** | `3` |
+
+### `hamming(`*`s1`*`,` *`s2`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The Hamming distance between to strings, i.e., the number of positions with different characters for two strings of equal length. Strings must be of equal length. Characters of different cases (e.g., `a` and `A`) are considered different. |
+| **Example** | `hamming('duck', 'luck')` |
+| **Result** | `1` |
+
+### `jaccard(`*`s1`*`,` *`s2`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The Jaccard similarity between two strings. Characters of different cases (e.g., `a` and `A`) are considered different. Returns a number between 0 and 1. |
+| **Example** | `jaccard('duck', 'luck')` |
+| **Result** | `0.6` |
+
+### `jaro_similarity(`*`s1`*`,` *`s2`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The Jaro similarity between two strings. Characters of different cases (e.g., `a` and `A`) are considered different. Returns a number between 0 and 1. |
+| **Example** | `jaro_similarity('duck', 'duckdb')` |
+| **Result** | `0.88` |
+
+### `jaro_winkler_similarity(`*`s1`*`,` *`s2`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The Jaro-Winkler similarity between two strings. Characters of different cases (e.g., `a` and `A`) are considered different. Returns a number between 0 and 1. |
+| **Example** | `jaro_winkler_similarity('duck', 'duckdb')` |
+| **Result** | `0.93` |
+
+### `levenshtein(`*`s1`*`,` *`s2`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The minimum number of single-character edits (insertions, deletions or substitutions) required to change one string to the other. Characters of different cases (e.g., `a` and `A`) are considered different. |
+| **Example** | `levenshtein('duck', 'db')` |
+| **Result** | `3` |
+
+### `mismatches(`*`s1`*`,` *`s2`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Alias for `hamming(`*`s1`*`,` *`s2`*`)`. The number of positions with different characters for two strings of equal length. Strings must be of equal length. Characters of different cases (e.g., `a` and `A`) are considered different. |
+| **Example** | `mismatches('duck', 'luck')` |
+| **Result** | `1` |
 
 ## Formatters
 

--- a/docs/sql/functions/date.md
+++ b/docs/sql/functions/date.md
@@ -25,31 +25,217 @@ Adding to or subtracting from [infinite values](../../sql/data_types/date#specia
 The table below shows the available functions for `DATE` types.
 Dates can also be manipulated with the [timestamp functions](../../sql/functions/timestamp) through type promotion.
 
-| Function | Description | Example | Result |
-|:--|:--|:---|:-|
-| `current_date` | Current date (at start of current transaction) | `current_date` | `2022-10-08` |
-| `date_add(`*`date`*`, `*`interval`*`)` | Add the interval to the date | `date_add(DATE '1992-09-15', INTERVAL 2 MONTH)` | `1992-11-15` |
-| `date_diff(`*`part`*`, `*`startdate`*`, `*`enddate`*`)` | The number of [partition](../../sql/functions/datepart) boundaries between the dates | `date_diff('month', DATE '1992-09-15', DATE '1992-11-14')` | `2` |
-| `date_part(`*`part`*`, `*`date`*`)` | Get the [subfield](../../sql/functions/datepart) (equivalent to `extract`) | `date_part('year', DATE '1992-09-20')` | `1992` |
-| `date_sub(`*`part`*`, `*`startdate`*`, `*`enddate`*`)` | The number of complete [partitions](../../sql/functions/datepart) between the dates | `date_sub('month', DATE '1992-09-15', DATE '1992-11-14')` | `1` |
-| `date_trunc(`*`part`*`, `*`date`*`)` | Truncate to specified [precision](../../sql/functions/datepart) | `date_trunc('month', DATE '1992-03-07')` | `1992-03-01` |
-| `datediff(`*`part`*`, `*`startdate`*`, `*`enddate`*`)` | Alias of date_diff. The number of [partition](../../sql/functions/datepart) boundaries between the dates | `datediff('month', DATE '1992-09-15', DATE '1992-11-14')` | `2` |
-| `datepart(`*`part`*`, `*`date`*`)` | Alias of date_part. Get the [subfield](../../sql/functions/datepart) (equivalent to `extract`) | `datepart('year', DATE '1992-09-20')` | `1992` |
-| `datesub(`*`part`*`, `*`startdate`*`, `*`enddate`*`)` | Alias of date_sub. The number of complete [partitions](../../sql/functions/datepart) between the dates | `datesub('month', DATE '1992-09-15', DATE '1992-11-14')` | `1` |
-| `datetrunc(`*`part`*`, `*`date`*`)` | Alias of date_trunc. Truncate to specified [precision](../../sql/functions/datepart) | `datetrunc('month', DATE '1992-03-07')` | `1992-03-01` |
-| `dayname(`*`date`*`)` | The (English) name of the weekday | `dayname(DATE '1992-09-20')` | `Sunday` |
-| `extract(`*`part`* `from `*`date`*`)` | Get [subfield](../../sql/functions/datepart) from a date | `extract('year' FROM DATE '1992-09-20')` | `1992` |
-| `greatest(`*`date`*`, `*`date`*`)` | The later of two dates | `greatest(DATE '1992-09-20', DATE '1992-03-07')` | `1992-09-20` |
-| `isfinite(`*`date`*`)` | Returns true if the date is finite, false otherwise | `isfinite(DATE '1992-03-07')` | `true` |
-| `isinf(`*`date`*`)` | Returns true if the date is infinite, false otherwise | `isinf(DATE '-infinity')` | `true` |
-| `last_day(`*`date`*`)` | The last day of the corresponding month in the date | `last_day(DATE '1992-09-20')` | `1992-09-30` |
-| `least(`*`date`*`, `*`date`*`)` | The earlier of two dates | `least(DATE '1992-09-20', DATE '1992-03-07')` | `1992-03-07` |
-| `make_date(`*`bigint`*`, `*`bigint`*`, `*`bigint`*`)` | The date for the given parts | `make_date(1992, 9, 20)` | `1992-09-20` |
-| `monthname(`*`date`*`)` | The (English) name of the month | `monthname(DATE '1992-09-20')` | `September` |
-| `strftime(date, format)` | Converts a date to a string according to the [format string](../../sql/functions/dateformat) | `strftime(date '1992-01-01', '%a, %-d %B %Y')` | `Wed, 1 January 1992` |
-| `time_bucket(`*`bucket_width`*`, `*`date`*`[, `*`offset`*`])` | Truncate `date` by the specified interval `bucket_width`. Buckets are offset by `offset` interval. | `time_bucket(INTERVAL '2 months', DATE '1992-04-20', INTERVAL '1 month')` | `1992-04-01` |
-| `time_bucket(`*`bucket_width`*`, `*`date`*`[, `*`origin`*`])` | Truncate `date` by the specified interval `bucket_width`. Buckets are aligned relative to `origin` date. `origin` defaults to 2000-01-03 for buckets that don't include a month or year interval, and to 2000-01-01 for month and year buckets. | `time_bucket(INTERVAL '2 weeks', DATE '1992-04-20', DATE '1992-04-01')` | `1992-04-15` |
-| `today()` | Current date (start of current transaction) | `today()` | `2022-10-08` |
+| Name | Description |
+|:--|:-------|
+| [`current_date`](#current_date) | Current date (at start of current transaction). |
+| [`date_add(`*`date`*`, `*`interval`*`)`](#date_adddate-interval) | Add the interval to the date. |
+| [`date_diff(`*`part`*`, `*`startdate`*`, `*`enddate`*`)`](#date_diffpart-startdate-enddate) | The number of [partition](../../sql/functions/datepart) boundaries between the dates. |
+| [`date_part(`*`part`*`, `*`date`*`)`](#date_partpart-date) | Get the [subfield](../../sql/functions/datepart) (equivalent to `extract`). |
+| [`date_sub(`*`part`*`, `*`startdate`*`, `*`enddate`*`)`](#date_subpart-startdate-enddate) | The number of complete [partitions](../../sql/functions/datepart) between the dates. |
+| [`date_trunc(`*`part`*`, `*`date`*`)`](#date_truncpart-date) | Truncate to specified [precision](../../sql/functions/datepart). |
+| [`datediff(`*`part`*`, `*`startdate`*`, `*`enddate`*`)`](#datediffpart-startdate-enddate) | Alias of date_diff. The number of [partition](../../sql/functions/datepart) boundaries between the dates. |
+| [`datepart(`*`part`*`, `*`date`*`)`](#datepartpart-date) | Alias of date_part. Get the [subfield](../../sql/functions/datepart) (equivalent to `extract`). |
+| [`datesub(`*`part`*`, `*`startdate`*`, `*`enddate`*`)`](#datesubpart-startdate-enddate) | Alias of date_sub. The number of complete [partitions](../../sql/functions/datepart) between the dates. |
+| [`datetrunc(`*`part`*`, `*`date`*`)`](#datetruncpart-date) | Alias of date_trunc. Truncate to specified [precision](../../sql/functions/datepart). |
+| [`dayname(`*`date`*`)`](#daynamedate) | The (English) name of the weekday. |
+| [`extract(`*`part`* `from `*`date`*`)`](#extractpart-from-date) | Get [subfield](../../sql/functions/datepart) from a date. |
+| [`greatest(`*`date`*`, `*`date`*`)`](#greatestdate-date) | The later of two dates. |
+| [`isfinite(`*`date`*`)`](#isfinitedate) | Returns true if the date is finite, false otherwise. |
+| [`isinf(`*`date`*`)`](#isinfdate) | Returns true if the date is infinite, false otherwise. |
+| [`last_day(`*`date`*`)`](#last_daydate) | The last day of the corresponding month in the date. |
+| [`least(`*`date`*`, `*`date`*`)`](#leastdate-date) | The earlier of two dates. |
+| [`make_date(`*`bigint`*`, `*`bigint`*`, `*`bigint`*`)`](#make_datebigint-bigint-bigint) | The date for the given parts. |
+| [`monthname(`*`date`*`)`](#monthnamedate) | The (English) name of the month. |
+| [`strftime(date, format)`](#strftimedate-format) | Converts a date to a string according to the [format string](../../sql/functions/dateformat). |
+| [`time_bucket(`*`bucket_width`*`, `*`date`*`[, `*`offset`*`])`](#time_bucketbucket_width-date-offset) | Truncate `date` by the specified interval `bucket_width`. Buckets are offset by `offset` interval. |
+| [`time_bucket(`*`bucket_width`*`, `*`date`*`[, `*`origin`*`])`](#time_bucketbucket_width-date-origin) | Truncate `date` by the specified interval `bucket_width`. Buckets are aligned relative to `origin` date. `origin` defaults to 2000-01-03 for buckets that don't include a month or year interval, and to 2000-01-01 for month and year buckets. |
+| [`today()`](#today) | Current date (start of current transaction). |
+
+### `current_date`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Current date (at start of current transaction). |
+| **Example** | `current_date` |
+| **Result** | `2022-10-08` |
+
+### `date_add(`*`date`*`, `*`interval`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Add the interval to the date. |
+| **Example** | `date_add(DATE '1992-09-15', INTERVAL 2 MONTH)` |
+| **Result** | `1992-11-15` |
+
+### `date_diff(`*`part`*`, `*`startdate`*`, `*`enddate`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The number of [partition](../../sql/functions/datepart) boundaries between the dates. |
+| **Example** | `date_diff('month', DATE '1992-09-15', DATE '1992-11-14')` |
+| **Result** | `2` |
+
+### `date_part(`*`part`*`, `*`date`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Get the [subfield](../../sql/functions/datepart) (equivalent to `extract`). |
+| **Example** | `date_part('year', DATE '1992-09-20')` |
+| **Result** | `1992` |
+
+### `date_sub(`*`part`*`, `*`startdate`*`, `*`enddate`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The number of complete [partitions](../../sql/functions/datepart) between the dates. |
+| **Example** | `date_sub('month', DATE '1992-09-15', DATE '1992-11-14')` |
+| **Result** | `1` |
+
+### `date_trunc(`*`part`*`, `*`date`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Truncate to specified [precision](../../sql/functions/datepart). |
+| **Example** | `date_trunc('month', DATE '1992-03-07')` |
+| **Result** | `1992-03-01` |
+
+### `datediff(`*`part`*`, `*`startdate`*`, `*`enddate`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Alias of date_diff. The number of [partition](../../sql/functions/datepart) boundaries between the dates. |
+| **Example** | `datediff('month', DATE '1992-09-15', DATE '1992-11-14')` |
+| **Result** | `2` |
+
+### `datepart(`*`part`*`, `*`date`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Alias of date_part. Get the [subfield](../../sql/functions/datepart) (equivalent to `extract`). |
+| **Example** | `datepart('year', DATE '1992-09-20')` |
+| **Result** | `1992` |
+
+### `datesub(`*`part`*`, `*`startdate`*`, `*`enddate`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Alias of date_sub. The number of complete [partitions](../../sql/functions/datepart) between the dates. |
+| **Example** | `datesub('month', DATE '1992-09-15', DATE '1992-11-14')` |
+| **Result** | `1` |
+
+### `datetrunc(`*`part`*`, `*`date`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Alias of date_trunc. Truncate to specified [precision](../../sql/functions/datepart). |
+| **Example** | `datetrunc('month', DATE '1992-03-07')` |
+| **Result** | `1992-03-01` |
+
+### `dayname(`*`date`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The (English) name of the weekday. |
+| **Example** | `dayname(DATE '1992-09-20')` |
+| **Result** | `Sunday` |
+
+### `extract(`*`part`* `from `*`date`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Get [subfield](../../sql/functions/datepart) from a date. |
+| **Example** | `extract('year' FROM DATE '1992-09-20')` |
+| **Result** | `1992` |
+
+### `greatest(`*`date`*`, `*`date`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The later of two dates. |
+| **Example** | `greatest(DATE '1992-09-20', DATE '1992-03-07')` |
+| **Result** | `1992-09-20` |
+
+### `isfinite(`*`date`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns true if the date is finite, false otherwise. |
+| **Example** | `isfinite(DATE '1992-03-07')` |
+| **Result** | `true` |
+
+### `isinf(`*`date`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns true if the date is infinite, false otherwise. |
+| **Example** | `isinf(DATE '-infinity')` |
+| **Result** | `true` |
+
+### `last_day(`*`date`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The last day of the corresponding month in the date. |
+| **Example** | `last_day(DATE '1992-09-20')` |
+| **Result** | `1992-09-30` |
+
+### `least(`*`date`*`, `*`date`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The earlier of two dates. |
+| **Example** | `least(DATE '1992-09-20', DATE '1992-03-07')` |
+| **Result** | `1992-03-07` |
+
+### `make_date(`*`bigint`*`, `*`bigint`*`, `*`bigint`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The date for the given parts. |
+| **Example** | `make_date(1992, 9, 20)` |
+| **Result** | `1992-09-20` |
+
+### `monthname(`*`date`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The (English) name of the month. |
+| **Example** | `monthname(DATE '1992-09-20')` |
+| **Result** | `September` |
+
+### `strftime(date, format)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Converts a date to a string according to the [format string](../../sql/functions/dateformat). |
+| **Example** | `strftime(date '1992-01-01', '%a, %-d %B %Y')` |
+| **Result** | `Wed, 1 January 1992` |
+
+### `time_bucket(`*`bucket_width`*`, `*`date`*`[, `*`offset`*`])`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Truncate `date` by the specified interval `bucket_width`. Buckets are offset by `offset` interval. |
+| **Example** | `time_bucket(INTERVAL '2 months', DATE '1992-04-20', INTERVAL '1 month')` |
+| **Result** | `1992-04-01` |
+
+### `time_bucket(`*`bucket_width`*`, `*`date`*`[, `*`origin`*`])`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Truncate `date` by the specified interval `bucket_width`. Buckets are aligned relative to `origin` date. `origin` defaults to 2000-01-03 for buckets that don't include a month or year interval, and to 2000-01-01 for month and year buckets. |
+| **Example** | `time_bucket(INTERVAL '2 weeks', DATE '1992-04-20', DATE '1992-04-01')` |
+| **Result** | `1992-04-15` |
+
+### `today()`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Current date (start of current transaction). |
+| **Example** | `today()` |
+| **Result** | `2022-10-08` |
+
+## Date Part Extraction Functions
 
 There are also dedicated extraction functions to get the [subfields](../../sql/functions/datepart#part-functions).
 A few examples include extracting the day from a date, or the day of the week from a date. 

--- a/docs/sql/functions/datepart.md
+++ b/docs/sql/functions/datepart.md
@@ -6,12 +6,10 @@ title: Date Part Functions
 The `date_part` and `date_diff` and `date_trunc` functions can be used to manipulate the fields of temporal types.
 The fields are specified as strings that contain the part name of the field.
 
-## Part Specifiers
-
 Below is a full list of all available date part specifiers.
 The examples are the corresponding parts of the timestamp `2021-08-03 11:59:44.123456`.
 
-### Usable as Date Part Specifiers and in Intervals
+## Part Specifiers Usable as Date Part Specifiers and in Intervals
 
 | Specifier | Description | Synonyms | Example |
 |:--|:--|:---|:-|
@@ -28,7 +26,7 @@ The examples are the corresponding parts of the timestamp `2021-08-03 11:59:44.1
 | `'second'` | Seconds | `'sec'`, `'seconds'`, `'secs'`, `'s'` | `44` |
 | `'year'` | Gregorian year | `'yr'`, `'y'`, `'years'`, `'yrs'` | `2021` |
 
-### Usable in Date Part Specifiers Only
+## Part Specifiers Only Usable as Date Part Specifiers
 
 | Specifier | Description | Synonyms | Example |
 |:--|:--|:---|:-|
@@ -47,35 +45,243 @@ The examples are the corresponding parts of the timestamp `2021-08-03 11:59:44.1
 Note that the time zone parts are all zero unless a time zone plugin such as ICU
 has been installed to support `TIMESTAMP WITH TIME ZONE`.
 
-### Part Functions
+## Part Functions
 
 There are dedicated extraction functions to get certain subfields:
 
-| Function | Description | Example | Result |
-|:--|:--|:---|:-|
-| `century(`*`date`*`)` | Century | `century(date '1992-02-15')` | `20` |
-| `day(`*`date`*`)` | Day | `day(date '1992-02-15')` | `15` |
-| `dayofmonth(`*`date`*`)` | Day (synonym) | `dayofmonth(date '1992-02-15')` | `15` |
-| `dayofweek(`*`date`*`)` | Numeric weekday (Sunday = 0, Saturday = 6) | `dayofweek(date '1992-02-15')` | `6` |
-| `dayofyear(`*`date`*`)` | Day of the year (starts from 1, i.e., January 1 = 1) | `dayofyear(date '1992-02-15')` | `46` |
-| `decade(`*`date`*`)` | Decade (year / 10) | `decade(date '1992-02-15')` | `199` |
-| `epoch(`*`date`*`)` | Seconds since 1970-01-01 | `epoch(date '1992-02-15')` | `698112000` |
-| `era(`*`date`*`)` | Calendar era | `era(date '0044-03-15 (BC)')` | `0` |
-| `hour(`*`date`*`)` | Hours | `hour(timestamp '2021-08-03 11:59:44.123456')` | `11` |
-| `isodow(`*`date`*`)` | Numeric ISO weekday (Monday = 1, Sunday = 7) | `isodow(date '1992-02-15')` | `6` |
-| `isoyear(`*`date`*`)` | ISO Year number (Starts on Monday of week containing Jan 4th) | `isoyear(date '2022-01-01')` | `2021` |
-| `microsecond(`*`date`*`)` | Sub-minute microseconds | `microsecond(timestamp '2021-08-03 11:59:44.123456')` | `44123456` |
-| `millennium(`*`date`*`)` | Millennium | `millennium(date '1992-02-15')` | `2` |
-| `millisecond(`*`date`*`)` | Sub-minute milliseconds | `millisecond(timestamp '2021-08-03 11:59:44.123456')` | `44123` |
-| `minute(`*`date`*`)` | Minutes | `minute(timestamp '2021-08-03 11:59:44.123456')` | `59` |
-| `month(`*`date`*`)` | Month | `month(date '1992-02-15')` | `2` |
-| `quarter(`*`date`*`)` | Quarter | `quarter(date '1992-02-15')` | `1` |
-| `second(`*`date`*`)` | Seconds | `second(timestamp '2021-08-03 11:59:44.123456')` | `44` |
-| `timezone_hour(`*`date`*`)` | Time zone offset hour portion | `timezone_hour(date '1992-02-15')` | `0` |
-| `timezone_minute(`*`date`*`)` | Time zone offset minutes portion | `timezone_minute(date '1992-02-15')` | `0` |
-| `timezone(`*`date`*`)` | Time Zone offset in minutes | `timezone(date '1992-02-15')` | `0` |
-| `week(`*`date`*`)` | ISO Week | `week(date '1992-02-15')` | `7` |
-| `weekday(`*`date`*`)` | Numeric weekday synonym (Sunday = 0, Saturday = 6) | `weekday(date '1992-02-15')` | `6` |
-| `weekofyear(`*`date`*`)` | ISO Week (synonym) | `weekofyear(date '1992-02-15')` | `7` |
-| `year(`*`date`*`)` | Year | `year(date '1992-02-15')` | `1992` |
-| `yearweek(`*`date`*`)` | `BIGINT` of combined ISO Year number and 2-digit version of ISO Week number | `yearweek(date '1992-02-15')` | `199207` |
+| Name | Description |
+|:--|:-------|
+| [`century(`*`date`*`)`](#centurydate) | Century. |
+| [`day(`*`date`*`)`](#daydate) | Day. |
+| [`dayofmonth(`*`date`*`)`](#dayofmonthdate) | Day (synonym). |
+| [`dayofweek(`*`date`*`)`](#dayofweekdate) | Numeric weekday (Sunday = 0, Saturday = 6). |
+| [`dayofyear(`*`date`*`)`](#dayofyeardate) | Day of the year (starts from 1, i.e., January 1 = 1). |
+| [`decade(`*`date`*`)`](#decadedate) | Decade (year / 10). |
+| [`epoch(`*`date`*`)`](#epochdate) | Seconds since 1970-01-01. |
+| [`era(`*`date`*`)`](#eradate) | Calendar era. |
+| [`hour(`*`date`*`)`](#hourdate) | Hours. |
+| [`isodow(`*`date`*`)`](#isodowdate) | Numeric ISO weekday (Monday = 1, Sunday = 7). |
+| [`isoyear(`*`date`*`)`](#isoyeardate) | ISO Year number (Starts on Monday of week containing Jan 4th). |
+| [`microsecond(`*`date`*`)`](#microseconddate) | Sub-minute microseconds. |
+| [`millennium(`*`date`*`)`](#millenniumdate) | Millennium. |
+| [`millisecond(`*`date`*`)`](#milliseconddate) | Sub-minute milliseconds. |
+| [`minute(`*`date`*`)`](#minutedate) | Minutes. |
+| [`month(`*`date`*`)`](#monthdate) | Month. |
+| [`quarter(`*`date`*`)`](#quarterdate) | Quarter. |
+| [`second(`*`date`*`)`](#seconddate) | Seconds. |
+| [`timezone_hour(`*`date`*`)`](#timezone_hourdate) | Time zone offset hour portion. |
+| [`timezone_minute(`*`date`*`)`](#timezone_minutedate) | Time zone offset minutes portion. |
+| [`timezone(`*`date`*`)`](#timezonedate) | Time Zone offset in minutes. |
+| [`week(`*`date`*`)`](#weekdate) | ISO Week. |
+| [`weekday(`*`date`*`)`](#weekdaydate) | Numeric weekday synonym (Sunday = 0, Saturday = 6). |
+| [`weekofyear(`*`date`*`)`](#weekofyeardate) | ISO Week (synonym). |
+| [`year(`*`date`*`)`](#yeardate) | Year. |
+| [`yearweek(`*`date`*`)`](#yearweekdate) | `BIGINT` of combined ISO Year number and 2-digit version of ISO Week number. |
+
+### `century(`*`date`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Century. |
+| **Example** | `century(date '1992-02-15')` |
+| **Result** | `20` |
+
+### `day(`*`date`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Day. |
+| **Example** | `day(date '1992-02-15')` |
+| **Result** | `15` |
+
+### `dayofmonth(`*`date`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Day (synonym). |
+| **Example** | `dayofmonth(date '1992-02-15')` |
+| **Result** | `15` |
+
+### `dayofweek(`*`date`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Numeric weekday (Sunday = 0, Saturday = 6). |
+| **Example** | `dayofweek(date '1992-02-15')` |
+| **Result** | `6` |
+
+### `dayofyear(`*`date`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Day of the year (starts from 1, i.e., January 1 = 1). |
+| **Example** | `dayofyear(date '1992-02-15')` |
+| **Result** | `46` |
+
+### `decade(`*`date`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Decade (year / 10). |
+| **Example** | `decade(date '1992-02-15')` |
+| **Result** | `199` |
+
+### `epoch(`*`date`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Seconds since 1970-01-01. |
+| **Example** | `epoch(date '1992-02-15')` |
+| **Result** | `698112000` |
+
+### `era(`*`date`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Calendar era. |
+| **Example** | `era(date '0044-03-15 (BC)')` |
+| **Result** | `0` |
+
+### `hour(`*`date`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Hours. |
+| **Example** | `hour(timestamp '2021-08-03 11:59:44.123456')` |
+| **Result** | `11` |
+
+### `isodow(`*`date`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Numeric ISO weekday (Monday = 1, Sunday = 7). |
+| **Example** | `isodow(date '1992-02-15')` |
+| **Result** | `6` |
+
+### `isoyear(`*`date`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | ISO Year number (Starts on Monday of week containing Jan 4th). |
+| **Example** | `isoyear(date '2022-01-01')` |
+| **Result** | `2021` |
+
+### `microsecond(`*`date`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Sub-minute microseconds. |
+| **Example** | `microsecond(timestamp '2021-08-03 11:59:44.123456')` |
+| **Result** | `44123456` |
+
+### `millennium(`*`date`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Millennium. |
+| **Example** | `millennium(date '1992-02-15')` |
+| **Result** | `2` |
+
+### `millisecond(`*`date`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Sub-minute milliseconds. |
+| **Example** | `millisecond(timestamp '2021-08-03 11:59:44.123456')` |
+| **Result** | `44123` |
+
+### `minute(`*`date`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Minutes. |
+| **Example** | `minute(timestamp '2021-08-03 11:59:44.123456')` |
+| **Result** | `59` |
+
+### `month(`*`date`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Month. |
+| **Example** | `month(date '1992-02-15')` |
+| **Result** | `2` |
+
+### `quarter(`*`date`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Quarter. |
+| **Example** | `quarter(date '1992-02-15')` |
+| **Result** | `1` |
+
+### `second(`*`date`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Seconds. |
+| **Example** | `second(timestamp '2021-08-03 11:59:44.123456')` |
+| **Result** | `44` |
+
+### `timezone_hour(`*`date`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Time zone offset hour portion. |
+| **Example** | `timezone_hour(date '1992-02-15')` |
+| **Result** | `0` |
+
+### `timezone_minute(`*`date`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Time zone offset minutes portion. |
+| **Example** | `timezone_minute(date '1992-02-15')` |
+| **Result** | `0` |
+
+### `timezone(`*`date`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Time Zone offset in minutes. |
+| **Example** | `timezone(date '1992-02-15')` |
+| **Result** | `0` |
+
+### `week(`*`date`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | ISO Week. |
+| **Example** | `week(date '1992-02-15')` |
+| **Result** | `7` |
+
+### `weekday(`*`date`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Numeric weekday synonym (Sunday = 0, Saturday = 6). |
+| **Example** | `weekday(date '1992-02-15')` |
+| **Result** | `6` |
+
+### `weekofyear(`*`date`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | ISO Week (synonym). |
+| **Example** | `weekofyear(date '1992-02-15')` |
+| **Result** | `7` |
+
+### `year(`*`date`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Year. |
+| **Example** | `year(date '1992-02-15')` |
+| **Result** | `1992` |
+
+### `yearweek(`*`date`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | `BIGINT` of combined ISO Year number and 2-digit version of ISO Week number. |
+| **Example** | `yearweek(date '1992-02-15')` |
+| **Result** | `199207` |

--- a/docs/sql/functions/enum.md
+++ b/docs/sql/functions/enum.md
@@ -13,10 +13,50 @@ CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy', 'anxious');
 These functions can take `NULL` or a specific value of the type as argument(s).
 With the exception of `enum_range_boundary`, the result depends only on the type of the argument and not on its value.
 
-| Function | Description | Example | Result |
-|:--|:--|:---|:-|
-| `enum_code(`*`enum_value`*`)` | Returns the numeric value backing the given enum value | `enum_code('happy'::mood)` | `2` |
-| `enum_first(`*`enum`*`)` | Returns the first value of the input enum type. | `enum_first(null::mood)` | `sad` |
-| `enum_last(`*`enum`*`)` | Returns the last value of the input enum type. | `enum_last(null::mood)` | `anxious` |
-| `enum_range(`*`enum`*`)` | Returns all values of the input enum type as an array. | `enum_range(null::mood)` | `[sad, ok, happy, anxious]` |
-| `enum_range_boundary(`*`enum`*`, `*`enum`*`)` | Returns the range between the two given enum values as an array. The values must be of the same enum type. When the first parameter is `NULL`, the result starts with the first value of the enum type. When the second parameter is `NULL`, the result ends with the last value of the enum type. | `enum_range_boundary(NULL, 'happy'::mood)` | `[sad, ok, happy]` |
+| Name | Description |
+|:--|:-------|
+| [`enum_code(`*`enum_value`*`)`](#enum_codeenum_value) | Returns the numeric value backing the given enum value. |
+| [`enum_first(`*`enum`*`)`](#enum_firstenum) | Returns the first value of the input enum type. |
+| [`enum_last(`*`enum`*`)`](#enum_lastenum) | Returns the last value of the input enum type. |
+| [`enum_range(`*`enum`*`)`](#enum_rangeenum) | Returns all values of the input enum type as an array. |
+| [`enum_range_boundary(`*`enum`*`, `*`enum`*`)`](#enum_range_boundaryenum-enum) | Returns the range between the two given enum values as an array. |
+
+### `enum_code(`*`enum_value`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns the numeric value backing the given enum value. |
+| **Example** | `enum_code('happy'::mood)` |
+| **Result** | `2` |
+
+### `enum_first(`*`enum`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns the first value of the input enum type. |
+| **Example** | `enum_first(NULL::mood)` |
+| **Result** | `sad` |
+
+### `enum_last(`*`enum`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns the last value of the input enum type. |
+| **Example** | `enum_last(NULL::mood)` |
+| **Result** | `anxious` |
+
+### `enum_range(`*`enum`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns all values of the input enum type as an array. |
+| **Example** | `enum_range(NULL::mood)` |
+| **Result** | `[sad, ok, happy, anxious]` |
+
+### `enum_range_boundary(`*`enum`*`, `*`enum`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns the range between the two given enum values as an array. The values must be of the same enum type. When the first parameter is `NULL`, the result starts with the first value of the enum type. When the second parameter is `NULL`, the result ends with the last value of the enum type. |
+| **Example** | `enum_range_boundary(NULL, 'happy'::mood)` |
+| **Result** | `[sad, ok, happy]` |

--- a/docs/sql/functions/interval.md
+++ b/docs/sql/functions/interval.md
@@ -24,23 +24,152 @@ The table below shows the available mathematical operators for `INTERVAL` types.
 
 The table below shows the available scalar functions for `INTERVAL` types.
 
-| Function | Description | Example | Result |
-|:--|:--|:---|:--|
-| `date_part(`*`part`*`, `*`interval`*`)` | Get [subfield](../../sql/functions/datepart) (equivalent to *extract*) | `date_part('year', INTERVAL '14 months')` | `1` |
-| `datepart(`*`part`*`, `*`interval`*`)` | Alias of date_part. Get [subfield](../../sql/functions/datepart) (equivalent to *extract*) | `datepart('year', INTERVAL '14 months')` | `1` |
-| `extract(`*`part`* `from` *`interval`*`)` | Get [subfield](../../sql/functions/datepart) from an interval | `extract('month' FROM INTERVAL '14 months')` | 2 |
-| `epoch(`*`interval`*`)` | Get total number of seconds in interval | `epoch(INTERVAL 5 HOUR)` | `18000.0` |
-| `to_centuries(`*`integer`*`)` | Construct a century interval | `to_centuries(5)` | `INTERVAL 500 YEAR` |
-| `to_days(`*`integer`*`)` | Construct a day interval | `to_days(5)` | `INTERVAL 5 DAY` |
-| `to_decades(`*`integer`*`)` | Construct a decade interval | `to_decades(5)` | `INTERVAL 50 YEAR` |
-| `to_hours(`*`integer`*`)` | Construct a hour interval | `to_hours(5)` | `INTERVAL 5 HOUR` |
-| `to_microseconds(`*`integer`*`)` | Construct a microsecond interval | `to_microseconds(5)` | `INTERVAL 5 MICROSECOND` |
-| `to_millennia(`*`integer`*`)` | Construct a millenium interval | `to_millennia(5)` | `INTERVAL 5000 YEAR` |
-| `to_milliseconds(`*`integer`*`)` | Construct a millisecond interval | `to_milliseconds(5)` | `INTERVAL 5 MILLISECOND` |
-| `to_minutes(`*`integer`*`)` | Construct a minute interval | `to_minutes(5)` | `INTERVAL 5 MINUTE` |
-| `to_months(`*`integer`*`)` | Construct a month interval | `to_months(5)` | `INTERVAL 5 MONTH` |
-| `to_seconds(`*`integer`*`)` | Construct a second interval | `to_seconds(5)` | `INTERVAL 5 SECOND` |
-| `to_weeks(`*`integer`*`)` | Construct a week interval | `to_weeks(5)` | `INTERVAL 35 DAY` |
-| `to_years(`*`integer`*`)` | Construct a year interval | `to_years(5)` | `INTERVAL 5 YEAR` |
+| Name | Description |
+|:--|:-------|
+| [`date_part(`*`part`*`, `*`interval`*`)`](#date_partpart-interval) | Get [subfield](../../sql/functions/datepart) (equivalent to *extract*). |
+| [`datepart(`*`part`*`, `*`interval`*`)`](#datepartpart-interval) | Alias of date_part. Get [subfield](../../sql/functions/datepart) (equivalent to *extract*). |
+| [`extract(`*`part`* `from` *`interval`*`)`](#extractpartfrominterval) | Get [subfield](../../sql/functions/datepart) from an interval. |
+| [`epoch(`*`interval`*`)`](#epochinterval) | Get total number of seconds in interval. |
+| [`to_centuries(`*`integer`*`)`](#to_centuriesinteger) | Construct a century interval. |
+| [`to_days(`*`integer`*`)`](#to_daysinteger) | Construct a day interval. |
+| [`to_decades(`*`integer`*`)`](#to_decadesinteger) | Construct a decade interval. |
+| [`to_hours(`*`integer`*`)`](#to_hoursinteger) | Construct a hour interval. |
+| [`to_microseconds(`*`integer`*`)`](#to_microsecondsinteger) | Construct a microsecond interval. |
+| [`to_millennia(`*`integer`*`)`](#to_millenniainteger) | Construct a millenium interval. |
+| [`to_milliseconds(`*`integer`*`)`](#to_millisecondsinteger) | Construct a millisecond interval. |
+| [`to_minutes(`*`integer`*`)`](#to_minutesinteger) | Construct a minute interval. |
+| [`to_months(`*`integer`*`)`](#to_monthsinteger) | Construct a month interval. |
+| [`to_seconds(`*`integer`*`)`](#to_secondsinteger) | Construct a second interval. |
+| [`to_weeks(`*`integer`*`)`](#to_weeksinteger) | Construct a week interval. |
+| [`to_years(`*`integer`*`)`](#to_yearsinteger) | Construct a year interval. |
 
-Only the documented [date parts](../../sql/functions/datepart) are defined for intervals.
+> Only the documented [date parts](../../sql/functions/datepart) are defined for intervals.
+
+### `date_part(`*`part`*`, `*`interval`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Get [subfield](../../sql/functions/datepart) (equivalent to *extract*). |
+| **Example** | `date_part('year', INTERVAL '14 months')` |
+| **Result** | `1` |
+
+### `datepart(`*`part`*`, `*`interval`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Alias of date_part. Get [subfield](../../sql/functions/datepart) (equivalent to *extract*). |
+| **Example** | `datepart('year', INTERVAL '14 months')` |
+| **Result** | `1` |
+
+### `extract(`*`part`* `from` *`interval`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Get [subfield](../../sql/functions/datepart) from an interval. |
+| **Example** | `extract('month' FROM INTERVAL '14 months')` |
+| **Result** | 2 |
+
+### `epoch(`*`interval`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Get total number of seconds in interval. |
+| **Example** | `epoch(INTERVAL 5 HOUR)` |
+| **Result** | `18000.0` |
+
+### `to_centuries(`*`integer`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Construct a century interval. |
+| **Example** | `to_centuries(5)` |
+| **Result** | `INTERVAL 500 YEAR` |
+
+### `to_days(`*`integer`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Construct a day interval. |
+| **Example** | `to_days(5)` |
+| **Result** | `INTERVAL 5 DAY` |
+
+### `to_decades(`*`integer`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Construct a decade interval. |
+| **Example** | `to_decades(5)` |
+| **Result** | `INTERVAL 50 YEAR` |
+
+### `to_hours(`*`integer`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Construct a hour interval. |
+| **Example** | `to_hours(5)` |
+| **Result** | `INTERVAL 5 HOUR` |
+
+### `to_microseconds(`*`integer`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Construct a microsecond interval. |
+| **Example** | `to_microseconds(5)` |
+| **Result** | `INTERVAL 5 MICROSECOND` |
+
+### `to_millennia(`*`integer`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Construct a millenium interval. |
+| **Example** | `to_millennia(5)` |
+| **Result** | `INTERVAL 5000 YEAR` |
+
+### `to_milliseconds(`*`integer`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Construct a millisecond interval. |
+| **Example** | `to_milliseconds(5)` |
+| **Result** | `INTERVAL 5 MILLISECOND` |
+
+### `to_minutes(`*`integer`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Construct a minute interval. |
+| **Example** | `to_minutes(5)` |
+| **Result** | `INTERVAL 5 MINUTE` |
+
+### `to_months(`*`integer`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Construct a month interval. |
+| **Example** | `to_months(5)` |
+| **Result** | `INTERVAL 5 MONTH` |
+
+### `to_seconds(`*`integer`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Construct a second interval. |
+| **Example** | `to_seconds(5)` |
+| **Result** | `INTERVAL 5 SECOND` |
+
+### `to_weeks(`*`integer`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Construct a week interval. |
+| **Example** | `to_weeks(5)` |
+| **Result** | `INTERVAL 35 DAY` |
+
+### `to_years(`*`integer`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Construct a year interval. |
+| **Example** | `to_years(5)` |
+| **Result** | `INTERVAL 5 YEAR` |
+

--- a/docs/sql/functions/lambda.md
+++ b/docs/sql/functions/lambda.md
@@ -16,11 +16,39 @@ For example, the following are all valid lambda functions:
 
 ### Scalar Functions That Accept Lambda Functions
 
-| Function | Aliases | Description | Example | Result |
-|--|--|---|--|-|
-| [`list_transform(`*`list`*`, `*`lambda`*`)`](#transform) | `array_transform`, `apply`, `list_apply`, `array_apply` | Returns a list that is the result of applying the lambda function to each element of the input list.                                       | `list_transform([4, 5, 6], x -> x + 1)`   | `[5, 6, 7]` |
-| [`list_filter(`*`list`*`, `*`lambda`*`)`](#filter)      | `array_filter`, `filter`                                | Constructs a list from those elements of the input list for which the lambda function returns `true`.                                      | `list_filter([4, 5, 6], x -> x > 4)`      | `[5, 6]`    |
-| [`list_reduce(`*`list`*`, `*`lambda`*`)`](#reduce)      | `array_reduce`, `reduce`                                | Reduces all elements of the input list into a single value by executing the lambda function on a running result and the next list element. | `list_reduce([4, 5, 6], (x, y) -> x + y)` | `15`        |
+
+| Name | Description |
+|:--|:-------|
+| [`list_transform(`*`list`*`, `*`lambda`*`)`](#list_transformlist-lambda) | Returns a list that is the result of applying the lambda function to each element of the input list. |
+| [`list_filter(`*`list`*`, `*`lambda`*`)`](#list_filterlist-lambda) | Constructs a list from those elements of the input list for which the lambda function returns `true`. |
+| [`list_reduce(`*`list`*`, `*`lambda`*`)`](#list_reducelist-lambda) | Reduces all elements of the input list into a single value by executing the lambda function on a running result and the next list element. |
+
+### `list_transform(`*`list`*`, `*`lambda`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns a list that is the result of applying the lambda function to each element of the input list. For more information, see [Transform](#transform). |
+| **Example** | `list_transform([4, 5, 6], x -> x + 1)` |
+| **Result** | `[5, 6, 7]` |
+| **Aliases** | `array_transform`, `apply`, `list_apply`, `array_apply` |
+
+### `list_filter(`*`list`*`, `*`lambda`*`)`   
+
+<div class="nostroke_table"></div>
+
+| **Description** | Constructs a list from those elements of the input list for which the lambda function returns `true`. For more information, see [Filter](#filter). |
+| **Example** | `list_filter([4, 5, 6], x -> x > 4)` |
+| **Result** | `[5, 6]` |
+| **Aliases** | `array_filter`, `filter` |
+
+### `list_reduce(`*`list`*`, `*`lambda`*`)`   
+
+<div class="nostroke_table"></div>
+
+| **Description** | Reduces all elements of the input list into a single value by executing the lambda function on a running result and the next list element. For more information, see [Reduce](#reduce). |
+| **Example** | `list_reduce([4, 5, 6], (x, y) -> x + y)` |
+| **Result** | `15` |
+| **Aliases** | `array_reduce`, `reduce` |
 
 ### Nesting
 

--- a/docs/sql/functions/nested.md
+++ b/docs/sql/functions/nested.md
@@ -9,48 +9,388 @@ This section describes functions and operators for examining and manipulating ne
 
 In the descriptions, `l` is the three element list `[4, 5, 6]`.
 
-<!-- This follows the order of shorthand, core/main function (list_), other list_ aliases, array_ aliases -->
+| Name | Description |
+|:--|:-------|
+| [*`list`*`[`*`index`*`]`](#listindex) | Bracket notation serves as an alias for `list_extract`. |
+| [*`list`*`[`*`begin`*`:`*`end`*`]`](#listbeginend) | Bracket notation with colon is an alias for `list_slice`. |
+| [*`list`*`[`*`begin`*`:`*`end`*`:`*`step`*`]`](#listbeginendstep) | `list_slice` in bracket notation with an added `step` feature. |
+| [`array_pop_back(`*`list`*`)`](#array_pop_backlist) | Returns the list without the last element. |
+| [`array_pop_front(`*`list`*`)`](#array_pop_frontlist) | Returns the list without the first element. |
+| [`flatten(`*`list_of_lists`*`)`](#flattenlist_of_lists) | Concatenate a list of lists into a single list. This only flattens one level of the list (see [examples](nested#flatten)). |
+| [`len(`*`list`*`)`](#lenlist) | Return the length of the list. |
+| [`list_aggregate(`*`list`*`, `*`name`*`)`](#list_aggregatelist-name) | Executes the aggregate function `name` on the elements of `list`. See the [List Aggregates](nested#list-aggregates) section for more details. |
+| [`list_any_value(`*`list`*`)`](#list_any_valuelist) | Returns the first non-null value in the list. |
+| [`list_append(`*`list`*`, `*`element`*`)`](#list_appendlist-element) | Appends `element` to `list`. |
+| [`list_concat(`*`list1`*`, `*`list2`*`)`](#list_concatlist1-list2) | Concatenates two lists. |
+| [`list_contains(`*`list`*`, `*`element`*`)`](#list_containslist-element) | Returns true if the list contains the element. |
+| [`list_cosine_similarity(`*`list1`*`, `*`list2`*`)`](#list_cosine_similaritylist1-list2) | Compute the cosine similarity between two lists. |
+| [`list_distance(`*`list1`*`, `*`list2`*`)`](#list_distancelist1-list2) | Calculates the Euclidean distance between two points with coordinates given in two inputs lists of equal length. |
+| [`list_distinct(`*`list`*`)`](#list_distinctlist) | Removes all duplicates and NULLs from a list. Does not preserve the original order. |
+| [`list_dot_product(`*`list1`*`, `*`list2`*`)`](#list_dot_productlist1-list2) | Computes the dot product of two same-sized lists of numbers. |
+| [`list_extract(`*`list`*`, `*`index`*`)`](#list_extractlist-index) | Extract the `index`th (1-based) value from the list. |
+| [`list_filter(`*`list`*`, `*`lambda`*`)`](#list_filterlist-lambda) | Constructs a list from those elements of the input list for which the lambda function returns true. See the [Lambda Functions](lambda#filter) page for more details. |
+| [`list_grade_up(`*`list`*`)`](#list_grade_uplist) | Works like sort, but the results are the indexes that correspond to the position in the original `list` instead of the actual values. |
+| [`list_has_all(`*`list`*`, `*`sub-list`*`)`](#list_has_alllist-sub-list) | Returns true if all elements of sub-list exist in list. |
+| [`list_has_any(`*`list1`*`, `*`list2`*`)`](#list_has_anylist1-list2) | Returns true if any elements exist is both lists. |
+| [`list_intersect(`*`list1`*`, `*`list2`*`)`](#list_intersectlist1-list2) | Returns a list of all the elements that exist in both l1 and l2, without duplicates. |
+| [`list_position(`*`list`*`, `*`element`*`)`](#list_positionlist-element) | Returns the index of the element if the list contains the element. |
+| [`list_prepend(`*`element`*`, `*`list`*`)`](#list_prependelement-list) | Prepends `element` to `list`. |
+| [`list_reduce(`*`list`*`, `*`lambda`*`)`](#list_reducelist-lambda) | Returns a single value that is the result of applying the lambda function to each element of the input list. See the [Lambda Functions](lambda#reduce) page for more details. |
+| [`list_resize(`*`list`*`, `*`size`*`[, `*`value`*`])`](#list_resizelist-size-value) | Resizes the list to contain `size` elements. Initializes new elements with `value` or `NULL` if `value` is not set. |
+| [`list_reverse_sort(`*`list`*`)`](#list_reverse_sortlist) | Sorts the elements of the list in reverse order. See the [Sorting Lists](nested#sorting-lists) section for more details about the null sorting order. |
+| [`list_reverse(`*`list`*`)`](#list_reverselist) | Reverses the list. |
+| [`list_select(`*`value_list`*`, `*`index_list`*`)`](#list_selectvalue_list-index_list) | Returns a list based on the elements selected by the `index_list`. |
+| [`list_slice(`*`list`*`, `*`begin`*`, `*`end`*`, `*`step`*`)`](#list_slicelist-begin-end-step) | `list_slice` with added `step` feature. |
+| [`list_slice(`*`list`*`, `*`begin`*`, `*`end`*`)`](#list_slicelist-begin-end) | Extract a sublist using slice conventions. Negative values are accepted. See [slicing](nested#slicing). |
+| [`list_sort(`*`list`*`)`](#list_sortlist) | Sorts the elements of the list. See the [Sorting Lists](nested#sorting-lists) section for more details about the sorting order and the null sorting order. |
+| [`list_transform(`*`list`*`, `*`lambda`*`)`](#list_transformlist-lambda) | Returns a list that is the result of applying the lambda function to each element of the input list. See the [Lambda Functions](lambda#transform) page for more details. |
+| [`list_unique(`*`list`*`)`](#list_uniquelist) | Counts the unique elements of a list. |
+| [`list_value(`*`any`*`, ...)`](#list_valueany-) | Create a `LIST` containing the argument values. |
+| [`list_where(`*`value_list`*`, `*`mask_list`*`)`](#list_wherevalue_list-mask_list) | Returns a list with the `BOOLEAN`s in `mask_list` applied as a mask to the `value_list`. |
+| [`list_zip(`*`list1`*`, `*`list2`*`, ...)`](#list_ziplist1-list2-) | Zips _k_ `LIST`s to a new `LIST` whose length will be that of the longest list. Its elements are structs of _k_ elements `list_1`, ..., `list_k`. Elements missing will be replaced with `NULL`. |
+| [`unnest(`*`list`*`)`](#unnestlist) | Unnests a list by one level. Note that this is a special function that alters the cardinality of the result. See the [`unnest` page](../query_syntax/unnest) for more details. |
 
-| Function | Aliases | Description | Example | Result |
-|--|--|---|--|-|
-| *`list`*`[`*`index`*`]`                                      |                                                           | Bracket notation serves as an alias for `list_extract`.                                                                                                                                          | `l[3]`                                                     | `6`                                                                                  |
-| *`list`*`[`*`begin`*`:`*`end`*`]`                            |                                                           | Bracket notation with colon is an alias for `list_slice`.                                                                                                                                        | `l[2:3]`                                                   | `[5, 6]`                                                                             |
-| *`list`*`[`*`begin`*`:`*`end`*`:`*`step`*`]`                 |                                                           | `list_slice` in bracket notation with an added `step` feature.                                                                                                                                   | `l[:-:2]`                                                  | `[4, 6]`                                                                             |
-| `array_pop_back(`*`list`*`)`                                 |                                                           | Returns the list without the last element.                                                                                                                                                       | `array_pop_back(l)`                                        | `[4, 5]`                                                                             |
-| `array_pop_front(`*`list`*`)`                                |                                                           | Returns the list without the first element.                                                                                                                                                      | `array_pop_front(l)`                                       | `[5, 6]`                                                                             |
-| `flatten(`*`list_of_lists`*`)`                               |                                                           | Concatenate a list of lists into a single list. This only flattens one level of the list (see [examples](nested#flatten)).                                                                       | `flatten([[1, 2], [3, 4]])`                                | `[1, 2, 3, 4]`                                                                       |
-| `len(`*`list`*`)`                                            | `array_length`                                            | Return the length of the list.                                                                                                                                                                   | `len([1, 2, 3])`                                           | `3`                                                                                  |
-| `list_aggregate(`*`list`*`, `*`name`*`)`                     | `list_aggr`, `aggregate`, `array_aggregate`, `array_aggr` | Executes the aggregate function `name` on the elements of `list`. See the [List Aggregates](nested#list-aggregates) section for more details.                                                    | `list_aggregate([1, 2, NULL], 'min')`                      | `1`                                                                                  |
-| `list_any_value(`*`list`*`)`                                 |                                                           | Returns the first non-null value in the list                                                                                                                                                     | `list_any_value([NULL, -3])`                               | `-3`                                                                                 |
-| `list_append(`*`list`*`, `*`element`*`)`                     | `array_append`, `array_push_back`                         | Appends `element` to `list`.                                                                                                                                                                     | `list_append([2, 3], 4)`                                   | `[2, 3, 4]`                                                                          |
-| `list_concat(`*`list1`*`, `*`list2`*`)`                      | `list_cat`, `array_concat`, `array_cat`                   | Concatenates two lists.                                                                                                                                                                          | `list_concat([2, 3], [4, 5, 6])`                           | `[2, 3, 4, 5, 6]`                                                                    |
-| `list_contains(`*`list`*`, `*`element`*`)`                   | `list_has`, `array_contains`, `array_has`                 | Returns true if the list contains the element.                                                                                                                                                   | `list_contains([1, 2, NULL], 1)`                           | `true`                                                                               |
-| `list_cosine_similarity(`*`list1`*`, `*`list2`*`)`           |                                                           | Compute the cosine similarity between two lists                                                                                                                                                  | `list_cosine_similarity([1, 2, 3], [1, 2, 5])`             | `0.9759000729485332`                                                                 |
-| `list_distance(`*`list1`*`, `*`list2`*`)`                    |                                                           | Calculates the Euclidean distance between two points with coordinates given in two inputs lists of equal length.                                                                                 | `list_distance([1, 2, 3], [1, 2, 5])`                      | `2.0`                                                                                |
-| `list_distinct(`*`list`*`)`                                  | `array_distinct`                                          | Removes all duplicates and NULLs from a list. Does not preserve the original order.                                                                                                              | `list_distinct([1, 1, NULL, -3, 1, 5])`                    | `[1, 5, -3]`                                                                         |
-| `list_dot_product(`*`list1`*`, `*`list2`*`)`                 | `list_inner_product`                                      | Computes the dot product of two same-sized lists of numbers.                                                                                                                                     | `list_dot_product([1, 2, 3], [1, 2, 5])`                   | `20.0`                                                                               |
-| `list_extract(`*`list`*`, `*`index`*`)`                      | `list_element`, `array_extract`                           | Extract the `index`th (1-based) value from the list.                                                                                                                                             | `list_extract(l, 3)`                                       | `6`                                                                                  |
-| `list_filter(`*`list`*`, `*`lambda`*`)`                      | `array_filter`, `filter`                                  | Constructs a list from those elements of the input list for which the lambda function returns true. See the [Lambda Functions](lambda#filter) page for more details.                        | `list_filter(l, x -> x > 4)`                               | `[5, 6]`                                                                             |
-| `list_grade_up(`*`list`*`)`                                  | `array_grade_up`                                          | Works like sort, but the results are the indexes that correspond to the position in the original `list` instead of the actual values.                                                            | `list_grade_up([30, 10, 40, 20])`                          | `[2, 4, 1, 3]`                                                                       |
-| `list_has_all(`*`list`*`, `*`sub-list`*`)`                   | `array_has_all`                                           | Returns true if all elements of sub-list exist in list.                                                                                                                                          | `list_has_all(l, [4, 6])`                                  | `true`                                                                               |
-| `list_has_any(`*`list1`*`, `*`list2`*`)`                     | `array_has_any`                                           | Returns true if any elements exist is both lists.                                                                                                                                                | `list_has_any([1, 2, 3], [2, 3, 4])`                       | `true`                                                                               |
-| `list_intersect(`*`list1`*`, `*`list2`*`)`                   | `array_intersect`                                         | Returns a list of all the elements that exist in both l1 and l2, without duplicates.                                                                                                             | `list_intersect([1, 2, 3], [2, 3, 4])`                     | `[2, 3]`                                                                             |
-| `list_position(`*`list`*`, `*`element`*`)`                   | `list_indexof`, `array_position`, `array_indexof`         | Returns the index of the element if the list contains the element.                                                                                                                               | `list_contains([1, 2, NULL], 2)`                           | `2`                                                                                  |
-| `list_prepend(`*`element`*`, `*`list`*`)`                    | `array_prepend`, `array_push_front`                       | Prepends `element` to `list`.                                                                                                                                                                    | `list_prepend(3, [4, 5, 6])`                               | `[3, 4, 5, 6]`                                                                       |
-| `list_reduce(`*`list`*`, `*`lambda`*`)`                      | `array_reduce`, `reduce`                                  | Returns a single value that is the result of applying the lambda function to each element of the input list. See the [Lambda Functions](lambda#reduce) page for more details.               | `list_reduce(l, (x, y) -> x + y)`                          | `15`                                                                                 |
-| `list_resize(`*`list`*`, `*`size`*`[, `*`value`*`])`         | `array_resize`                                            | Resizes the list to contain `size` elements. Initializes new elements with `value` or `NULL` if `value` is not set.                                                                              | `list_resize([1, 2, 3], 5, 0)`                             | `[1, 2, 3, 0, 0]`                                                                    |
-| `list_reverse_sort(`*`list`*`)`                              | `array_reverse_sort`                                      | Sorts the elements of the list in reverse order. See the [Sorting Lists](nested#sorting-lists) section for more details about the null sorting order.                                            | `list_reverse_sort([3, 6, 1, 2])`                          | `[6, 3, 2, 1]`                                                                       |
-| `list_reverse(`*`list`*`)`                                   | `array_reverse`                                           | Reverses the list.                                                                                                                                                                               | `list_reverse(l)`                                          | `[6, 5, 4]`                                                                          |
-| `list_select(`*`value_list`*`, `*`index_list`*`)`            | `array_select`                                            | Returns a list based on the elements selected by the `index_list`.                                                                                                                               | `list_select([10, 20, 30, 40], [1, 4])`                    | `[10, 40]`                                                                           |
-| `list_slice(`*`list`*`, `*`begin`*`, `*`end`*`, `*`step`*`)` | `array_slice`                                             | `list_slice` with added `step` feature.                                                                                                                                                          | `list_slice(l, 1, 3, 2)`                                   | `[4, 6]`                                                                             |
-| `list_slice(`*`list`*`, `*`begin`*`, `*`end`*`)`             | `array_slice`                                             | Extract a sublist using slice conventions. Negative values are accepted. See [slicing](nested#slicing).                                                                                          | `list_slice(l, 2, 3)`                                      | `[5, 6]`                                                                             |
-| `list_sort(`*`list`*`)`                                      | `array_sort`                                              | Sorts the elements of the list. See the [Sorting Lists](nested#sorting-lists) section for more details about the sorting order and the null sorting order.                                       | `list_sort([3, 6, 1, 2])`                                  | `[1, 2, 3, 6]`                                                                       |
-| `list_transform(`*`list`*`, `*`lambda`*`)`                   | `array_transform`, `apply`, `list_apply`, `array_apply`   | Returns a list that is the result of applying the lambda function to each element of the input list. See the [Lambda Functions](lambda#transform) page for more details.                    | `list_transform(l, x -> x + 1)`                            | `[5, 6, 7]`                                                                          |
-| `list_unique(`*`list`*`)`                                    | `array_unique`                                            | Counts the unique elements of a list.                                                                                                                                                            | `list_unique([1, 1, NULL, -3, 1, 5])`                      | `3`                                                                                  |
-| `list_value(`*`any`*`, ...)`                                 | `list_pack`                                               | Create a `LIST` containing the argument values.                                                                                                                                                  | `list_value(4, 5, 6)`                                      | `[4, 5, 6]`                                                                          |
-| `list_where(`*`value_list`*`, `*`mask_list`*`)`              | `array_where`                                             | Returns a list with the `BOOLEAN`s in `mask_list` applied as a mask to the `value_list`.                                                                                                         | `list_where([10, 20, 30, 40], [true, false, false, true])` | `[10, 40]`                                                                           |
-| `list_zip(`*`list1`*`, `*`list2`*`, ...)`                    | `array_zip`                                               | Zips _k_ `LIST`s to a new `LIST` whose length will be that of the longest list. Its elements are structs of _k_ elements `list_1`, ..., `list_k`. Elements missing will be replaced with `NULL`. | `list_zip([1, 2], [3, 4], [5, 6])`                         | `[{'list_1': 1, 'list_2': 3, 'list_3': 5}, {'list_1': 2, 'list_2': 4, 'list_3': 6}]` |
-| `unnest(`*`list`*`)`                                         |                                                           | Unnests a list by one level. Note that this is a special function that alters the cardinality of the result. See the [`unnest` page](../query_syntax/unnest) for more details.                   | `unnest([1, 2, 3])`                                        | `1`, `2`, `3`                                                                        |
+### *`list`*`[`*`index`*`]`                                     
+
+<div class="nostroke_table"></div>
+
+| **Description** | Bracket notation serves as an alias for `list_extract`. |
+| **Example** | `l[3]` |
+| **Result** | `6` |
+| **Alias** |  |
+
+### *`list`*`[`*`begin`*`:`*`end`*`]`                           
+
+<div class="nostroke_table"></div>
+
+| **Description** | Bracket notation with colon is an alias for `list_slice`. |
+| **Example** | `l[2:3]` |
+| **Result** | `[5, 6]` |
+| **Alias** |  |
+
+### *`list`*`[`*`begin`*`:`*`end`*`:`*`step`*`]`                
+
+<div class="nostroke_table"></div>
+
+| **Description** | `list_slice` in bracket notation with an added `step` feature. |
+| **Example** | `l[:-:2]` |
+| **Result** | `[4, 6]` |
+| **Alias** |  |
+
+### `array_pop_back(`*`list`*`)`                                
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns the list without the last element. |
+| **Example** | `array_pop_back(l)` |
+| **Result** | `[4, 5]` |
+| **Alias** |  |
+
+### `array_pop_front(`*`list`*`)`                               
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns the list without the first element. |
+| **Example** | `array_pop_front(l)` |
+| **Result** | `[5, 6]` |
+| **Alias** |  |
+
+### `flatten(`*`list_of_lists`*`)`                              
+
+<div class="nostroke_table"></div>
+
+| **Description** | Concatenate a list of lists into a single list. This only flattens one level of the list (see [examples](nested#flatten)). |
+| **Example** | `flatten([[1, 2], [3, 4]])` |
+| **Result** | `[1, 2, 3, 4]` |
+| **Alias** |  |
+
+### `len(`*`list`*`)`                                           
+
+<div class="nostroke_table"></div>
+
+| **Description** | Return the length of the list. |
+| **Example** | `len([1, 2, 3])` |
+| **Result** | `3` |
+| **Alias** | `array_length` |
+
+### `list_aggregate(`*`list`*`, `*`name`*`)`                    
+
+<div class="nostroke_table"></div>
+
+| **Description** | Executes the aggregate function `name` on the elements of `list`. See the [List Aggregates](nested#list-aggregates) section for more details. |
+| **Example** | `list_aggregate([1, 2, NULL], 'min')` |
+| **Result** | `1` |
+| **Aliases** | `list_aggr`, `aggregate`, `array_aggregate`, `array_aggr` |
+
+### `list_any_value(`*`list`*`)`                                
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns the first non-null value in the list. |
+| **Example** | `list_any_value([NULL, -3])` |
+| **Result** | `-3` |
+| **Alias** |  |
+
+### `list_append(`*`list`*`, `*`element`*`)`                    
+
+<div class="nostroke_table"></div>
+
+| **Description** | Appends `element` to `list`. |
+| **Example** | `list_append([2, 3], 4)` |
+| **Result** | `[2, 3, 4]` |
+| **Aliases** | `array_append`, `array_push_back` |
+
+### `list_concat(`*`list1`*`, `*`list2`*`)`                     
+
+<div class="nostroke_table"></div>
+
+| **Description** | Concatenates two lists. |
+| **Example** | `list_concat([2, 3], [4, 5, 6])` |
+| **Result** | `[2, 3, 4, 5, 6]` |
+| **Aliases** | `list_cat`, `array_concat`, `array_cat` |
+
+### `list_contains(`*`list`*`, `*`element`*`)`                  
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns true if the list contains the element. |
+| **Example** | `list_contains([1, 2, NULL], 1)` |
+| **Result** | `true` |
+| **Aliases** | `list_has`, `array_contains`, `array_has` |
+
+### `list_cosine_similarity(`*`list1`*`, `*`list2`*`)`          
+
+<div class="nostroke_table"></div>
+
+| **Description** | Compute the cosine similarity between two lists. |
+| **Example** | `list_cosine_similarity([1, 2, 3], [1, 2, 5])` |
+| **Result** | `0.9759000729485332` |
+| **Alias** |  |
+
+### `list_distance(`*`list1`*`, `*`list2`*`)`                   
+
+<div class="nostroke_table"></div>
+
+| **Description** | Calculates the Euclidean distance between two points with coordinates given in two inputs lists of equal length. |
+| **Example** | `list_distance([1, 2, 3], [1, 2, 5])` |
+| **Result** | `2.0` |
+| **Alias** |  |
+
+### `list_distinct(`*`list`*`)`                                 
+
+<div class="nostroke_table"></div>
+
+| **Description** | Removes all duplicates and NULLs from a list. Does not preserve the original order. |
+| **Example** | `list_distinct([1, 1, NULL, -3, 1, 5])` |
+| **Result** | `[1, 5, -3]` |
+| **Alias** | `array_distinct` |
+
+### `list_dot_product(`*`list1`*`, `*`list2`*`)`                
+
+<div class="nostroke_table"></div>
+
+| **Description** | Computes the dot product of two same-sized lists of numbers. |
+| **Example** | `list_dot_product([1, 2, 3], [1, 2, 5])` |
+| **Result** | `20.0` |
+| **Alias** | `list_inner_product` |
+
+### `list_extract(`*`list`*`, `*`index`*`)`                     
+
+<div class="nostroke_table"></div>
+
+| **Description** | Extract the `index`th (1-based) value from the list. |
+| **Example** | `list_extract(l, 3)` |
+| **Result** | `6` |
+| **Aliases** | `list_element`, `array_extract` |
+
+### `list_filter(`*`list`*`, `*`lambda`*`)`                     
+
+<div class="nostroke_table"></div>
+
+| **Description** | Constructs a list from those elements of the input list for which the lambda function returns true. See the [Lambda Functions](lambda#filter) page for more details. |
+| **Example** | `list_filter(l, x -> x > 4)` |
+| **Result** | `[5, 6]` |
+| **Aliases** | `array_filter`, `filter` |
+
+### `list_grade_up(`*`list`*`)`                                 
+
+<div class="nostroke_table"></div>
+
+| **Description** | Works like sort, but the results are the indexes that correspond to the position in the original `list` instead of the actual values. |
+| **Example** | `list_grade_up([30, 10, 40, 20])` |
+| **Result** | `[2, 4, 1, 3]` |
+| **Alias** | `array_grade_up` |
+
+### `list_has_all(`*`list`*`, `*`sub-list`*`)`                  
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns true if all elements of sub-list exist in list. |
+| **Example** | `list_has_all(l, [4, 6])` |
+| **Result** | `true` |
+| **Alias** | `array_has_all` |
+
+### `list_has_any(`*`list1`*`, `*`list2`*`)`                    
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns true if any elements exist is both lists. |
+| **Example** | `list_has_any([1, 2, 3], [2, 3, 4])` |
+| **Result** | `true` |
+| **Alias** | `array_has_any` |
+
+### `list_intersect(`*`list1`*`, `*`list2`*`)`                  
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns a list of all the elements that exist in both l1 and l2, without duplicates. |
+| **Example** | `list_intersect([1, 2, 3], [2, 3, 4])` |
+| **Result** | `[2, 3]` |
+| **Alias** | `array_intersect` |
+
+### `list_position(`*`list`*`, `*`element`*`)`                  
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns the index of the element if the list contains the element. |
+| **Example** | `list_contains([1, 2, NULL], 2)` |
+| **Result** | `2` |
+| **Aliases** | `list_indexof`, `array_position`, `array_indexof` |
+
+### `list_prepend(`*`element`*`, `*`list`*`)`                   
+
+<div class="nostroke_table"></div>
+
+| **Description** | Prepends `element` to `list`. |
+| **Example** | `list_prepend(3, [4, 5, 6])` |
+| **Result** | `[3, 4, 5, 6]` |
+| **Aliases** | `array_prepend`, `array_push_front` |
+
+### `list_reduce(`*`list`*`, `*`lambda`*`)`                     
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns a single value that is the result of applying the lambda function to each element of the input list. See the [Lambda Functions](lambda#reduce) page for more details. |
+| **Example** | `list_reduce(l, (x, y) -> x + y)` |
+| **Result** | `15` |
+| **Aliases** | `array_reduce`, `reduce` |
+
+### `list_resize(`*`list`*`, `*`size`*`[, `*`value`*`])`        
+
+<div class="nostroke_table"></div>
+
+| **Description** | Resizes the list to contain `size` elements. Initializes new elements with `value` or `NULL` if `value` is not set. |
+| **Example** | `list_resize([1, 2, 3], 5, 0)` |
+| **Result** | `[1, 2, 3, 0, 0]` |
+| **Alias** | `array_resize` |
+
+### `list_reverse_sort(`*`list`*`)`                             
+
+<div class="nostroke_table"></div>
+
+| **Description** | Sorts the elements of the list in reverse order. See the [Sorting Lists](nested#sorting-lists) section for more details about the null sorting order. |
+| **Example** | `list_reverse_sort([3, 6, 1, 2])` |
+| **Result** | `[6, 3, 2, 1]` |
+| **Alias** | `array_reverse_sort` |
+
+### `list_reverse(`*`list`*`)`                                  
+
+<div class="nostroke_table"></div>
+
+| **Description** | Reverses the list. |
+| **Example** | `list_reverse(l)` |
+| **Result** | `[6, 5, 4]` |
+| **Alias** | `array_reverse` |
+
+### `list_select(`*`value_list`*`, `*`index_list`*`)`           
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns a list based on the elements selected by the `index_list`. |
+| **Example** | `list_select([10, 20, 30, 40], [1, 4])` |
+| **Result** | `[10, 40]` |
+| **Alias** | `array_select` |
+
+### `list_slice(`*`list`*`, `*`begin`*`, `*`end`*`, `*`step`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | `list_slice` with added `step` feature. |
+| **Example** | `list_slice(l, 1, 3, 2)` |
+| **Result** | `[4, 6]` |
+| **Alias** | `array_slice` |
+
+### `list_slice(`*`list`*`, `*`begin`*`, `*`end`*`)`            
+
+<div class="nostroke_table"></div>
+
+| **Description** | Extract a sublist using slice conventions. Negative values are accepted. See [slicing](nested#slicing). |
+| **Example** | `list_slice(l, 2, 3)` |
+| **Result** | `[5, 6]` |
+| **Alias** | `array_slice` |
+
+### `list_sort(`*`list`*`)`                                     
+
+<div class="nostroke_table"></div>
+
+| **Description** | Sorts the elements of the list. See the [Sorting Lists](nested#sorting-lists) section for more details about the sorting order and the null sorting order. |
+| **Example** | `list_sort([3, 6, 1, 2])` |
+| **Result** | `[1, 2, 3, 6]` |
+| **Alias** | `array_sort` |
+
+### `list_transform(`*`list`*`, `*`lambda`*`)`                  
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns a list that is the result of applying the lambda function to each element of the input list. See the [Lambda Functions](lambda#transform) page for more details. |
+| **Example** | `list_transform(l, x -> x + 1)` |
+| **Result** | `[5, 6, 7]` |
+| **Aliases** | `array_transform`, `apply`, `list_apply`, `array_apply` |
+
+### `list_unique(`*`list`*`)`                                   
+
+<div class="nostroke_table"></div>
+
+| **Description** | Counts the unique elements of a list. |
+| **Example** | `list_unique([1, 1, NULL, -3, 1, 5])` |
+| **Result** | `3` |
+| **Alias** | `array_unique` |
+
+### `list_value(`*`any`*`, ...)`                                
+
+<div class="nostroke_table"></div>
+
+| **Description** | Create a `LIST` containing the argument values. |
+| **Example** | `list_value(4, 5, 6)` |
+| **Result** | `[4, 5, 6]` |
+| **Alias** | `list_pack` |
+
+### `list_where(`*`value_list`*`, `*`mask_list`*`)`             
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns a list with the `BOOLEAN`s in `mask_list` applied as a mask to the `value_list`. |
+| **Example** | `list_where([10, 20, 30, 40], [true, false, false, true])` |
+| **Result** | `[10, 40]` |
+| **Alias** | `array_where` |
+
+### `list_zip(`*`list1`*`, `*`list2`*`, ...)`                   
+
+<div class="nostroke_table"></div>
+
+| **Description** | Zips _k_ `LIST`s to a new `LIST` whose length will be that of the longest list. Its elements are structs of _k_ elements `list_1`, ..., `list_k`. Elements missing will be replaced with `NULL`. |
+| **Example** | `list_zip([1, 2], [3, 4], [5, 6])` |
+| **Result** | `[{'list_1': 1, 'list_2': 3, 'list_3': 5}, {'list_1': 2, 'list_2': 4, 'list_3': 6}]` |
+| **Alias** | `array_zip` |
+
+### `unnest(`*`list`*`)`                                        
+
+<div class="nostroke_table"></div>
+
+| **Description** | Unnests a list by one level. Note that this is a special function that alters the cardinality of the result. See the [`unnest` page](../query_syntax/unnest) for more details. |
+| **Example** | `unnest([1, 2, 3])` |
+| **Result** | `1`, `2`, `3` |
+| **Alias** |  |
 
 ## List Operators
 
@@ -87,39 +427,208 @@ FROM (VALUES (['Hello', '', 'World'])) t(strings);
 
 ## Struct Functions
 
-| Function | Description | Example | Result |
-|:--|:---|:---|:--|
-| *`struct`*`.`*`entry`* | Dot notation that serves as an alias for `struct_extract` from named `STRUCT`s. | `({'i': 3, 's': 'string'}).i` | `3` |
-| *`struct`*`[`*`entry`*`]` | Bracket notation that serves as an alias for `struct_extract` from named `STRUCT`s. | `({'i': 3, 's': 'string'})['i']` | `3` |
-| *`struct`*`[`*`idx`*`]` | Bracket notation that serves as an alias for `struct_extract` from unnamed `STRUCT`s (tuples), using an index (1-based). | `(row(42, 84))[1]` | `42` |
-| `row(`*`any`*`, ...)` | Create an unnamed `STRUCT` (tuple) containing the argument values. | `row(i, i % 4, i / 4)` | `(10, 2, 2.5)`|
-| `struct_extract(`*`struct`*`, `*`'entry'`*`)` | Extract the named entry from the `STRUCT`. | `struct_extract({'i': 3, 'v2': 3, 'v3': 0}, 'i')` | `3` |
-| `struct_extract(`*`struct`*`, `*`idx`*`)` | Extract the entry from an unnamed `STRUCT` (tuple) using an index (1-based). | `struct_extract(row(42, 84), 1)` | `42` |
-| `struct_insert(`*`struct`*`, `*`name := any`*`, ...)` | Add field(s)/value(s) to an existing `STRUCT` with the argument values. The entry name(s) will be the bound variable name(s). | `struct_insert({'a': 1}, b := 2)` | `{'a': 1, 'b': 2}` |
-| `struct_pack(`*`name := any`*`, ...)` | Create a `STRUCT` containing the argument values. The entry name will be the bound variable name. | `struct_pack(i := 4, s := 'string')` | `{'i': 4, 's': string}` |
+| Name | Description |
+|:--|:-------|
+| [*`struct`*`.`*`entry`*](#structentry) | Dot notation that serves as an alias for `struct_extract` from named `STRUCT`s. |
+| [*`struct`*`[`*`entry`*`]`](#structentry) | Bracket notation that serves as an alias for `struct_extract` from named `STRUCT`s. |
+| [*`struct`*`[`*`idx`*`]`](#structidx) | Bracket notation that serves as an alias for `struct_extract` from unnamed `STRUCT`s (tuples), using an index (1-based). |
+| [`row(`*`any`*`, ...)`](#rowany-) | Create an unnamed `STRUCT` (tuple) containing the argument values. |
+| [`struct_extract(`*`struct`*`, `*`'entry'`*`)`](#struct_extractstruct-entry) | Extract the named entry from the `STRUCT`. |
+| [`struct_extract(`*`struct`*`, `*`idx`*`)`](#struct_extractstruct-idx) | Extract the entry from an unnamed `STRUCT` (tuple) using an index (1-based). |
+| [`struct_insert(`*`struct`*`, `*`name := any`*`, ...)`](#struct_insertstruct-nameany-) | Add field(s)/value(s) to an existing `STRUCT` with the argument values. The entry name(s) will be the bound variable name(s). |
+| [`struct_pack(`*`name := any`*`, ...)`](#struct_packnameany-) | Create a `STRUCT` containing the argument values. The entry name will be the bound variable name. |
+
+### *`struct`*`.`*`entry`*
+
+<div class="nostroke_table"></div>
+
+| **Description** | Dot notation that serves as an alias for `struct_extract` from named `STRUCT`s. |
+| **Example** | `({'i': 3, 's': 'string'}).i` |
+| **Result** | `3` |
+
+### *`struct`*`[`*`entry`*`]`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Bracket notation that serves as an alias for `struct_extract` from named `STRUCT`s. |
+| **Example** | `({'i': 3, 's': 'string'})['i']` |
+| **Result** | `3` |
+
+### *`struct`*`[`*`idx`*`]`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Bracket notation that serves as an alias for `struct_extract` from unnamed `STRUCT`s (tuples), using an index (1-based). |
+| **Example** | `(row(42, 84))[1]` |
+| **Result** | `42` |
+
+### `row(`*`any`*`, ...)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Create an unnamed `STRUCT` (tuple) containing the argument values. |
+| **Example** | `row(i, i % 4, i / 4)` |
+| **Result** | `(10, 2, 2.5)` |
+
+### `struct_extract(`*`struct`*`, `*`'entry'`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Extract the named entry from the `STRUCT`. |
+| **Example** | `struct_extract({'i': 3, 'v2': 3, 'v3': 0}, 'i')` |
+| **Result** | `3` |
+
+### `struct_extract(`*`struct`*`, `*`idx`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Extract the entry from an unnamed `STRUCT` (tuple) using an index (1-based). |
+| **Example** | `struct_extract(row(42, 84), 1)` |
+| **Result** | `42` |
+
+### `struct_insert(`*`struct`*`, `*`name := any`*`, ...)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Add field(s)/value(s) to an existing `STRUCT` with the argument values. The entry name(s) will be the bound variable name(s). |
+| **Example** | `struct_insert({'a': 1}, b := 2)` |
+| **Result** | `{'a': 1, 'b': 2}` |
+
+### `struct_pack(`*`name := any`*`, ...)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Create a `STRUCT` containing the argument values. The entry name will be the bound variable name. |
+| **Example** | `struct_pack(i := 4, s := 'string')` |
+| **Result** | `{'i': 4, 's': string}` |
 
 ## Map Functions
 
-| Function | Description | Example | Result |
-|:--|:---|:---|:-|
-| `cardinality(`*`map`*`)` | Return the size of the map (or the number of entries in the map). | `cardinality(map([4, 2], ['a', 'b']))` | `2` |
-| `element_at(`*`map, key`*`)` | Return a list containing the value for a given key or an empty list if the key is not contained in the map. The type of the key provided in the second parameter must match the type of the map's keys else an error is returned. | `element_at(map([100, 5], [42, 43]), 100)` | `[42]` |
-| `map_entries(`*`map`*`)` | Return a list of struct(k, v) for each key-value pair in the map. | `map_entries(map([100, 5], [42, 43]))` | `[{'key': 100, 'value': 42}, {'key': 5, 'value': 43}]` |
-| `map_extract(`*`map, key`*`)` | Alias of `element_at`. Return a list containing the value for a given key or an empty list if the key is not contained in the map. The type of the key provided in the second parameter must match the type of the map's keys else an error is returned. | `map_extract(map([100, 5], [42, 43]), 100)` | `[42]` |
-| `map_from_entries(`*`STRUCT(k, v)[]`*`)` | Returns a map created from the entries of the array | `map_from_entries([{k: 5, v: 'val1'}, {k: 3, v: 'val2'}])` | `{5=val1, 3=val2}` |
-| `map_keys(`*`map`*`)` | Return a list of all keys in the map. | `map_keys(map([100, 5], [42,43]))` | `[100, 5]` |
-| `map_values(`*`map`*`)` | Return a list of all values in the map. | `map_values(map([100, 5], [42, 43]))` | `[42, 43]` |
-| `map()` | Returns an empty map. | `map()` | `{}` |
-| `map[`*`entry`*`]` | Alias for `element_at` | `map([100, 5], ['a', 'b'])[100]` | `[a]` |
+| Name | Description |
+|:--|:-------|
+| [`cardinality(`*`map`*`)`](#cardinalitymap) | Return the size of the map (or the number of entries in the map). |
+| [`element_at(`*`map, key`*`)`](#element_atmap-key) | Return a list containing the value for a given key or an empty list if the key is not contained in the map. The type of the key provided in the second parameter must match the type of the map's keys else an error is returned. |
+| [`map_entries(`*`map`*`)`](#map_entriesmap) | Return a list of struct(k, v) for each key-value pair in the map. |
+| [`map_extract(`*`map, key`*`)`](#map_extractmap-key) | Alias of `element_at`. Return a list containing the value for a given key or an empty list if the key is not contained in the map. The type of the key provided in the second parameter must match the type of the map's keys else an error is returned. |
+| [`map_from_entries(`*`STRUCT(k, v)[]`*`)`](#map_from_entriesstructk-v) | Returns a map created from the entries of the array. |
+| [`map_keys(`*`map`*`)`](#map_keysmap) | Return a list of all keys in the map. |
+| [`map_values(`*`map`*`)`](#map_valuesmap) | Return a list of all values in the map. |
+| [`map()`](#map) | Returns an empty map. |
+| [`map[`*`entry`*`]`](#mapentry) | Alias for `element_at`. |
+
+### `cardinality(`*`map`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Return the size of the map (or the number of entries in the map). |
+| **Example** | `cardinality(map([4, 2], ['a', 'b']))` |
+| **Result** | `2` |
+
+### `element_at(`*`map, key`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Return a list containing the value for a given key or an empty list if the key is not contained in the map. The type of the key provided in the second parameter must match the type of the map's keys else an error is returned. |
+| **Example** | `element_at(map([100, 5], [42, 43]), 100)` |
+| **Result** | `[42]` |
+
+### `map_entries(`*`map`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Return a list of struct(k, v) for each key-value pair in the map. |
+| **Example** | `map_entries(map([100, 5], [42, 43]))` |
+| **Result** | `[{'key': 100, 'value': 42}, {'key': 5, 'value': 43}]` |
+
+### `map_extract(`*`map, key`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Alias of `element_at`. Return a list containing the value for a given key or an empty list if the key is not contained in the map. The type of the key provided in the second parameter must match the type of the map's keys else an error is returned. |
+| **Example** | `map_extract(map([100, 5], [42, 43]), 100)` |
+| **Result** | `[42]` |
+
+### `map_from_entries(`*`STRUCT(k, v)[]`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns a map created from the entries of the array. |
+| **Example** | `map_from_entries([{k: 5, v: 'val1'}, {k: 3, v: 'val2'}])` |
+| **Result** | `{5=val1, 3=val2}` |
+
+### `map_keys(`*`map`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Return a list of all keys in the map. |
+| **Example** | `map_keys(map([100, 5], [42,43]))` |
+| **Result** | `[100, 5]` |
+
+### `map_values(`*`map`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Return a list of all values in the map. |
+| **Example** | `map_values(map([100, 5], [42, 43]))` |
+| **Result** | `[42, 43]` |
+
+### `map()`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns an empty map. |
+| **Example** | `map()` |
+| **Result** | `{}` |
+
+### `map[`*`entry`*`]`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Alias for `element_at`. |
+| **Example** | `map([100, 5], ['a', 'b'])[100]` |
+| **Result** | `[a]` |
 
 ## Union Functions
 
-| Function | Description | Example | Result |
-|:--|:---|:---|:-|
-| *`union`*`.`*`tag`* | Dot notation serves as an alias for `union_extract`.| `(union_value(k := 'hello')).k` | `string` |
-| `union_extract(`*`union`*`, `*`'tag'`*`)` | Extract the value with the named tags from the union. `NULL` if the tag is not currently selected | `union_extract(s, 'k')` | `hello` |
-| `union_value(`*`tag := any`*`)` | Create a single member `UNION` containing the argument value. The tag of the value will be the bound variable name. | `union_value(k := 'hello')` | `'hello'::UNION(k VARCHAR)`| 
-| `union_tag(`*`union`*`)` | Retrieve the currently selected tag of the union as an [Enum](../../sql/data_types/enum). | `union_tag(union_value(k := 'foo'))`  | `'k'` |
+| Name | Description |
+|:--|:-------|
+| [*`union`*`.`*`tag`*](#uniontag) | Dot notation serves as an alias for `union_extract`. |
+| [`union_extract(`*`union`*`, `*`'tag'`*`)`](#union_extractunion-tag) | Extract the value with the named tags from the union. `NULL` if the tag is not currently selected. |
+| [`union_value(`*`tag := any`*`)`](#union_valuetagany) | Create a single member `UNION` containing the argument value. The tag of the value will be the bound variable name. |
+| [`union_tag(`*`union`*`)`](#union_tagunion) | Retrieve the currently selected tag of the union as an [Enum](../../sql/data_types/enum). |
+
+### *`union`*`.`*`tag`*
+
+<div class="nostroke_table"></div>
+
+| **Description** | Dot notation serves as an alias for `union_extract`. |
+| **Example** | `(union_value(k := 'hello')).k` |
+| **Result** | `string` |
+
+### `union_extract(`*`union`*`, `*`'tag'`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Extract the value with the named tags from the union. `NULL` if the tag is not currently selected. |
+| **Example** | `union_extract(s, 'k')` |
+| **Result** | `hello` |
+
+### `union_value(`*`tag := any`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Create a single member `UNION` containing the argument value. The tag of the value will be the bound variable name. |
+| **Example** | `union_value(k := 'hello')` |
+| **Result** | `'hello'::UNION(k VARCHAR)` |
+
+### `union_tag(`*`union`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Retrieve the currently selected tag of the union as an [Enum](../../sql/data_types/enum). |
+| **Example** | `union_tag(union_value(k := 'foo'))` |
+| **Result** | `'k'` |
+
 
 ## Range Functions
 

--- a/docs/sql/functions/numeric.md
+++ b/docs/sql/functions/numeric.md
@@ -45,59 +45,483 @@ whereas the others are available for all numeric data types.
 
 The table below shows the available mathematical functions.
 
-| Function | Description | Example | Result |
-|:---|:---|:---|:--|
-| `@` | Absolute value (parentheses optional if operating on a column) | `@(-2)` | `2` |
-| `abs(x)` | Absolute value | `abs(-17.4)` | `17.4` |
-| `acos(x)` | Computes the arccosine of x | `acos(0.5)` | `1.0471975511965976` |
-| `add(x, y)` | Alias for `x + y` | `add(2, 3)` | `5` |
-| `asin(x)` | Computes the arcsine of x | `asin(0.5)` | `0.5235987755982989` |
-| `atan(x)` | Computes the arctangent of x | `atan(0.5)` | `0.4636476090008061` |
-| `atan2(y, x)` | Computes the arctangent (y, x) | `atan2(0.5, 0.5)` | `0.7853981633974483` |
-| `bit_count(x)` | Returns the number of bits that are set | `bit_count(31)` | `5` |
-| `cbrt(x)` | Returns the cube root of the number | `cbrt(8)` | `2` |
-| `ceil(x)` | Rounds the number up | `ceil(17.4)` | `18` |
-| `ceiling(x)` | Rounds the number up. Alias of `ceil` | `ceiling(17.4)` | `18` |
-| `cos(x)` | Computes the cosine of x | `cos(90)` | `-0.4480736161291701` |
-| `cot(x)` | Computes the cotangent of x | `cot(0.5)` | `1.830487721712452` |
-| `degrees(x)` | Converts radians to degrees | `degrees(pi())` | `180` |
-| `divide(x, y)` | Alias for `x // y` | `divide(5, 2)` | `2` |
-| `even(x)` | Round to next even number by rounding away from zero | `even(2.9)` | `4` |
-| `exp(x)` | Computes `e ** x` | `exp(0.693)` | `2` |
-| `factorial(x)` | See `!` operator. Computes the product of the current integer and all integers below it | `factorial(4)` | `24` |
-| `fdiv(x, y)` | Performs integer division (`x // y`) but returns a `DOUBLE` value | `fdiv(5, 2)` | `2.0` |
-| `floor(x)` | Rounds the number down | `floor(17.4)` | `17` |
-| `fmod(x, y)` | Calculates the modulo value. Always returns a `DOUBLE` value | `fmod(5, 2)` | `1.0` |
-| `gamma(x)` | Interpolation of (x-1) factorial (so decimal inputs are allowed) | `gamma(5.5)` | `52.34277778455352` |
-| `gcd(x, y)` | Computes the greatest common divisor of x and y | `gcd(42, 57)` | `3` |
-| `greatest_common_divisor(x, y)` | Computes the greatest common divisor of x and y | `greatest_common_divisor(42, 57)` | `3` |
-| `greatest(x1, x2, ...)` | Selects the largest value | `greatest(3, 2, 4, 4)` | `4` |
-| `isfinite(x)` | Returns true if the floating point value is finite, false otherwise | `isfinite(5.5)` | `true` |
-| `isinf(x)` | Returns true if the floating point value is infinite, false otherwise | `isinf('Infinity'::float)` | `true` |
-| `isnan(x)` | Returns true if the floating point value is not a number, false otherwise | `isnan('NaN'::float)` | `true` |
-| `lcm(x, y)` | Computes the least common multiple of x and y | `lcm(42, 57)` | `798` |
-| `least_common_multiple(x, y)` | Computes the least common multiple of x and y | `least_common_multiple(42, 57)` | `798` |
-| `least(x1, x2, ...)` | Selects the smallest value | `least(3, 2, 4, 4)` | `2` |
-| `lgamma(x)` | Computes the log of the `gamma` function | `lgamma(2)` | `0` |
-| `ln(x)` | Computes the natural logarithm of *x* | `ln(2)` | `0.693` |
-| `log(x)` | Computes the 10-log of *x* | `log(100)` | `2` |
-| `log10(x)` | Alias of `log`. computes the 10-log of *x* | `log10(1000)` | `3` |
-| `log2(x)` | Computes the 2-log of *x* | `log2(8)` | `3` |
-| `multiply(x, y)` | Alias for `x * y` | `multiply(2, 3)` | `6` |
-| `nextafter(x, y)` | Return the next floating point value after *x* in the direction of *y* | `nextafter(1::float, 2::float)` | `1.0000001` |
-| `pi()` | Returns the value of pi | `pi()` | `3.141592653589793` |
-| `pow(x, y)` | Computes x to the power of y | `pow(2, 3)` | `8` |
-| `power(x, y)` | Alias of `pow`. computes x to the power of y | `power(2, 3)` | `8` |
-| `radians(x)` | Converts degrees to radians | `radians(90)` | `1.5707963267948966` |
-| `random()` | Returns a random number between 0 and 1 | `random()` | various |
-| `round_even(v NUMERIC, s INT)` | Alias of `roundbankers(v, s)`. Round to *s* decimal places using the [_rounding half to even_ rule](https://en.wikipedia.org/wiki/Rounding#Rounding_half_to_even). Values *s < 0* are allowed | `round_even(24.5, 0)` | `24.0` |
-| `round(v NUMERIC, s INT)` | Round to *s* decimal places. Values *s < 0* are allowed | `round(42.4332, 2)` | `42.43` |
-| `setseed(x)` | Sets the seed to be used for the random function | `setseed(0.42)` | |
-| `sign(x)` | Returns the sign of x as -1, 0 or 1 | `sign(-349)` | `-1` |
-| `signbit(x)` | Returns whether the signbit is set or not | `signbit(-0.0)` | `true` |
-| `sin(x)` | Computes the sin of x | `sin(90)` | `0.8939966636005579` |
-| `sqrt(x)` | Returns the square root of the number | `sqrt(9)` | `3` |
-| `subtract(x, y)` | Alias for `x - y` | `subtract(2, 3)` | `-1`|
-| `tan(x)` | Computes the tangent of x | `tan(90)` | `-1.995200412208242` |
-| `trunc(x)` | Truncates the number | `trunc(17.4)` | `17` |
-| `xor(x)` | Bitwise XOR | `xor(17, 5)` | `20` |
+| Name | Description |
+|:--|:-------|
+| [`@`](#absx) | Absolute value (parentheses optional if operating on a column). |
+| [`abs(x)`](#absx) | Absolute value. |
+| [`acos(x)`](#acosx) | Computes the arccosine of x. |
+| [`add(x, y)`](#addx-y) | Alias for `x + y`. |
+| [`asin(x)`](#asinx) | Computes the arcsine of x. |
+| [`atan(x)`](#atanx) | Computes the arctangent of x. |
+| [`atan2(y, x)`](#atan2y-x) | Computes the arctangent (y, x). |
+| [`bit_count(x)`](#bit_countx) | Returns the number of bits that are set. |
+| [`cbrt(x)`](#cbrtx) | Returns the cube root of the number. |
+| [`ceil(x)`](#ceilx) | Rounds the number up. |
+| [`ceiling(x)`](#ceilingx) | Rounds the number up. Alias of `ceil`. |
+| [`cos(x)`](#cosx) | Computes the cosine of x. |
+| [`cot(x)`](#cotx) | Computes the cotangent of x. |
+| [`degrees(x)`](#degreesx) | Converts radians to degrees. |
+| [`divide(x, y)`](#dividex-y) | Alias for `x // y`. |
+| [`even(x)`](#evenx) | Round to next even number by rounding away from zero. |
+| [`exp(x)`](#expx) | Computes `e ** x`. |
+| [`factorial(x)`](#factorialx) | See `!` operator. Computes the product of the current integer and all integers below it. |
+| [`fdiv(x, y)`](#fdivx-y) | Performs integer division (`x // y`) but returns a `DOUBLE` value. |
+| [`floor(x)`](#floorx) | Rounds the number down. |
+| [`fmod(x, y)`](#fmodx-y) | Calculates the modulo value. Always returns a `DOUBLE` value. |
+| [`gamma(x)`](#gammax) | Interpolation of (x-1) factorial (so decimal inputs are allowed). |
+| [`gcd(x, y)`](#gcdx-y) | Computes the greatest common divisor of x and y. |
+| [`greatest_common_divisor(x, y)`](#greatest_common_divisorx-y) | Computes the greatest common divisor of x and y. |
+| [`greatest(x1, x2, ...)`](#greatestx1-x2-) | Selects the largest value. |
+| [`isfinite(x)`](#isfinitex) | Returns true if the floating point value is finite, false otherwise. |
+| [`isinf(x)`](#isinfx) | Returns true if the floating point value is infinite, false otherwise. |
+| [`isnan(x)`](#isnanx) | Returns true if the floating point value is not a number, false otherwise. |
+| [`lcm(x, y)`](#lcmx-y) | Computes the least common multiple of x and y. |
+| [`least_common_multiple(x, y)`](#least_common_multiplex-y) | Computes the least common multiple of x and y. |
+| [`least(x1, x2, ...)`](#leastx1-x2-) | Selects the smallest value. |
+| [`lgamma(x)`](#lgammax) | Computes the log of the `gamma` function. |
+| [`ln(x)`](#lnx) | Computes the natural logarithm of *x*. |
+| [`log(x)`](#logx) | Computes the 10-log of *x*. |
+| [`log10(x)`](#log10x) | Alias of `log`. computes the 10-log of *x*. |
+| [`log2(x)`](#log2x) | Computes the 2-log of *x*. |
+| [`multiply(x, y)`](#multiplyx-y) | Alias for `x * y`. |
+| [`nextafter(x, y)`](#nextafterx-y) | Return the next floating point value after *x* in the direction of *y*. |
+| [`pi()`](#pi) | Returns the value of pi. |
+| [`pow(x, y)`](#powx-y) | Computes x to the power of y. |
+| [`power(x, y)`](#powerx-y) | Alias of `pow`. computes x to the power of y. |
+| [`radians(x)`](#radiansx) | Converts degrees to radians. |
+| [`random()`](#random) | Returns a random number between 0 and 1. |
+| [`round_even(v NUMERIC, s INT)`](#round_evenv-numeric-s-int) | Alias of `roundbankers(v, s)`. Round to *s* decimal places using the [_rounding half to even_ rule](https://en.wikipedia.org/wiki/Rounding#Rounding_half_to_even). Values *s < 0* are allowed. |
+| [`round(v NUMERIC, s INT)`](#roundv-numeric-s-int) | Round to *s* decimal places. Values *s < 0* are allowed. |
+| [`setseed(x)`](#setseedx) | Sets the seed to be used for the random function. |
+| [`sign(x)`](#signx) | Returns the sign of x as -1, 0 or 1. |
+| [`signbit(x)`](#signbitx) | Returns whether the signbit is set or not. |
+| [`sin(x)`](#sinx) | Computes the sin of x. |
+| [`sqrt(x)`](#sqrtx) | Returns the square root of the number. |
+| [`subtract(x, y)`](#subtractx-y) | Alias for `x - y`. |
+| [`tan(x)`](#tanx) | Computes the tangent of x. |
+| [`trunc(x)`](#truncx) | Truncates the number. |
+| [`xor(x)`](#xorx) | Bitwise XOR. |
+
+### `abs(x)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Absolute value. |
+| **Example** | `abs(-17.4)` |
+| **Result** | `17.4` |
+| **Alias** | `@` |
+
+### `acos(x)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Computes the arccosine of x. |
+| **Example** | `acos(0.5)` |
+| **Result** | `1.0471975511965976` |
+
+### `add(x, y)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Alias for `x + y`. |
+| **Example** | `add(2, 3)` |
+| **Result** | `5` |
+
+### `asin(x)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Computes the arcsine of x. |
+| **Example** | `asin(0.5)` |
+| **Result** | `0.5235987755982989` |
+
+### `atan(x)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Computes the arctangent of x. |
+| **Example** | `atan(0.5)` |
+| **Result** | `0.4636476090008061` |
+
+### `atan2(y, x)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Computes the arctangent (y, x). |
+| **Example** | `atan2(0.5, 0.5)` |
+| **Result** | `0.7853981633974483` |
+
+### `bit_count(x)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns the number of bits that are set. |
+| **Example** | `bit_count(31)` |
+| **Result** | `5` |
+
+### `cbrt(x)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns the cube root of the number. |
+| **Example** | `cbrt(8)` |
+| **Result** | `2` |
+
+### `ceil(x)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Rounds the number up. |
+| **Example** | `ceil(17.4)` |
+| **Result** | `18` |
+
+### `ceiling(x)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Rounds the number up. Alias of `ceil`. |
+| **Example** | `ceiling(17.4)` |
+| **Result** | `18` |
+
+### `cos(x)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Computes the cosine of x. |
+| **Example** | `cos(90)` |
+| **Result** | `-0.4480736161291701` |
+
+### `cot(x)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Computes the cotangent of x. |
+| **Example** | `cot(0.5)` |
+| **Result** | `1.830487721712452` |
+
+### `degrees(x)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Converts radians to degrees. |
+| **Example** | `degrees(pi())` |
+| **Result** | `180` |
+
+### `divide(x, y)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Alias for `x // y`. |
+| **Example** | `divide(5, 2)` |
+| **Result** | `2` |
+
+### `even(x)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Round to next even number by rounding away from zero. |
+| **Example** | `even(2.9)` |
+| **Result** | `4` |
+
+### `exp(x)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Computes `e ** x`. |
+| **Example** | `exp(0.693)` |
+| **Result** | `2` |
+
+### `factorial(x)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | See `!` operator. Computes the product of the current integer and all integers below it. |
+| **Example** | `factorial(4)` |
+| **Result** | `24` |
+
+### `fdiv(x, y)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Performs integer division (`x // y`) but returns a `DOUBLE` value. |
+| **Example** | `fdiv(5, 2)` |
+| **Result** | `2.0` |
+
+### `floor(x)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Rounds the number down. |
+| **Example** | `floor(17.4)` |
+| **Result** | `17` |
+
+### `fmod(x, y)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Calculates the modulo value. Always returns a `DOUBLE` value. |
+| **Example** | `fmod(5, 2)` |
+| **Result** | `1.0` |
+
+### `gamma(x)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Interpolation of (x-1) factorial (so decimal inputs are allowed). |
+| **Example** | `gamma(5.5)` |
+| **Result** | `52.34277778455352` |
+
+### `gcd(x, y)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Computes the greatest common divisor of x and y. |
+| **Example** | `gcd(42, 57)` |
+| **Result** | `3` |
+
+### `greatest_common_divisor(x, y)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Computes the greatest common divisor of x and y. |
+| **Example** | `greatest_common_divisor(42, 57)` |
+| **Result** | `3` |
+
+### `greatest(x1, x2, ...)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Selects the largest value. |
+| **Example** | `greatest(3, 2, 4, 4)` |
+| **Result** | `4` |
+
+### `isfinite(x)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns true if the floating point value is finite, false otherwise. |
+| **Example** | `isfinite(5.5)` |
+| **Result** | `true` |
+
+### `isinf(x)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns true if the floating point value is infinite, false otherwise. |
+| **Example** | `isinf('Infinity'::float)` |
+| **Result** | `true` |
+
+### `isnan(x)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns true if the floating point value is not a number, false otherwise. |
+| **Example** | `isnan('NaN'::float)` |
+| **Result** | `true` |
+
+### `lcm(x, y)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Computes the least common multiple of x and y. |
+| **Example** | `lcm(42, 57)` |
+| **Result** | `798` |
+
+### `least_common_multiple(x, y)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Computes the least common multiple of x and y. |
+| **Example** | `least_common_multiple(42, 57)` |
+| **Result** | `798` |
+
+### `least(x1, x2, ...)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Selects the smallest value. |
+| **Example** | `least(3, 2, 4, 4)` |
+| **Result** | `2` |
+
+### `lgamma(x)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Computes the log of the `gamma` function. |
+| **Example** | `lgamma(2)` |
+| **Result** | `0` |
+
+### `ln(x)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Computes the natural logarithm of *x*. |
+| **Example** | `ln(2)` |
+| **Result** | `0.693` |
+
+### `log(x)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Computes the 10-log of *x*. |
+| **Example** | `log(100)` |
+| **Result** | `2` |
+
+### `log10(x)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Alias of `log`. computes the 10-log of *x*. |
+| **Example** | `log10(1000)` |
+| **Result** | `3` |
+
+### `log2(x)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Computes the 2-log of *x*. |
+| **Example** | `log2(8)` |
+| **Result** | `3` |
+
+### `multiply(x, y)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Alias for `x * y`. |
+| **Example** | `multiply(2, 3)` |
+| **Result** | `6` |
+
+### `nextafter(x, y)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Return the next floating point value after *x* in the direction of *y*. |
+| **Example** | `nextafter(1::float, 2::float)` |
+| **Result** | `1.0000001` |
+
+### `pi()`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns the value of pi. |
+| **Example** | `pi()` |
+| **Result** | `3.141592653589793` |
+
+### `pow(x, y)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Computes x to the power of y. |
+| **Example** | `pow(2, 3)` |
+| **Result** | `8` |
+
+### `power(x, y)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Alias of `pow`. computes x to the power of y. |
+| **Example** | `power(2, 3)` |
+| **Result** | `8` |
+
+### `radians(x)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Converts degrees to radians. |
+| **Example** | `radians(90)` |
+| **Result** | `1.5707963267948966` |
+
+### `random()`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns a random number between 0 and 1. |
+| **Example** | `random()` |
+| **Result** | various |
+
+### `round_even(v NUMERIC, s INT)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Alias of `roundbankers(v, s)`. Round to *s* decimal places using the [_rounding half to even_ rule](https://en.wikipedia.org/wiki/Rounding#Rounding_half_to_even). Values *s < 0* are allowed. |
+| **Example** | `round_even(24.5, 0)` |
+| **Result** | `24.0` |
+
+### `round(v NUMERIC, s INT)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Round to *s* decimal places. Values *s < 0* are allowed. |
+| **Example** | `round(42.4332, 2)` |
+| **Result** | `42.43` |
+
+### `setseed(x)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Sets the seed to be used for the random function. |
+| **Example** | `setseed(0.42)` |
+
+### `sign(x)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns the sign of x as -1, 0 or 1. |
+| **Example** | `sign(-349)` |
+| **Result** | `-1` |
+
+### `signbit(x)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns whether the signbit is set or not. |
+| **Example** | `signbit(-0.0)` |
+| **Result** | `true` |
+
+### `sin(x)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Computes the sin of x. |
+| **Example** | `sin(90)` |
+| **Result** | `0.8939966636005579` |
+
+### `sqrt(x)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns the square root of the number. |
+| **Example** | `sqrt(9)` |
+| **Result** | `3` |
+
+### `subtract(x, y)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Alias for `x - y`. |
+| **Example** | `subtract(2, 3)` |
+| **Result** | `-1` |
+
+### `tan(x)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Computes the tangent of x. |
+| **Example** | `tan(90)` |
+| **Result** | `-1.995200412208242` |
+
+### `trunc(x)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Truncates the number. |
+| **Example** | `trunc(17.4)` |
+| **Result** | `17` |
+
+### `xor(x)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Bitwise XOR. |
+| **Example** | `xor(17, 5)` |
+| **Result** | `20` |

--- a/docs/sql/functions/regular_expressions.md
+++ b/docs/sql/functions/regular_expressions.md
@@ -16,16 +16,80 @@ DuckDB uses the [RE2 library](https://github.com/google/re2) as its regular expr
 
 ## Functions
 
-| Function | Description | Example | Result |
-|:---|:---|:---|:--|
-| `regexp_extract_all(`*`string`*`, `*`regex`*`[, `*`group`*` = 0])` | Split the *string* along the *regex* and extract all occurrences of *group* | `regexp_extract_all('hello_world', '([a-z ]+)_?', 1)` | `[hello, world]` |
-| `regexp_extract(`*`string`*`, `*`pattern `*`, `*`name_list`*`)`; | If *string* contains the regexp *pattern*, returns the capturing groups as a struct with corresponding names from *name_list* | `regexp_extract('2023-04-15', '(\d+)-(\d+)-(\d+)', ['y', 'm', 'd'])` | `{'y':'2023', 'm':'04', 'd':'15'}` |
-| `regexp_extract(`*`string`*`, `*`pattern `*`[, `*`idx`*`])`; | If *string* contains the regexp *pattern*, returns the capturing group specified by optional parameter *idx* | `regexp_extract('hello_world', '([a-z ]+)_?', 1)` | `hello` |
-| `regexp_full_match(`*`string`*`, `*`regex`*`)`| Returns `true` if the entire *string* matches the *regex* | `regexp_full_match('anabanana', '(an)*')` | `false` |
-| `regexp_matches(`*`string`*`, `*`pattern`*`)` | Returns `true` if  *string* contains the regexp *pattern*, `false` otherwise | `regexp_matches('anabanana', '(an)*')` | `true` |
-| `regexp_replace(`*`string`*`, `*`pattern`*`, `*`replacement`*`)`; | If *string* contains the regexp *pattern*, replaces the matching part with *replacement* | `regexp_replace('hello', '[lo]', '-')` | `he-lo` |
-| `regexp_split_to_array(`*`string`*`, `*`regex`*`)` | Alias of `string_split_regex`. Splits the *string* along the *regex* | `regexp_split_to_array('hello␣world; 42', ';?␣')` | `['hello', 'world', '42']` |
-| `regexp_split_to_table(`*`string`*`, `*`regex`*`)` | Splits the *string* along the *regex* and returns a row for each part | `regexp_split_to_array('hello␣world; 42', ';?␣')` | Two rows: `'hello'`, `'world'` |
+| Name | Description |
+|:--|:-------|
+| [`regexp_extract_all(`*`string`*`, `*`regex`*`[, `*`group`*` = 0])`](#regexp_extract_allstring-regex-group0) | Split the *string* along the *regex* and extract all occurrences of *group*. |
+| [`regexp_extract(`*`string`*`, `*`pattern `*`, `*`name_list`*`)`;](#regexp_extractstring-pattern-name_list) | If *string* contains the regexp *pattern*, returns the capturing groups as a struct with corresponding names from *name_list*. |
+| [`regexp_extract(`*`string`*`, `*`pattern `*`[, `*`idx`*`])`;](#regexp_extractstring-pattern-idx) | If *string* contains the regexp *pattern*, returns the capturing group specified by optional parameter *idx*. |
+| [`regexp_full_match(`*`string`*`, `*`regex`*`)`](#regexp_full_matchstring-regex) | Returns `true` if the entire *string* matches the *regex*. |
+| [`regexp_matches(`*`string`*`, `*`pattern`*`)`](#regexp_matchesstring-pattern) | Returns `true` if  *string* contains the regexp *pattern*, `false` otherwise. |
+| [`regexp_replace(`*`string`*`, `*`pattern`*`, `*`replacement`*`)`;](#regexp_replacestring-pattern-replacement) | If *string* contains the regexp *pattern*, replaces the matching part with *replacement*. |
+| [`regexp_split_to_array(`*`string`*`, `*`regex`*`)`](#regexp_split_to_arraystring-regex) | Alias of `string_split_regex`. Splits the *string* along the *regex*. |
+| [`regexp_split_to_table(`*`string`*`, `*`regex`*`)`](#regexp_split_to_tablestring-regex) | Splits the *string* along the *regex* and returns a row for each part. |
+
+### `regexp_extract_all(`*`string`*`, `*`regex`*`[, `*`group`*` = 0])`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Split the *string* along the *regex* and extract all occurrences of *group*. |
+| **Example** | `regexp_extract_all('hello_world', '([a-z ]+)_?', 1)` |
+| **Result** | `[hello, world]` |
+
+### `regexp_extract(`*`string`*`, `*`pattern `*`, `*`name_list`*`)`;
+
+<div class="nostroke_table"></div>
+
+| **Description** | If *string* contains the regexp *pattern*, returns the capturing groups as a struct with corresponding names from *name_list*. |
+| **Example** | `regexp_extract('2023-04-15', '(\d+)-(\d+)-(\d+)', ['y', 'm', 'd'])` |
+| **Result** | `{'y':'2023', 'm':'04', 'd':'15'}` |
+
+### `regexp_extract(`*`string`*`, `*`pattern `*`[, `*`idx`*`])`;
+
+<div class="nostroke_table"></div>
+
+| **Description** | If *string* contains the regexp *pattern*, returns the capturing group specified by optional parameter *idx*. |
+| **Example** | `regexp_extract('hello_world', '([a-z ]+)_?', 1)` |
+| **Result** | `hello` |
+
+### `regexp_full_match(`*`string`*`, `*`regex`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns `true` if the entire *string* matches the *regex*. |
+| **Example** | `regexp_full_match('anabanana', '(an)*')` |
+| **Result** | `false` |
+
+### `regexp_matches(`*`string`*`, `*`pattern`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns `true` if  *string* contains the regexp *pattern*, `false` otherwise. |
+| **Example** | `regexp_matches('anabanana', '(an)*')` |
+| **Result** | `true` |
+
+### `regexp_replace(`*`string`*`, `*`pattern`*`, `*`replacement`*`)`;
+
+<div class="nostroke_table"></div>
+
+| **Description** | If *string* contains the regexp *pattern*, replaces the matching part with *replacement*. |
+| **Example** | `regexp_replace('hello', '[lo]', '-')` |
+| **Result** | `he-lo` |
+
+### `regexp_split_to_array(`*`string`*`, `*`regex`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Alias of `string_split_regex`. Splits the *string* along the *regex*. |
+| **Example** | `regexp_split_to_array('hello␣world; 42', ';?␣')` |
+| **Result** | `['hello', 'world', '42']` |
+
+### `regexp_split_to_table(`*`string`*`, `*`regex`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Splits the *string* along the *regex* and returns a row for each part. |
+| **Example** | `regexp_split_to_array('hello␣world; 42', ';?␣')` |
+| **Result** | Two rows: `'hello'`, `'world'` |
 
 The `regexp_matches` function is similar to the `SIMILAR TO` operator, however, it does not require the entire string to match. Instead, `regexp_matches` returns `true` if the string merely contains the pattern (unless the special tokens `^` and `$` are used to anchor the regular expression to the start and end of the string). Below are some examples:
 
@@ -40,7 +104,7 @@ SELECT regexp_matches('abc', '^(b|c).*');  -- false
 SELECT regexp_matches('abc', '(?i)A');     -- true
 ```
 
-### Options for Regular Expression Functions
+## Options for Regular Expression Functions
 
 The `regexp_matches` and `regexp_replace` functions also support the following options.
 

--- a/docs/sql/functions/time.md
+++ b/docs/sql/functions/time.md
@@ -20,16 +20,88 @@ The table below shows the available mathematical operators for `TIME` types.
 
 The table below shows the available scalar functions for `TIME` types.
 
-| Function | Description | Example | Result |
-|:--|:--|:---|:--|
-| `current_time`/`get_current_time()` | Current time (start of current transaction) | | |
-| `date_diff(`*`part`*`, `*`starttime`*`, `*`endtime`*`)` | The number of [partition](../../sql/functions/datepart) boundaries between the times | `date_diff('hour', TIME '01:02:03', TIME '06:01:03')` | `5` |
-| `date_part(`*`part`*`, `*`time`*`)` | Get [subfield](../../sql/functions/datepart) (equivalent to *extract*) | `date_part('minute', TIME '14:21:13')` | `21` |
-| `date_sub(`*`part`*`, `*`starttime`*`, `*`endtime`*`)` | The number of complete [partitions](../../sql/functions/datepart) between the times | `date_sub('hour', TIME '01:02:03', TIME '06:01:03')` | `4` |
-| `datediff(`*`part`*`, `*`starttime`*`, `*`endtime`*`)` | Alias of `date_diff`. The number of [partition](../../sql/functions/datepart) boundaries between the times | `datediff('hour', TIME '01:02:03', TIME '06:01:03')` | `5` |
-| `datepart(`*`part`*`, `*`time`*`)` | Alias of date_part. Get [subfield](../../sql/functions/datepart) (equivalent to *extract*) | `datepart('minute', TIME '14:21:13')` | `21` |
-| `datesub(`*`part`*`, `*`starttime`*`, `*`endtime`*`)` | Alias of date_sub. The number of complete [partitions](../../sql/functions/datepart) between the times | `datesub('hour', TIME '01:02:03', TIME '06:01:03')` | `4` |
-| `extract(`*`part`* `FROM` *`time`*`)` | Get subfield from a time | `extract('hour' FROM TIME '14:21:13')` | `14` |
-| `make_time(`*`bigint`*`, `*`bigint`*`, `*`double`*`)` | The time for the given parts | `make_time(13, 34, 27.123456)` | `13:34:27.123456` |
+| Name | Description |
+|:--|:-------|
+| [`current_time`/`get_current_time()`](#current_timeget_current_time) | Current time (start of current transaction). |
+| [`date_diff(`*`part`*`, `*`starttime`*`, `*`endtime`*`)`](#date_diffpart-starttime-endtime) | The number of [partition](../../sql/functions/datepart) boundaries between the times. |
+| [`date_part(`*`part`*`, `*`time`*`)`](#date_partpart-time) | Get [subfield](../../sql/functions/datepart) (equivalent to *extract*). |
+| [`date_sub(`*`part`*`, `*`starttime`*`, `*`endtime`*`)`](#date_subpart-starttime-endtime) | The number of complete [partitions](../../sql/functions/datepart) between the times. |
+| [`datediff(`*`part`*`, `*`starttime`*`, `*`endtime`*`)`](#datediffpart-starttime-endtime) | Alias of `date_diff`. The number of [partition](../../sql/functions/datepart) boundaries between the times. |
+| [`datepart(`*`part`*`, `*`time`*`)`](#datepartpart-time) | Alias of date_part. Get [subfield](../../sql/functions/datepart) (equivalent to *extract*). |
+| [`datesub(`*`part`*`, `*`starttime`*`, `*`endtime`*`)`](#datesubpart-starttime-endtime) | Alias of date_sub. The number of complete [partitions](../../sql/functions/datepart) between the times. |
+| [`extract(`*`part`* `FROM` *`time`*`)`](#extractpart-from-time) | Get subfield from a time. |
+| [`make_time(`*`bigint`*`, `*`bigint`*`, `*`double`*`)`](#make_timebigint-bigint-double) | The time for the given parts. |
 
 The only [date parts](../../sql/functions/datepart) that are defined for times are `epoch`, `hours`, `minutes`, `seconds`, `milliseconds` and `microseconds`.
+
+### `current_time`/`get_current_time()`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Current time (start of current transaction). |
+| **Example** | `get_current_time()` |
+| **Result** | `10:31:58.578` |
+
+### `date_diff(`*`part`*`, `*`starttime`*`, `*`endtime`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The number of [partition](../../sql/functions/datepart) boundaries between the times. |
+| **Example** | `date_diff('hour', TIME '01:02:03', TIME '06:01:03')` |
+| **Result** | `5` |
+
+### `date_part(`*`part`*`, `*`time`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Get [subfield](../../sql/functions/datepart) (equivalent to *extract*). |
+| **Example** | `date_part('minute', TIME '14:21:13')` |
+| **Result** | `21` |
+
+### `date_sub(`*`part`*`, `*`starttime`*`, `*`endtime`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The number of complete [partitions](../../sql/functions/datepart) between the times. |
+| **Example** | `date_sub('hour', TIME '01:02:03', TIME '06:01:03')` |
+| **Result** | `4` |
+
+### `datediff(`*`part`*`, `*`starttime`*`, `*`endtime`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Alias of `date_diff`. The number of [partition](../../sql/functions/datepart) boundaries between the times. |
+| **Example** | `datediff('hour', TIME '01:02:03', TIME '06:01:03')` |
+| **Result** | `5` |
+
+### `datepart(`*`part`*`, `*`time`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Alias of date_part. Get [subfield](../../sql/functions/datepart) (equivalent to *extract*). |
+| **Example** | `datepart('minute', TIME '14:21:13')` |
+| **Result** | `21` |
+
+### `datesub(`*`part`*`, `*`starttime`*`, `*`endtime`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Alias of date_sub. The number of complete [partitions](../../sql/functions/datepart) between the times. |
+| **Example** | `datesub('hour', TIME '01:02:03', TIME '06:01:03')` |
+| **Result** | `4` |
+
+### `extract(`*`part`* `FROM` *`time`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Get subfield from a time. |
+| **Example** | `extract('hour' FROM TIME '14:21:13')` |
+| **Result** | `14` |
+
+### `make_time(`*`bigint`*`, `*`bigint`*`, `*`double`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The time for the given parts. |
+| **Example** | `make_time(13, 34, 27.123456)` |
+| **Result** | `13:34:27.123456` |

--- a/docs/sql/functions/timestamp.md
+++ b/docs/sql/functions/timestamp.md
@@ -17,49 +17,49 @@ The table below shows the available mathematical operators for `TIMESTAMP` types
 
 Adding to or subtracting from [infinite values](../../sql/data_types/timestamp#special-values) produces the same infinite value.
 
-## Timestamp Functions
+## Scalar Timestamp Functions
 
 The table below shows the available scalar functions for `TIMESTAMP` values.
 
-| Function | Description | Example | Result |
-|:--|:--|:---|:--|
-| `age(`*`timestamp`*`, `*`timestamp`*`)` | Subtract arguments, resulting in the time difference between the two timestamps | `age(TIMESTAMP '2001-04-10', TIMESTAMP '1992-09-20')` | `8 years 6 months 20 days` |
-| `age(`*`timestamp`*`)` | Subtract from current_date | `age(TIMESTAMP '1992-09-20')` | `29 years 1 month 27 days 12:39:00.844` |
-| `century(`*`timestamp`*`)` | Extracts the century of a timestamp | `century(TIMESTAMP '1992-03-22')` | `20` |
-| `date_diff(`*`part`*`, `*`startdate`*`, `*`enddate`*`)` | The number of [partition](../../sql/functions/datepart) boundaries between the timestamps | `date_diff('hour', TIMESTAMP '1992-09-30 23:59:59', TIMESTAMP '1992-10-01 01:58:00')` | `2` |
-| `date_part([`*`part`*`, ...], `*`timestamp`*`)` | Get the listed [subfields](../../sql/functions/datepart) as a `struct`. The list must be constant. | `date_part(['year', 'month', 'day'], TIMESTAMP '1992-09-20 20:38:40')` | `{year: 1992, month: 9, day: 20}` |
-| `date_part(`*`part`*`, `*`timestamp`*`)` | Get [subfield](../../sql/functions/datepart) (equivalent to *extract*) | `date_part('minute', TIMESTAMP '1992-09-20 20:38:40')` | `38` |
-| `date_sub(`*`part`*`, `*`startdate`*`, `*`enddate`*`)` | The number of complete [partitions](../../sql/functions/datepart) between the timestamps | `date_sub('hour', TIMESTAMP '1992-09-30 23:59:59', TIMESTAMP '1992-10-01 01:58:00')` | `1` |
-| `date_trunc(`*`part`*`, `*`timestamp`*`)` | Truncate to specified [precision](../../sql/functions/datepart) | `date_trunc('hour', TIMESTAMP '1992-09-20 20:38:40')` | `1992-09-20 20:00:00` |
-| `datediff(`*`part`*`, `*`startdate`*`, `*`enddate`*`)` | Alias of date_diff. The number of [partition](../../sql/functions/datepart) boundaries between the timestamps | `datediff('hour', TIMESTAMP '1992-09-30 23:59:59', TIMESTAMP '1992-10-01 01:58:00')` | `2` |
-| `datepart([`*`part`*`, ...], `*`timestamp`*`)` | Alias of date_part. Get the listed [subfields](../../sql/functions/datepart) as a `struct`. The list must be constant. | `datepart(['year', 'month', 'day'], TIMESTAMP '1992-09-20 20:38:40')` | `{year: 1992, month: 9, day: 20}` |
-| `datepart(`*`part`*`, `*`timestamp`*`)` | Alias of date_part. Get [subfield](../../sql/functions/datepart) (equivalent to *extract*) | `datepart('minute', TIMESTAMP '1992-09-20 20:38:40')` | `38` |
-| `datesub(`*`part`*`, `*`startdate`*`, `*`enddate`*`)` | Alias of date_sub. The number of complete [partitions](../../sql/functions/datepart) between the timestamps | `datesub('hour', TIMESTAMP '1992-09-30 23:59:59', TIMESTAMP '1992-10-01 01:58:00')` | `1` |
-| `datetrunc(`*`part`*`, `*`timestamp`*`)` | Alias of date_trunc. Truncate to specified [precision](../../sql/functions/datepart) | `datetrunc('hour', TIMESTAMP '1992-09-20 20:38:40')` | `1992-09-20 20:00:00` |
-| `dayname(`*`timestamp`*`)` | The (English) name of the weekday | `dayname(TIMESTAMP '1992-03-22')` | `Sunday` |
-| `epoch_ms(`*`ms`*`)` | Converts ms since epoch to a timestamp | `epoch_ms(701222400000)` | `1992-03-22 00:00:00` |
-| `epoch_ms(`*`timestamp`*`)` | Converts a timestamp to milliseconds since the epoch | `epoch_ms('2022-11-07 08:43:04.123456'::TIMESTAMP);` | `1667810584123` |
-| `epoch_ms(`*`timestamp`*`)` | Return the total number of milliseconds since the epoch | `epoch_ms(timestamp '2021-08-03 11:59:44.123456')` | `1627991984123` |
-| `epoch_ns(`*`timestamp`*`)` | Return the total number of nanoseconds since the epoch | `epoch_ns(timestamp '2021-08-03 11:59:44.123456')` | `1627991984123456000` |
-| `epoch_us(`*`timestamp`*`)` | Return the total number of microseconds since the epoch | `epoch_ms(timestamp '2021-08-03 11:59:44.123456')` | `1627991984123456` |
-| `epoch(`*`timestamp`*`)` | Converts a timestamp to seconds since the epoch | `epoch('2022-11-07 08:43:04'::TIMESTAMP);` | `1667810584` |
-| `extract(`*`field`* `from` *`timestamp`*`)` | Get [subfield](../../sql/functions/datepart) from a timestamp | `extract('hour' FROM TIMESTAMP '1992-09-20 20:38:48')` | `20` |
-| `greatest(`*`timestamp`*`, `*`timestamp`*`)` | The later of two timestamps | `greatest(TIMESTAMP '1992-09-20 20:38:48', TIMESTAMP '1992-03-22 01:02:03.1234')` | `1992-09-20 20:38:48` |
-| `isfinite(`*`timestamp`*`)` | Returns true if the timestamp is finite, false otherwise | `isfinite(TIMESTAMP '1992-03-07')` | `true` |
-| `isinf(`*`timestamp`*`)` | Returns true if the timestamp is infinite, false otherwise | `isinf(TIMESTAMP '-infinity')` | `true` |
-| `last_day(`*`timestamp`*`)` | The last day of the month. | `last_day(TIMESTAMP '1992-03-22 01:02:03.1234')` | `1992-03-31` |
-| `least(`*`timestamp`*`, `*`timestamp`*`)` | The earlier of two timestamps | `least(TIMESTAMP '1992-09-20 20:38:48', TIMESTAMP '1992-03-22 01:02:03.1234')` | `1992-03-22 01:02:03.1234` |
-| `make_timestamp(`*`bigint`*`, `*`bigint`*`, `*`bigint`*`, `*`bigint`*`, `*`bigint`*`, `*`double`*`)` | The timestamp for the given parts | `make_timestamp(1992, 9, 20, 13, 34, 27.123456)` | `1992-09-20 13:34:27.123456` |
-| `make_timestamp(`*`microseconds`*`)` | The timestamp for the given number of µs since the epoch | `make_timestamp(1667810584123456)` | `2022-11-07 08:43:04.123456` |
-| `monthname(`*`timestamp`*`)` | The (English) name of the month. | `monthname(TIMESTAMP '1992-09-20')` | `September` |
-| `strftime(`*`timestamp`*`, `*`format`*`)` | Converts timestamp to string according to the [format string](../../sql/functions/dateformat) | `strftime(timestamp '1992-01-01 20:38:40', '%a, %-d %B %Y - %I:%M:%S %p')` | `Wed, 1 January 1992 - 08:38:40 PM` |
-| `strptime(`*`text`*`, `*`format-list`*`)` | Converts string to timestamp applying the [format strings](../../sql/functions/dateformat) in the list until one succeeds. Throws on failure. | `strptime('4/15/2023 10:56:00', ['%d/%m/%Y %H:%M:%S', '%m/%d/%Y %H:%M:%S'])` | `2023-04-15 10:56:00` |
-| `strptime(`*`text`*`, `*`format`*`)` | Converts string to timestamp according to the [format string](../../sql/functions/dateformat). Throws on failure. | `strptime('Wed, 1 January 1992 - 08:38:40 PM', '%a, %-d %B %Y - %I:%M:%S %p')` | `1992-01-01 20:38:40` |
-| `time_bucket(`*`bucket_width`*`, `*`timestamp`*`[, `*`offset`*`])` | Truncate `timestamp` by the specified interval `bucket_width`. Buckets are offset by `offset` interval. | `time_bucket(INTERVAL '10 minutes', TIMESTAMP '1992-04-20 15:26:00-07', INTERVAL '5 minutes')` | `1992-04-20 15:25:00` |
-| `time_bucket(`*`bucket_width`*`, `*`timestamp`*`[, `*`origin`*`])` | Truncate `timestamp` by the specified interval `bucket_width`. Buckets are aligned relative to `origin` timestamp. `origin` defaults to 2000-01-03 00:00:00 for buckets that don't include a month or year interval, and to 2000-01-01 00:00:00 for month and year buckets. | `time_bucket(INTERVAL '2 weeks', TIMESTAMP '1992-04-20 15:26:00', TIMESTAMP '1992-04-01 00:00:00')` | `1992-04-15 00:00:00` |
-| `to_timestamp(`*`double`*`)` | Converts seconds since the epoch to a timestamp with time zone | `to_timestamp(1284352323.5)` | `2010-09-13 04:32:03.5+00` |
-| `try_strptime(`*`text`*`, `*`format-list`*`)` | Converts string to timestamp applying the [format strings](../../sql/functions/dateformat) in the list until one succeeds. Returns `NULL` on failure. | `try_strptime('4/15/2023 10:56:00', ['%d/%m/%Y %H:%M:%S', '%m/%d/%Y %H:%M:%S'])` | `2023-04-15 10:56:00` |
-| `try_strptime(`*`text`*`, `*`format`*`)` | Converts string to timestamp according to the [format string](../../sql/functions/dateformat). Returns `NULL` on failure. | `try_strptime('Wed, 1 January 1992 - 08:38:40 PM', '%a, %-d %B %Y - %I:%M:%S %p')` | `1992-01-01 20:38:40` |
+| Name | Description |
+|:--|:-------|
+| [`age(`*`timestamp`*`, `*`timestamp`*`)`](#agetimestamp-timestamp) | Subtract arguments, resulting in the time difference between the two timestamps. |
+| [`age(`*`timestamp`*`)`](#agetimestamp) | Subtract from current_date. |
+| [`century(`*`timestamp`*`)`](#centurytimestamp) | Extracts the century of a timestamp. |
+| [`date_diff(`*`part`*`, `*`startdate`*`, `*`enddate`*`)`](#date_diffpart-startdate-enddate) | The number of [partition](../../sql/functions/datepart) boundaries between the timestamps. |
+| [`date_part([`*`part`*`, ...], `*`timestamp`*`)`](#date_partpart--timestamp) | Get the listed [subfields](../../sql/functions/datepart) as a `struct`. The list must be constant. |
+| [`date_part(`*`part`*`, `*`timestamp`*`)`](#date_partpart-timestamp) | Get [subfield](../../sql/functions/datepart) (equivalent to *extract*). |
+| [`date_sub(`*`part`*`, `*`startdate`*`, `*`enddate`*`)`](#date_subpart-startdate-enddate) | The number of complete [partitions](../../sql/functions/datepart) between the timestamps. |
+| [`date_trunc(`*`part`*`, `*`timestamp`*`)`](#date_truncpart-timestamp) | Truncate to specified [precision](../../sql/functions/datepart). |
+| [`datediff(`*`part`*`, `*`startdate`*`, `*`enddate`*`)`](#datediffpart-startdate-enddate) | Alias of date_diff. The number of [partition](../../sql/functions/datepart) boundaries between the timestamps. |
+| [`datepart([`*`part`*`, ...], `*`timestamp`*`)`](#datepartpart--timestamp) | Alias of date_part. Get the listed [subfields](../../sql/functions/datepart) as a `struct`. The list must be constant. |
+| [`datepart(`*`part`*`, `*`timestamp`*`)`](#datepartpart-timestamp) | Alias of date_part. Get [subfield](../../sql/functions/datepart) (equivalent to *extract*). |
+| [`datesub(`*`part`*`, `*`startdate`*`, `*`enddate`*`)`](#datesubpart-startdate-enddate) | Alias of date_sub. The number of complete [partitions](../../sql/functions/datepart) between the timestamps. |
+| [`datetrunc(`*`part`*`, `*`timestamp`*`)`](#datetruncpart-timestamp) | Alias of date_trunc. Truncate to specified [precision](../../sql/functions/datepart). |
+| [`dayname(`*`timestamp`*`)`](#daynametimestamp) | The (English) name of the weekday. |
+| [`epoch_ms(`*`ms`*`)`](#epoch_msms) | Converts ms since epoch to a timestamp. |
+| [`epoch_ms(`*`timestamp`*`)`](#epoch_mstimestamp) | Converts a timestamp to milliseconds since the epoch. |
+| [`epoch_ms(`*`timestamp`*`)`](#epoch_mstimestamp) | Return the total number of milliseconds since the epoch. |
+| [`epoch_ns(`*`timestamp`*`)`](#epoch_nstimestamp) | Return the total number of nanoseconds since the epoch. |
+| [`epoch_us(`*`timestamp`*`)`](#epoch_ustimestamp) | Return the total number of microseconds since the epoch. |
+| [`epoch(`*`timestamp`*`)`](#epochtimestamp) | Converts a timestamp to seconds since the epoch. |
+| [`extract(`*`field`* `from` *`timestamp`*`)`](#extractfieldfromtimestamp) | Get [subfield](../../sql/functions/datepart) from a timestamp. |
+| [`greatest(`*`timestamp`*`, `*`timestamp`*`)`](#greatesttimestamp-timestamp) | The later of two timestamps. |
+| [`isfinite(`*`timestamp`*`)`](#isfinitetimestamp) | Returns true if the timestamp is finite, false otherwise. |
+| [`isinf(`*`timestamp`*`)`](#isinftimestamp) | Returns true if the timestamp is infinite, false otherwise. |
+| [`last_day(`*`timestamp`*`)`](#last_daytimestamp) | The last day of the month. |
+| [`least(`*`timestamp`*`, `*`timestamp`*`)`](#leasttimestamp-timestamp) | The earlier of two timestamps. |
+| [`make_timestamp(`*`bigint`*`, `*`bigint`*`, `*`bigint`*`, `*`bigint`*`, `*`bigint`*`, `*`double`*`)`](#make_timestampbigint-bigint-bigint-bigint-bigint-double) | The timestamp for the given parts. |
+| [`make_timestamp(`*`microseconds`*`)`](#make_timestampmicroseconds) | The timestamp for the given number of µs since the epoch. |
+| [`monthname(`*`timestamp`*`)`](#monthnametimestamp) | The (English) name of the month. |
+| [`strftime(`*`timestamp`*`, `*`format`*`)`](#strftimetimestamp-format) | Converts timestamp to string according to the [format string](../../sql/functions/dateformat). |
+| [`strptime(`*`text`*`, `*`format-list`*`)`](#strptimetext-format-list) | Converts string to timestamp applying the [format strings](../../sql/functions/dateformat) in the list until one succeeds. Throws on failure. |
+| [`strptime(`*`text`*`, `*`format`*`)`](#strptimetext-format) | Converts string to timestamp according to the [format string](../../sql/functions/dateformat). Throws on failure. |
+| [`time_bucket(`*`bucket_width`*`, `*`timestamp`*`[, `*`offset`*`])`](#time_bucketbucket_width-timestamp-offset) | Truncate `timestamp` by the specified interval `bucket_width`. Buckets are offset by `offset` interval. |
+| [`time_bucket(`*`bucket_width`*`, `*`timestamp`*`[, `*`origin`*`])`](#time_bucketbucket_width-timestamp-origin) | Truncate `timestamp` by the specified interval `bucket_width`. Buckets are aligned relative to `origin` timestamp. `origin` defaults to 2000-01-03 00:00:00 for buckets that don't include a month or year interval, and to 2000-01-01 00:00:00 for month and year buckets. |
+| [`to_timestamp(`*`double`*`)`](#to_timestampdouble) | Converts seconds since the epoch to a timestamp with time zone. |
+| [`try_strptime(`*`text`*`, `*`format-list`*`)`](#try_strptimetext-format-list) | Converts string to timestamp applying the [format strings](../../sql/functions/dateformat) in the list until one succeeds. Returns `NULL` on failure. |
+| [`try_strptime(`*`text`*`, `*`format`*`)`](#try_strptimetext-format) | Converts string to timestamp according to the [format string](../../sql/functions/dateformat). Returns `NULL` on failure. |
 
 There are also dedicated extraction functions to get the [subfields](../../sql/functions/datepart).
 
@@ -67,13 +67,323 @@ Functions applied to infinite dates will either return the same infinite dates
 (e.g, `greatest`) or `NULL` (e.g., `date_part`) depending on what "makes sense".
 In general, if the function needs to examine the parts of the infinite date, the result will be `NULL`.
 
+### `age(`*`timestamp`*`, `*`timestamp`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Subtract arguments, resulting in the time difference between the two timestamps. |
+| **Example** | `age(TIMESTAMP '2001-04-10', TIMESTAMP '1992-09-20')` |
+| **Result** | `8 years 6 months 20 days` |
+
+### `age(`*`timestamp`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Subtract from current_date. |
+| **Example** | `age(TIMESTAMP '1992-09-20')` |
+| **Result** | `29 years 1 month 27 days 12:39:00.844` |
+
+### `century(`*`timestamp`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Extracts the century of a timestamp. |
+| **Example** | `century(TIMESTAMP '1992-03-22')` |
+| **Result** | `20` |
+
+### `date_diff(`*`part`*`, `*`startdate`*`, `*`enddate`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The number of [partition](../../sql/functions/datepart) boundaries between the timestamps. |
+| **Example** | `date_diff('hour', TIMESTAMP '1992-09-30 23:59:59', TIMESTAMP '1992-10-01 01:58:00')` |
+| **Result** | `2` |
+
+### `date_part([`*`part`*`, ...], `*`timestamp`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Get the listed [subfields](../../sql/functions/datepart) as a `struct`. The list must be constant. |
+| **Example** | `date_part(['year', 'month', 'day'], TIMESTAMP '1992-09-20 20:38:40')` |
+| **Result** | `{year: 1992, month: 9, day: 20}` |
+
+### `date_part(`*`part`*`, `*`timestamp`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Get [subfield](../../sql/functions/datepart) (equivalent to *extract*). |
+| **Example** | `date_part('minute', TIMESTAMP '1992-09-20 20:38:40')` |
+| **Result** | `38` |
+
+### `date_sub(`*`part`*`, `*`startdate`*`, `*`enddate`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The number of complete [partitions](../../sql/functions/datepart) between the timestamps. |
+| **Example** | `date_sub('hour', TIMESTAMP '1992-09-30 23:59:59', TIMESTAMP '1992-10-01 01:58:00')` |
+| **Result** | `1` |
+
+### `date_trunc(`*`part`*`, `*`timestamp`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Truncate to specified [precision](../../sql/functions/datepart). |
+| **Example** | `date_trunc('hour', TIMESTAMP '1992-09-20 20:38:40')` |
+| **Result** | `1992-09-20 20:00:00` |
+
+### `datediff(`*`part`*`, `*`startdate`*`, `*`enddate`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Alias of date_diff. The number of [partition](../../sql/functions/datepart) boundaries between the timestamps. |
+| **Example** | `datediff('hour', TIMESTAMP '1992-09-30 23:59:59', TIMESTAMP '1992-10-01 01:58:00')` |
+| **Result** | `2` |
+
+### `datepart([`*`part`*`, ...], `*`timestamp`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Alias of date_part. Get the listed [subfields](../../sql/functions/datepart) as a `struct`. The list must be constant. |
+| **Example** | `datepart(['year', 'month', 'day'], TIMESTAMP '1992-09-20 20:38:40')` |
+| **Result** | `{year: 1992, month: 9, day: 20}` |
+
+### `datepart(`*`part`*`, `*`timestamp`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Alias of date_part. Get [subfield](../../sql/functions/datepart) (equivalent to *extract*). |
+| **Example** | `datepart('minute', TIMESTAMP '1992-09-20 20:38:40')` |
+| **Result** | `38` |
+
+### `datesub(`*`part`*`, `*`startdate`*`, `*`enddate`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Alias of date_sub. The number of complete [partitions](../../sql/functions/datepart) between the timestamps. |
+| **Example** | `datesub('hour', TIMESTAMP '1992-09-30 23:59:59', TIMESTAMP '1992-10-01 01:58:00')` |
+| **Result** | `1` |
+
+### `datetrunc(`*`part`*`, `*`timestamp`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Alias of date_trunc. Truncate to specified [precision](../../sql/functions/datepart). |
+| **Example** | `datetrunc('hour', TIMESTAMP '1992-09-20 20:38:40')` |
+| **Result** | `1992-09-20 20:00:00` |
+
+### `dayname(`*`timestamp`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The (English) name of the weekday. |
+| **Example** | `dayname(TIMESTAMP '1992-03-22')` |
+| **Result** | `Sunday` |
+
+### `epoch_ms(`*`ms`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Converts ms since epoch to a timestamp. |
+| **Example** | `epoch_ms(701222400000)` |
+| **Result** | `1992-03-22 00:00:00` |
+
+### `epoch_ms(`*`timestamp`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Converts a timestamp to milliseconds since the epoch. |
+| **Example** | `epoch_ms('2022-11-07 08:43:04.123456'::TIMESTAMP);` |
+| **Result** | `1667810584123` |
+
+### `epoch_ms(`*`timestamp`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Return the total number of milliseconds since the epoch. |
+| **Example** | `epoch_ms(timestamp '2021-08-03 11:59:44.123456')` |
+| **Result** | `1627991984123` |
+
+### `epoch_ns(`*`timestamp`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Return the total number of nanoseconds since the epoch. |
+| **Example** | `epoch_ns(timestamp '2021-08-03 11:59:44.123456')` |
+| **Result** | `1627991984123456000` |
+
+### `epoch_us(`*`timestamp`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Return the total number of microseconds since the epoch. |
+| **Example** | `epoch_ms(timestamp '2021-08-03 11:59:44.123456')` |
+| **Result** | `1627991984123456` |
+
+### `epoch(`*`timestamp`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Converts a timestamp to seconds since the epoch. |
+| **Example** | `epoch('2022-11-07 08:43:04'::TIMESTAMP);` |
+| **Result** | `1667810584` |
+
+### `extract(`*`field`* `from` *`timestamp`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Get [subfield](../../sql/functions/datepart) from a timestamp. |
+| **Example** | `extract('hour' FROM TIMESTAMP '1992-09-20 20:38:48')` |
+| **Result** | `20` |
+
+### `greatest(`*`timestamp`*`, `*`timestamp`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The later of two timestamps. |
+| **Example** | `greatest(TIMESTAMP '1992-09-20 20:38:48', TIMESTAMP '1992-03-22 01:02:03.1234')` |
+| **Result** | `1992-09-20 20:38:48` |
+
+### `isfinite(`*`timestamp`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns true if the timestamp is finite, false otherwise. |
+| **Example** | `isfinite(TIMESTAMP '1992-03-07')` |
+| **Result** | `true` |
+
+### `isinf(`*`timestamp`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns true if the timestamp is infinite, false otherwise. |
+| **Example** | `isinf(TIMESTAMP '-infinity')` |
+| **Result** | `true` |
+
+### `last_day(`*`timestamp`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The last day of the month. |
+| **Example** | `last_day(TIMESTAMP '1992-03-22 01:02:03.1234')` |
+| **Result** | `1992-03-31` |
+
+### `least(`*`timestamp`*`, `*`timestamp`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The earlier of two timestamps. |
+| **Example** | `least(TIMESTAMP '1992-09-20 20:38:48', TIMESTAMP '1992-03-22 01:02:03.1234')` |
+| **Result** | `1992-03-22 01:02:03.1234` |
+
+### `make_timestamp(`*`bigint`*`, `*`bigint`*`, `*`bigint`*`, `*`bigint`*`, `*`bigint`*`, `*`double`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The timestamp for the given parts. |
+| **Example** | `make_timestamp(1992, 9, 20, 13, 34, 27.123456)` |
+| **Result** | `1992-09-20 13:34:27.123456` |
+
+### `make_timestamp(`*`microseconds`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The timestamp for the given number of µs since the epoch. |
+| **Example** | `make_timestamp(1667810584123456)` |
+| **Result** | `2022-11-07 08:43:04.123456` |
+
+### `monthname(`*`timestamp`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The (English) name of the month. |
+| **Example** | `monthname(TIMESTAMP '1992-09-20')` |
+| **Result** | `September` |
+
+### `strftime(`*`timestamp`*`, `*`format`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Converts timestamp to string according to the [format string](../../sql/functions/dateformat). |
+| **Example** | `strftime(timestamp '1992-01-01 20:38:40', '%a, %-d %B %Y - %I:%M:%S %p')` |
+| **Result** | `Wed, 1 January 1992 - 08:38:40 PM` |
+
+### `strptime(`*`text`*`, `*`format-list`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Converts string to timestamp applying the [format strings](../../sql/functions/dateformat) in the list until one succeeds. Throws on failure. |
+| **Example** | `strptime('4/15/2023 10:56:00', ['%d/%m/%Y %H:%M:%S', '%m/%d/%Y %H:%M:%S'])` |
+| **Result** | `2023-04-15 10:56:00` |
+
+### `strptime(`*`text`*`, `*`format`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Converts string to timestamp according to the [format string](../../sql/functions/dateformat). Throws on failure. |
+| **Example** | `strptime('Wed, 1 January 1992 - 08:38:40 PM', '%a, %-d %B %Y - %I:%M:%S %p')` |
+| **Result** | `1992-01-01 20:38:40` |
+
+### `time_bucket(`*`bucket_width`*`, `*`timestamp`*`[, `*`offset`*`])`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Truncate `timestamp` by the specified interval `bucket_width`. Buckets are offset by `offset` interval. |
+| **Example** | `time_bucket(INTERVAL '10 minutes', TIMESTAMP '1992-04-20 15:26:00-07', INTERVAL '5 minutes')` |
+| **Result** | `1992-04-20 15:25:00` |
+
+### `time_bucket(`*`bucket_width`*`, `*`timestamp`*`[, `*`origin`*`])`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Truncate `timestamp` by the specified interval `bucket_width`. Buckets are aligned relative to `origin` timestamp. `origin` defaults to 2000-01-03 00:00:00 for buckets that don't include a month or year interval, and to 2000-01-01 00:00:00 for month and year buckets. |
+| **Example** | `time_bucket(INTERVAL '2 weeks', TIMESTAMP '1992-04-20 15:26:00', TIMESTAMP '1992-04-01 00:00:00')` |
+| **Result** | `1992-04-15 00:00:00` |
+
+### `to_timestamp(`*`double`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Converts seconds since the epoch to a timestamp with time zone. |
+| **Example** | `to_timestamp(1284352323.5)` |
+| **Result** | `2010-09-13 04:32:03.5+00` |
+
+### `try_strptime(`*`text`*`, `*`format-list`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Converts string to timestamp applying the [format strings](../../sql/functions/dateformat) in the list until one succeeds. Returns `NULL` on failure. |
+| **Example** | `try_strptime('4/15/2023 10:56:00', ['%d/%m/%Y %H:%M:%S', '%m/%d/%Y %H:%M:%S'])` |
+| **Result** | `2023-04-15 10:56:00` |
+
+### `try_strptime(`*`text`*`, `*`format`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Converts string to timestamp according to the [format string](../../sql/functions/dateformat). Returns `NULL` on failure. |
+| **Example** | `try_strptime('Wed, 1 January 1992 - 08:38:40 PM', '%a, %-d %B %Y - %I:%M:%S %p')` |
+| **Result** | `1992-01-01 20:38:40` |
+
 ## Timestamp Table Functions
 
 The table below shows the available table functions for `TIMESTAMP` types.
 
-| Function | Description | Example |
-|:--|:--|:---|
-| `generate_series(`*`timestamp`*`, `*`timestamp`*`, `*`interval`*`)` | Generate a table of timestamps in the closed range, stepping by the interval | `generate_series(TIMESTAMP '2001-04-10', TIMESTAMP '2001-04-11', INTERVAL 30 MINUTE)` |
-| `range(`*`timestamp`*`, `*`timestamp`*`, `*`interval`*`)` | Generate a table of timestamps in the half open range, stepping by the interval | `range(TIMESTAMP '2001-04-10', TIMESTAMP '2001-04-11', INTERVAL 30 MINUTE)` |
+| Name | Description |
+|:--|:-------|
+| [`generate_series(`*`timestamp`*`, `*`timestamp`*`, `*`interval`*`)`](#generate_seriestimestamp-timestamp-interval) | Generate a table of timestamps in the closed range, stepping by the interval. |
+| [`range(`*`timestamp`*`, `*`timestamp`*`, `*`interval`*`)`](#rangetimestamp-timestamp-interval) | Generate a table of timestamps in the half open range, stepping by the interval. |
 
 > Infinite values are not allowed as table function bounds.
+
+### `generate_series(`*`timestamp`*`, `*`timestamp`*`, `*`interval`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Generate a table of timestamps in the closed range, stepping by the interval. |
+| **Example** | `generate_series(TIMESTAMP '2001-04-10', TIMESTAMP '2001-04-11', INTERVAL 30 MINUTE)` |
+
+### `range(`*`timestamp`*`, `*`timestamp`*`, `*`interval`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Generate a table of timestamps in the half open range, stepping by the interval. |
+| **Example** | `range(TIMESTAMP '2001-04-10', TIMESTAMP '2001-04-11', INTERVAL 30 MINUTE)` |

--- a/docs/sql/functions/timestamptz.md
+++ b/docs/sql/functions/timestamptz.md
@@ -21,16 +21,80 @@ The table below shows the available scalar functions for `TIMESTAMPTZ` values.
 Since these functions do not involve binning or display,
 they are always available.
 
-| Function | Description | Example | Result |
-|:--|:--|:---|:--|
-| `current_timestamp` | Current date and time (start of current transaction) | `current_timestamp` | `2022-10-08 12:44:46.122-07` |
-| `get_current_timestamp()` | Current date and time (start of current transaction) | `get_current_timestamp()` | `2022-10-08 12:44:46.122-07` |
-| `greatest(`*`timestamptz`*`, `*`timestamptz`*`)` | The later of two timestamps | `greatest(TIMESTAMPTZ '1992-09-20 20:38:48', TIMESTAMPTZ '1992-03-22 01:02:03.1234')` | `1992-09-20 20:38:48-07` |
-| `isfinite(`*`timestamptz`*`)` | Returns true if the timestamp with time zone is finite, false otherwise | `isfinite(TIMESTAMPTZ '1992-03-07')` | `true` |
-| `isinf(`*`timestamptz`*`)` | Returns true if the timestamp with time zone is infinite, false otherwise | `isinf(TIMESTAMPTZ '-infinity')` | `true` |
-| `least(`*`timestamptz`*`, `*`timestamptz`*`)` | The earlier of two timestamps | `least(TIMESTAMPTZ '1992-09-20 20:38:48', TIMESTAMPTZ '1992-03-22 01:02:03.1234')` | `1992-03-22 01:02:03.1234-08` |
-| `now()` | Current date and time (start of current transaction) | `now()` | `2022-10-08 12:44:46.122-07`|
-| `transaction_timestamp()` | Current date and time (start of current transaction) | `transaction_timestamp()` | `2022-10-08 12:44:46.122-07`|
+| Name | Description |
+|:--|:-------|
+| [`current_timestamp`](#current_timestamp) | Current date and time (start of current transaction). |
+| [`get_current_timestamp()`](#get_current_timestamp) | Current date and time (start of current transaction). |
+| [`greatest(`*`timestamptz`*`, `*`timestamptz`*`)`](#greatesttimestamptz-timestamptz) | The later of two timestamps. |
+| [`isfinite(`*`timestamptz`*`)`](#isfinitetimestamptz) | Returns true if the timestamp with time zone is finite, false otherwise. |
+| [`isinf(`*`timestamptz`*`)`](#isinftimestamptz) | Returns true if the timestamp with time zone is infinite, false otherwise. |
+| [`least(`*`timestamptz`*`, `*`timestamptz`*`)`](#leasttimestamptz-timestamptz) | The earlier of two timestamps. |
+| [`now()`](#now) | Current date and time (start of current transaction). |
+| [`transaction_timestamp()`](#transaction_timestamp) | Current date and time (start of current transaction). |
+
+### `current_timestamp`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Current date and time (start of current transaction). |
+| **Example** | `current_timestamp` |
+| **Result** | `2022-10-08 12:44:46.122-07` |
+
+### `get_current_timestamp()`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Current date and time (start of current transaction). |
+| **Example** | `get_current_timestamp()` |
+| **Result** | `2022-10-08 12:44:46.122-07` |
+
+### `greatest(`*`timestamptz`*`, `*`timestamptz`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The later of two timestamps. |
+| **Example** | `greatest(TIMESTAMPTZ '1992-09-20 20:38:48', TIMESTAMPTZ '1992-03-22 01:02:03.1234')` |
+| **Result** | `1992-09-20 20:38:48-07` |
+
+### `isfinite(`*`timestamptz`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns true if the timestamp with time zone is finite, false otherwise. |
+| **Example** | `isfinite(TIMESTAMPTZ '1992-03-07')` |
+| **Result** | `true` |
+
+### `isinf(`*`timestamptz`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns true if the timestamp with time zone is infinite, false otherwise. |
+| **Example** | `isinf(TIMESTAMPTZ '-infinity')` |
+| **Result** | `true` |
+
+### `least(`*`timestamptz`*`, `*`timestamptz`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The earlier of two timestamps. |
+| **Example** | `least(TIMESTAMPTZ '1992-09-20 20:38:48', TIMESTAMPTZ '1992-03-22 01:02:03.1234')` |
+| **Result** | `1992-03-22 01:02:03.1234-08` |
+
+### `now()`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Current date and time (start of current transaction). |
+| **Example** | `now()` |
+| **Result** | `2022-10-08 12:44:46.122-07` |
+
+### `transaction_timestamp()`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Current date and time (start of current transaction). |
+| **Example** | `transaction_timestamp()` |
+| **Result** | `2022-10-08 12:44:46.122-07` |
 
 ## Timestamp with Time Zone Strings
 
@@ -69,33 +133,233 @@ Adding to or subtracting from [infinite values](../../sql/data_types/timestamp#s
 
 The table below shows the ICU provided scalar functions for `TIMESTAMP WITH TIME ZONE` values.
 
-| Function | Description | Example | Result |
-|:---|:---|:---|:---|
-| `age(`*`timestamptz`*`, `*`timestamptz`*`)` | Subtract arguments, resulting in the time difference between the two timestamps | `age(TIMESTAMPTZ '2001-04-10', TIMESTAMPTZ '1992-09-20')` | `8 years 6 months 20 days` |
-| `age(`*`timestamptz`*`)` | Subtract from current_date | `age(TIMESTAMP '1992-09-20')` | `29 years 1 month 27 days 12:39:00.844` |
-| `date_diff(`*`part`*`, `*`startdate`*`, `*`enddate`*`)` | The number of [partition](../../sql/functions/datepart) boundaries between the timestamps | `date_diff('hour', TIMESTAMPTZ '1992-09-30 23:59:59', TIMESTAMPTZ '1992-10-01 01:58:00')` | `2` |
-| `date_part([`*`part`*`, ...], `*`timestamptz`*`)` | Get the listed [subfields](../../sql/functions/datepart) as a `struct`. The list must be constant. | `date_part(['year', 'month', 'day'], TIMESTAMPTZ '1992-09-20 20:38:40-07')` | `{year: 1992, month: 9, day: 20}` |
-| `date_part(`*`part`*`, `*`timestamptz`*`)` | Get [subfield](../../sql/functions/datepart) (equivalent to *extract*) | `date_part('minute', TIMESTAMPTZ '1992-09-20 20:38:40')` | `38` |
-| `date_sub(`*`part`*`, `*`startdate`*`, `*`enddate`*`)` | The number of complete [partitions](../../sql/functions/datepart) between the timestamps | `date_sub('hour', TIMESTAMPTZ '1992-09-30 23:59:59', TIMESTAMPTZ '1992-10-01 01:58:00')` | `1` |
-| `date_trunc(`*`part`*`, `*`timestamptz`*`)` | Truncate to specified [precision](../../sql/functions/datepart) | `date_trunc('hour', TIMESTAMPTZ '1992-09-20 20:38:40')` | `1992-09-20 20:00:00` |
-| `datediff(`*`part`*`, `*`startdate`*`, `*`enddate`*`)` | Alias of date_diff. The number of [partition](../../sql/functions/datepart) boundaries between the timestamps | `datediff('hour', TIMESTAMPTZ '1992-09-30 23:59:59', TIMESTAMPTZ '1992-10-01 01:58:00')` | `2` |
-| `datepart([`*`part`*`, ...], `*`timestamptz`*`)` | Alias of date_part. Get the listed [subfields](../../sql/functions/datepart) as a `struct`. The list must be constant. | `datepart(['year', 'month', 'day'], TIMESTAMPTZ '1992-09-20 20:38:40-07')` | `{year: 1992, month: 9, day: 20}` |
-| `datepart(`*`part`*`, `*`timestamptz`*`)` | Alias of date_part. Get [subfield](../../sql/functions/datepart) (equivalent to *extract*) | `datepart('minute', TIMESTAMPTZ '1992-09-20 20:38:40')` | `38` |
-| `datesub(`*`part`*`, `*`startdate`*`, `*`enddate`*`)` | Alias of date_sub. The number of complete [partitions](../../sql/functions/datepart) between the timestamps | `datesub('hour', TIMESTAMPTZ '1992-09-30 23:59:59', TIMESTAMPTZ '1992-10-01 01:58:00')` | `1` |
-| `datetrunc(`*`part`*`, `*`timestamptz`*`)` | Alias of date_trunc. Truncate to specified [precision](../../sql/functions/datepart) | `datetrunc('hour', TIMESTAMPTZ '1992-09-20 20:38:40')` | `1992-09-20 20:00:00` |
-| `epoch_ms(`*`timestamptz`*`)` | Converts a timestamptz to milliseconds since the epoch | `epoch_ms('2022-11-07 08:43:04.123456+00'::TIMESTAMPTZ);` | `1667810584123` |
-| `epoch_ns(`*`timestamptz`*`)` | Converts a timestamptz to nanoseconds since the epoch | `epoch_ns('2022-11-07 08:43:04.123456+00'::TIMESTAMPTZ);` | `1667810584123456000` |
-| `epoch_us(`*`timestamptz`*`)` | Converts a timestamptz to microseconds since the epoch | `epoch_us('2022-11-07 08:43:04.123456+00'::TIMESTAMPTZ);` | `1667810584123456` |
-| `extract(`*`field`* `from` *`timestamptz`*`)` | Get [subfield](../../sql/functions/datepart) from a timestamp with time zone | `extract('hour' FROM TIMESTAMPTZ '1992-09-20 20:38:48')` | `20` |
-| `last_day(`*`timestamptz`*`)` | The last day of the month. | `last_day(TIMESTAMPTZ '1992-03-22 01:02:03.1234')` | `1992-03-31` |
-| `make_timestamptz(`*`bigint`*`, `*`bigint`*`, `*`bigint`*`, `*`bigint`*`, `*`bigint`*`, `*`double`*`, `*`string`*`)` | The timestamp with time zone for the given parts and time zone | `make_timestamptz(1992, 9, 20, 15, 34, 27.123456, 'CET')` | `1992-09-20 06:34:27.123456-07` |
-| `make_timestamptz(`*`bigint`*`, `*`bigint`*`, `*`bigint`*`, `*`bigint`*`, `*`bigint`*`, `*`double`*`)` | The timestamp with time zone for the given parts in the current time zone | `make_timestamptz(1992, 9, 20, 13, 34, 27.123456)` | `1992-09-20 13:34:27.123456-07` |
-| `make_timestamptz(`*`microseconds`*`)` | The timestamp with time zone for the given µs since the epoch | `make_timestamptz(1667810584123456)` | `2022-11-07 16:43:04.123456-08` |
-| `strftime(`*`timestamptz`*`, `*`format`*`)` | Converts timestamp with time zone to string according to the [format string](../../sql/functions/dateformat) | `strftime(timestamptz '1992-01-01 20:38:40', '%a, %-d %B %Y - %I:%M:%S %p')` | `Wed, 1 January 1992 - 08:38:40 PM` |
-| `strptime(`*`text`*`, `*`format`*`)` | Converts string to timestamp with time zone according to the [format string](../../sql/functions/dateformat) if `%Z` is specified. | `strptime('Wed, 1 January 1992 - 08:38:40 PST', '%a, %-d %B %Y - %H:%M:%S %Z')` | `1992-01-01 08:38:40-08` |
-| `time_bucket(`*`bucket_width`*`, `*`timestamptz`*`[, `*`offset`*`])` | Truncate `timestamptz` by the specified interval `bucket_width`. Buckets are offset by `offset` interval. | `time_bucket(INTERVAL '10 minutes', TIMESTAMPTZ '1992-04-20 15:26:00-07', INTERVAL '5 minutes')` | `1992-04-20 15:25:00-07` |
-| `time_bucket(`*`bucket_width`*`, `*`timestamptz`*`[, `*`origin`*`])` | Truncate `timestamptz` by the specified interval `bucket_width`. Buckets are aligned relative to `origin` timestamptz. `origin` defaults to 2000-01-03 00:00:00+00 for buckets that don't include a month or year interval, and to 2000-01-01 00:00:00+00 for month and year buckets. | `time_bucket(INTERVAL '2 weeks', TIMESTAMPTZ '1992-04-20 15:26:00-07', TIMESTAMPTZ '1992-04-01 00:00:00-07')` | `1992-04-15 00:00:00-07` |
-| `time_bucket(`*`bucket_width`*`, `*`timestamptz`*`[, `*`timezone`*`])` | Truncate `timestamptz` by the specified interval `bucket_width`. Bucket starts and ends are calculated using `timezone`. `timezone` is a varchar and defaults to UTC. | `time_bucket(INTERVAL '2 days', TIMESTAMPTZ '1992-04-20 15:26:00-07', 'Europe/Berlin')` | `1992-04-19 15:00:00-07` |
+| Name | Description |
+|:--|:-------|
+| [`age(`*`timestamptz`*`, `*`timestamptz`*`)`](#agetimestamptz-timestamptz) | Subtract arguments, resulting in the time difference between the two timestamps. |
+| [`age(`*`timestamptz`*`)`](#agetimestamptz) | Subtract from current_date. |
+| [`date_diff(`*`part`*`, `*`startdate`*`, `*`enddate`*`)`](#date_diffpart-startdate-enddate) | The number of [partition](../../sql/functions/datepart) boundaries between the timestamps. |
+| [`date_part([`*`part`*`, ...], `*`timestamptz`*`)`](#date_partpart--timestamptz) | Get the listed [subfields](../../sql/functions/datepart) as a `struct`. The list must be constant. |
+| [`date_part(`*`part`*`, `*`timestamptz`*`)`](#date_partpart-timestamptz) | Get [subfield](../../sql/functions/datepart) (equivalent to *extract*). |
+| [`date_sub(`*`part`*`, `*`startdate`*`, `*`enddate`*`)`](#date_subpart-startdate-enddate) | The number of complete [partitions](../../sql/functions/datepart) between the timestamps. |
+| [`date_trunc(`*`part`*`, `*`timestamptz`*`)`](#date_truncpart-timestamptz) | Truncate to specified [precision](../../sql/functions/datepart). |
+| [`datediff(`*`part`*`, `*`startdate`*`, `*`enddate`*`)`](#datediffpart-startdate-enddate) | Alias of date_diff. The number of [partition](../../sql/functions/datepart) boundaries between the timestamps. |
+| [`datepart([`*`part`*`, ...], `*`timestamptz`*`)`](#datepartpart--timestamptz) | Alias of date_part. Get the listed [subfields](../../sql/functions/datepart) as a `struct`. The list must be constant. |
+| [`datepart(`*`part`*`, `*`timestamptz`*`)`](#datepartpart-timestamptz) | Alias of date_part. Get [subfield](../../sql/functions/datepart) (equivalent to *extract*). |
+| [`datesub(`*`part`*`, `*`startdate`*`, `*`enddate`*`)`](#datesubpart-startdate-enddate) | Alias of date_sub. The number of complete [partitions](../../sql/functions/datepart) between the timestamps. |
+| [`datetrunc(`*`part`*`, `*`timestamptz`*`)`](#datetruncpart-timestamptz) | Alias of date_trunc. Truncate to specified [precision](../../sql/functions/datepart). |
+| [`epoch_ms(`*`timestamptz`*`)`](#epoch_mstimestamptz) | Converts a timestamptz to milliseconds since the epoch. |
+| [`epoch_ns(`*`timestamptz`*`)`](#epoch_nstimestamptz) | Converts a timestamptz to nanoseconds since the epoch. |
+| [`epoch_us(`*`timestamptz`*`)`](#epoch_ustimestamptz) | Converts a timestamptz to microseconds since the epoch. |
+| [`extract(`*`field`* `from` *`timestamptz`*`)`](#extractfieldfromtimestamptz) | Get [subfield](../../sql/functions/datepart) from a `TIMESTAMP WITH TIME ZONE`. |
+| [`last_day(`*`timestamptz`*`)`](#last_daytimestamptz) | The last day of the month. |
+| [`make_timestamptz(`*`bigint`*`, `*`bigint`*`, `*`bigint`*`, `*`bigint`*`, `*`bigint`*`, `*`double`*`, `*`string`*`)`](#make_timestamptzbigint-bigint-bigint-bigint-bigint-double-string) | The `TIMESTAMP WITH TIME ZONE` for the given parts and time zone. |
+| [`make_timestamptz(`*`bigint`*`, `*`bigint`*`, `*`bigint`*`, `*`bigint`*`, `*`bigint`*`, `*`double`*`)`](#make_timestamptzbigint-bigint-bigint-bigint-bigint-double) | The `TIMESTAMP WITH TIME ZONE` for the given parts in the current time zone. |
+| [`make_timestamptz(`*`microseconds`*`)`](#make_timestamptzmicroseconds) | The `TIMESTAMP WITH TIME ZONE` for the given µs since the epoch. |
+| [`strftime(`*`timestamptz`*`, `*`format`*`)`](#strftimetimestamptz-format) | Converts a `TIMESTAMP WITH TIME ZONE` value to string according to the [format string](../../sql/functions/dateformat). |
+| [`strptime(`*`text`*`, `*`format`*`)`](#strptimetext-format) | Converts string to `TIMESTAMP WITH TIME ZONE` according to the [format string](../../sql/functions/dateformat) if `%Z` is specified. |
+| [`time_bucket(`*`bucket_width`*`, `*`timestamptz`*`[, `*`offset`*`])`](#time_bucketbucket_width-timestamptz-offset) | Truncate `timestamptz` by the specified interval `bucket_width`. Buckets are offset by `offset` interval. |
+| [`time_bucket(`*`bucket_width`*`, `*`timestamptz`*`[, `*`origin`*`])`](#time_bucketbucket_width-timestamptz-origin) | Truncate `timestamptz` by the specified interval `bucket_width`. Buckets are aligned relative to `origin` timestamptz. `origin` defaults to 2000-01-03 00:00:00+00 for buckets that don't include a month or year interval, and to 2000-01-01 00:00:00+00 for month and year buckets. |
+| [`time_bucket(`*`bucket_width`*`, `*`timestamptz`*`[, `*`timezone`*`])`](#time_bucketbucket_width-timestamptz-timezone) | Truncate `timestamptz` by the specified interval `bucket_width`. Bucket starts and ends are calculated using `timezone`. `timezone` is a varchar and defaults to UTC. |
+
+### `age(`*`timestamptz`*`, `*`timestamptz`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Subtract arguments, resulting in the time difference between the two timestamps. |
+| **Example** | `age(TIMESTAMPTZ '2001-04-10', TIMESTAMPTZ '1992-09-20')` |
+| **Result** | `8 years 6 months 20 days` |
+
+### `age(`*`timestamptz`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Subtract from current_date. |
+| **Example** | `age(TIMESTAMP '1992-09-20')` |
+| **Result** | `29 years 1 month 27 days 12:39:00.844` |
+
+### `date_diff(`*`part`*`, `*`startdate`*`, `*`enddate`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The number of [partition](../../sql/functions/datepart) boundaries between the timestamps. |
+| **Example** | `date_diff('hour', TIMESTAMPTZ '1992-09-30 23:59:59', TIMESTAMPTZ '1992-10-01 01:58:00')` |
+| **Result** | `2` |
+
+### `date_part([`*`part`*`, ...], `*`timestamptz`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Get the listed [subfields](../../sql/functions/datepart) as a `struct`. The list must be constant. |
+| **Example** | `date_part(['year', 'month', 'day'], TIMESTAMPTZ '1992-09-20 20:38:40-07')` |
+| **Result** | `{year: 1992, month: 9, day: 20}` |
+
+### `date_part(`*`part`*`, `*`timestamptz`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Get [subfield](../../sql/functions/datepart) (equivalent to *extract*). |
+| **Example** | `date_part('minute', TIMESTAMPTZ '1992-09-20 20:38:40')` |
+| **Result** | `38` |
+
+### `date_sub(`*`part`*`, `*`startdate`*`, `*`enddate`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The number of complete [partitions](../../sql/functions/datepart) between the timestamps. |
+| **Example** | `date_sub('hour', TIMESTAMPTZ '1992-09-30 23:59:59', TIMESTAMPTZ '1992-10-01 01:58:00')` |
+| **Result** | `1` |
+
+### `date_trunc(`*`part`*`, `*`timestamptz`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Truncate to specified [precision](../../sql/functions/datepart). |
+| **Example** | `date_trunc('hour', TIMESTAMPTZ '1992-09-20 20:38:40')` |
+| **Result** | `1992-09-20 20:00:00` |
+
+### `datediff(`*`part`*`, `*`startdate`*`, `*`enddate`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Alias of date_diff. The number of [partition](../../sql/functions/datepart) boundaries between the timestamps. |
+| **Example** | `datediff('hour', TIMESTAMPTZ '1992-09-30 23:59:59', TIMESTAMPTZ '1992-10-01 01:58:00')` |
+| **Result** | `2` |
+
+### `datepart([`*`part`*`, ...], `*`timestamptz`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Alias of date_part. Get the listed [subfields](../../sql/functions/datepart) as a `struct`. The list must be constant. |
+| **Example** | `datepart(['year', 'month', 'day'], TIMESTAMPTZ '1992-09-20 20:38:40-07')` |
+| **Result** | `{year: 1992, month: 9, day: 20}` |
+
+### `datepart(`*`part`*`, `*`timestamptz`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Alias of date_part. Get [subfield](../../sql/functions/datepart) (equivalent to *extract*). |
+| **Example** | `datepart('minute', TIMESTAMPTZ '1992-09-20 20:38:40')` |
+| **Result** | `38` |
+
+### `datesub(`*`part`*`, `*`startdate`*`, `*`enddate`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Alias of date_sub. The number of complete [partitions](../../sql/functions/datepart) between the timestamps. |
+| **Example** | `datesub('hour', TIMESTAMPTZ '1992-09-30 23:59:59', TIMESTAMPTZ '1992-10-01 01:58:00')` |
+| **Result** | `1` |
+
+### `datetrunc(`*`part`*`, `*`timestamptz`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Alias of date_trunc. Truncate to specified [precision](../../sql/functions/datepart). |
+| **Example** | `datetrunc('hour', TIMESTAMPTZ '1992-09-20 20:38:40')` |
+| **Result** | `1992-09-20 20:00:00` |
+
+### `epoch_ms(`*`timestamptz`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Converts a timestamptz to milliseconds since the epoch. |
+| **Example** | `epoch_ms('2022-11-07 08:43:04.123456+00'::TIMESTAMPTZ);` |
+| **Result** | `1667810584123` |
+
+### `epoch_ns(`*`timestamptz`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Converts a timestamptz to nanoseconds since the epoch. |
+| **Example** | `epoch_ns('2022-11-07 08:43:04.123456+00'::TIMESTAMPTZ);` |
+| **Result** | `1667810584123456000` |
+
+### `epoch_us(`*`timestamptz`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Converts a timestamptz to microseconds since the epoch. |
+| **Example** | `epoch_us('2022-11-07 08:43:04.123456+00'::TIMESTAMPTZ);` |
+| **Result** | `1667810584123456` |
+
+### `extract(`*`field`* `from` *`timestamptz`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Get [subfield](../../sql/functions/datepart) from a `TIMESTAMP WITH TIME ZONE`. |
+| **Example** | `extract('hour' FROM TIMESTAMPTZ '1992-09-20 20:38:48')` |
+| **Result** | `20` |
+
+### `last_day(`*`timestamptz`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The last day of the month. |
+| **Example** | `last_day(TIMESTAMPTZ '1992-03-22 01:02:03.1234')` |
+| **Result** | `1992-03-31` |
+
+### `make_timestamptz(`*`bigint`*`, `*`bigint`*`, `*`bigint`*`, `*`bigint`*`, `*`bigint`*`, `*`double`*`, `*`string`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The `TIMESTAMP WITH TIME ZONE` for the given parts and time zone. |
+| **Example** | `make_timestamptz(1992, 9, 20, 15, 34, 27.123456, 'CET')` |
+| **Result** | `1992-09-20 06:34:27.123456-07` |
+
+### `make_timestamptz(`*`bigint`*`, `*`bigint`*`, `*`bigint`*`, `*`bigint`*`, `*`bigint`*`, `*`double`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The `TIMESTAMP WITH TIME ZONE` for the given parts in the current time zone. |
+| **Example** | `make_timestamptz(1992, 9, 20, 13, 34, 27.123456)` |
+| **Result** | `1992-09-20 13:34:27.123456-07` |
+
+### `make_timestamptz(`*`microseconds`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The `TIMESTAMP WITH TIME ZONE` for the given µs since the epoch. |
+| **Example** | `make_timestamptz(1667810584123456)` |
+| **Result** | `2022-11-07 16:43:04.123456-08` |
+
+### `strftime(`*`timestamptz`*`, `*`format`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Converts a `TIMESTAMP WITH TIME ZONE` value to string according to the [format string](../../sql/functions/dateformat). |
+| **Example** | `strftime(timestamptz '1992-01-01 20:38:40', '%a, %-d %B %Y - %I:%M:%S %p')` |
+| **Result** | `Wed, 1 January 1992 - 08:38:40 PM` |
+
+### `strptime(`*`text`*`, `*`format`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Converts string to `TIMESTAMP WITH TIME ZONE` according to the [format string](../../sql/functions/dateformat) if `%Z` is specified. |
+| **Example** | `strptime('Wed, 1 January 1992 - 08:38:40 PST', '%a, %-d %B %Y - %H:%M:%S %Z')` |
+| **Result** | `1992-01-01 08:38:40-08` |
+
+### `time_bucket(`*`bucket_width`*`, `*`timestamptz`*`[, `*`offset`*`])`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Truncate `timestamptz` by the specified interval `bucket_width`. Buckets are offset by `offset` interval. |
+| **Example** | `time_bucket(INTERVAL '10 minutes', TIMESTAMPTZ '1992-04-20 15:26:00-07', INTERVAL '5 minutes')` |
+| **Result** | `1992-04-20 15:25:00-07` |
+
+### `time_bucket(`*`bucket_width`*`, `*`timestamptz`*`[, `*`origin`*`])`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Truncate `timestamptz` by the specified interval `bucket_width`. Buckets are aligned relative to `origin` timestamptz. `origin` defaults to 2000-01-03 00:00:00+00 for buckets that don't include a month or year interval, and to 2000-01-01 00:00:00+00 for month and year buckets. |
+| **Example** | `time_bucket(INTERVAL '2 weeks', TIMESTAMPTZ '1992-04-20 15:26:00-07', TIMESTAMPTZ '1992-04-01 00:00:00-07')` |
+| **Result** | `1992-04-15 00:00:00-07` |
+
+### `time_bucket(`*`bucket_width`*`, `*`timestamptz`*`[, `*`timezone`*`])`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Truncate `timestamptz` by the specified interval `bucket_width`. Bucket starts and ends are calculated using `timezone`. `timezone` is a varchar and defaults to UTC. |
+| **Example** | `time_bucket(INTERVAL '2 days', TIMESTAMPTZ '1992-04-20 15:26:00-07', 'Europe/Berlin')` |
+| **Result** | `1992-04-19 15:00:00-07` |
 
 There are also dedicated extraction functions to get the [subfields](../../sql/functions/datepart).
 
@@ -103,12 +367,26 @@ There are also dedicated extraction functions to get the [subfields](../../sql/f
 
 The table below shows the available table functions for `TIMESTAMP WITH TIME ZONE` types.
 
-| Function | Description | Example |
-|:--|:---|:---|
-| `generate_series(`*`timestamptz`*`, `*`timestamptz`*`, `*`interval`*`)` | Generate a table of timestamps in the closed range (including both the starting timestamp and the ending timestamp), stepping by the interval | `generate_series(TIMESTAMPTZ '2001-04-10', TIMESTAMPTZ '2001-04-11', INTERVAL 30 MINUTE)` |
-| `range(`*`timestamptz`*`, `*`timestamptz`*`, `*`interval`*`)` | Generate a table of timestamps in the half open range (including the starting timestamp, but stopping before the ending timestamp) , stepping by the interval | `range(TIMESTAMPTZ '2001-04-10', TIMESTAMPTZ '2001-04-11', INTERVAL 30 MINUTE)` |
+| Name | Description |
+|:--|:-------|
+| [`generate_series(`*`timestamptz`*`, `*`timestamptz`*`, `*`interval`*`)`](#generate_seriestimestamptz-timestamptz-interval) | Generate a table of timestamps in the closed range (including both the starting timestamp and the ending timestamp), stepping by the interval. |
+| [`range(`*`timestamptz`*`, `*`timestamptz`*`, `*`interval`*`)`](#rangetimestamptz-timestamptz-interval) | Generate a table of timestamps in the half open range (including the starting timestamp, but stopping before the ending timestamp) , stepping by the interval. |
 
 > Infinite values are not allowed as table function bounds.
+
+### `generate_series(`*`timestamptz`*`, `*`timestamptz`*`, `*`interval`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Generate a table of timestamps in the closed range (including both the starting timestamp and the ending timestamp), stepping by the interval. |
+| **Example** | `generate_series(TIMESTAMPTZ '2001-04-10', TIMESTAMPTZ '2001-04-11', INTERVAL 30 MINUTE)` |
+
+### `range(`*`timestamptz`*`, `*`timestamptz`*`, `*`interval`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Generate a table of timestamps in the half open range (including the starting timestamp, but stopping before the ending timestamp) , stepping by the interval. |
+| **Example** | `range(TIMESTAMPTZ '2001-04-10', TIMESTAMPTZ '2001-04-11', INTERVAL 30 MINUTE)` |
 
 ## ICU Timestamp Without Time Zone Functions
 
@@ -119,16 +397,64 @@ A local timestamp is effectively a way of encoding the part values from a time z
 They should be used with caution because the produced values can contain gaps and ambiguities thanks to daylight savings time.
 Often the same functionality can be implemented more reliably using the `struct` variant of the `date_part` function.
 
-| Function | Description | Example | Result |
-|:--|:--|:---|:--|
-| `current_localtime()` | Returns a `TIME` whose GMT bin values correspond to local time in the current time zone. | `current_localtime()` | `08:47:56.497` |
-| `current_localtimestamp()` | Returns a `TIMESTAMP` whose GMT bin values correspond to local date and time in the current time zone. | `current_localtimestamp()` | `2022-12-17 08:47:56.497` |
-| `localtime` | Synonym for the `current_localtime()` function call. | `localtime` | `08:47:56.497` |
-| `localtimestamp` | Synonym for the `current_localtimestamp()` function call. | `localtimestamp` | `2022-12-17 08:47:56.497` |
-| `timezone(`*`text`*`, `*`timestamp`*`)` | Use the [date parts](../../sql/functions/datepart) of the timestamp in GMT to construct a timestamp in the given time zone. Effectively, the argument is a "local" time. | `timezone('America/Denver', TIMESTAMP '2001-02-16 20:38:40')` | `2001-02-16 19:38:40-08` |
-| `timezone(`*`text`*`, `*`timestamptz`*`)` | Use the [date parts](../../sql/functions/datepart) of the timestamp in the given time zone to construct a timestamp. Effectively, the result is a "local" time. | `timezone('America/Denver', TIMESTAMPTZ '2001-02-16 20:38:40-05')` | `2001-02-16 18:38:40` |
+| Name | Description |
+|:--|:-------|
+| [`current_localtime()`](#current_localtime) | Returns a `TIME` whose GMT bin values correspond to local time in the current time zone. |
+| [`current_localtimestamp()`](#current_localtimestamp) | Returns a `TIMESTAMP` whose GMT bin values correspond to local date and time in the current time zone. |
+| [`localtime`](#localtime) | Synonym for the `current_localtime()` function call. |
+| [`localtimestamp`](#localtimestamp) | Synonym for the `current_localtimestamp()` function call. |
+| [`timezone(`*`text`*`, `*`timestamp`*`)`](#timezonetext-timestamp) | Use the [date parts](../../sql/functions/datepart) of the timestamp in GMT to construct a timestamp in the given time zone. Effectively, the argument is a "local" time. |
+| [`timezone(`*`text`*`, `*`timestamptz`*`)`](#timezonetext-timestamptz) | Use the [date parts](../../sql/functions/datepart) of the timestamp in the given time zone to construct a timestamp. Effectively, the result is a "local" time. |
 
-### At Time Zone
+### `current_localtime()`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns a `TIME` whose GMT bin values correspond to local time in the current time zone. |
+| **Example** | `current_localtime()` |
+| **Result** | `08:47:56.497` |
+
+### `current_localtimestamp()`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns a `TIMESTAMP` whose GMT bin values correspond to local date and time in the current time zone. |
+| **Example** | `current_localtimestamp()` |
+| **Result** | `2022-12-17 08:47:56.497` |
+
+### `localtime`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Synonym for the `current_localtime()` function call. |
+| **Example** | `localtime` |
+| **Result** | `08:47:56.497` |
+
+### `localtimestamp`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Synonym for the `current_localtimestamp()` function call. |
+| **Example** | `localtimestamp` |
+| **Result** | `2022-12-17 08:47:56.497` |
+
+### `timezone(`*`text`*`, `*`timestamp`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Use the [date parts](../../sql/functions/datepart) of the timestamp in GMT to construct a timestamp in the given time zone. Effectively, the argument is a "local" time. |
+| **Example** | `timezone('America/Denver', TIMESTAMP '2001-02-16 20:38:40')` |
+| **Result** | `2001-02-16 19:38:40-08` |
+
+### `timezone(`*`text`*`, `*`timestamptz`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Use the [date parts](../../sql/functions/datepart) of the timestamp in the given time zone to construct a timestamp. Effectively, the result is a "local" time. |
+| **Example** | `timezone('America/Denver', TIMESTAMPTZ '2001-02-16 20:38:40-05')` |
+| **Result** | `2001-02-16 18:38:40` |
+
+## At Time Zone
 
 The `AT TIME ZONE` syntax is syntactic sugar for the (two argument) `timezone` function listed above:
 

--- a/docs/sql/functions/utility.md
+++ b/docs/sql/functions/utility.md
@@ -7,36 +7,259 @@ title: Utility Functions
 
 The functions below are difficult to categorize into specific function types and are broadly useful.
 
-| Function | Description | Example | Result |
-|:--|:--|:---|:--|
-| `alias(`*`column`*`)` | Return the name of the column| `alias(column1)` | `column1` |
-| `checkpoint(`*`database`*`)`| Synchronize WAL with file for (optional) database without interrupting transactions. | `checkpoint(my_db)`| success boolean |
-| `coalesce(`*`expr`*`, `*`...`*`)` | Return the first expression that evaluates to a non-`NULL` value. Accepts 1 or more parameters. Each expression can be a column, literal value, function result, or many others. | `coalesce(NULL, NULL, 'default_string')` | `default_string`|
-| `constant_or_null(`*`arg1`*`, `*`arg2`*`)` | If *`arg2`* is `NULL`, return `NULL`. Otherwise, return *`arg1`*. | `constant_or_null(42, NULL)` | `NULL` |
-| `count_if(`*`x`*`)` | Returns 1 if *x* is `true` or a non-zero number | `count_if(42)` | 1 |
-| `current_catalog()` | Return the name of the currently active catalog. Default is memory. | `current_catalog()` | `memory` |
-| `current_schema()`| Return the name of the currently active schema. Default is main. | `current_schema()` | `main`|
-| `current_schemas(`*`boolean`*`)`| Return list of schemas. Pass a parameter of `true` to include implicit schemas.| `current_schemas(true)`| `['temp', 'main', 'pg_catalog']`|
-| `current_setting(`*`'setting_name'`*`)` | Return the current value of the configuration setting| `current_setting('access_mode')` | `automatic` |
-| `currval(`*`'sequence_name'`*`)`| Return the current value of the sequence. Note that `nextval` must be called at least once prior to calling `currval`. | `currval('my_sequence_name')`| `1` |
-| `error(`*`message`*`)` | Throws the given error *`message`* | `error('access_mode')` | |
-| `force_checkpoint(`*`database`*`)`| Synchronize WAL with file for (optional) database interrupting transactions. | `force_checkpoint(my_db)`| success boolean |
-| `gen_random_uuid()` | Alias of `uuid`. Return a random UUID similar to this: `eeccb8c5-9943-b2bb-bb5e-222f4e14b687`. | `gen_random_uuid()`| various |
-| `hash(`*`value`*`)` | Returns a `UBIGINT` with the hash of the *`value`*| `hash('🦆')` | `2595805878642663834` |
-| `icu_sort_key(`*`string`*`, `*`collator`*`)` | Surrogate key used to sort special characters according to the specific locale. Collator parameter is optional. Valid only when ICU extension is installed.| `icu_sort_key('ö', 'DE')` | `460145960106` |
-| `ifnull(`*`expr`*`, `*`other`*`)` | A two-argument version of coalesce | `ifnull(NULL, 'default_string')` | `default_string`|
-| `md5(`*`string`*`)` | Return an md5 one-way hash of the *`string`*.| `md5('123')` | `202c...`|
-| `nextval(`*`'sequence_name'`*`)`| Return the following value of the sequence.| `nextval('my_sequence_name')`| `2` |
-| `nullif(`*`a`*`, `*`b`*`)` | Return null if a = b, else return a. Equivalent to `CASE WHEN a = b THEN NULL ELSE a END`. | `nullif(1+1, 2)` | `NULL`|
-| `pg_typeof(`*`expression`*`)` | Returns the lower case name of the data type of the result of the expression. For PostgreSQL compatibility.| `pg_typeof('abc')` | `varchar` |
-| `read_blob(`*`source`*`)` | Returns the content from *`source`* (a filename, a list of filenames, or a glob pattern) as a `BLOB`. See the [`read_blob` guide](../../guides/import/read_file#read_blob) for more details. | `read_blob('hello.bin')` | `hello\x0A` |
-| `read_text(`*`source`*`)` | Returns the content from *`source`* (a filename, a list of filenames, or a glob pattern) as a `VARCHAR`. The file content is first validated to be valid UTF-8. If `read_text` attempts to read a file with invalid UTF-8 an error is thrown suggesting to use `read_blob` instead. See the [`read_text` guide](../../guides/import/read_file#read_text) for more details. | `read_text('hello.txt')` | `hello\n` |
-| `sha256(`*`value`*`)` | Returns a `VARCHAR` with the SHA-256 hash of the *`value`*| `sha-256('🦆')` | `d7a5...` |
-| `stats(`*`expression`*`)` | Returns a string with statistics about the expression. Expression can be a column, constant, or SQL expression.| `stats(5)` | `'[Min: 5, Max: 5][Has Null: false]'` |
-| `txid_current()`| Returns the current transaction's ID (a `BIGINT`). It will assign a new one if the current transaction does not have one already.| `txid_current()` | various |
-| `typeof(`*`expression`*`)`| Returns the name of the data type of the result of the expression. | `typeof('abc')`| `VARCHAR` |
-| `uuid()`| Return a random UUID similar to this: `eeccb8c5-9943-b2bb-bb5e-222f4e14b687`.| `uuid()` | various |
-| `version()` | Return the currently active version of DuckDB in this format | `version()`| various |
+| Name | Description |
+|:--|:-------|
+| [`alias(`*`column`*`)`](#aliascolumn) | Return the name of the column. |
+| [`checkpoint(`*`database`*`)`](#checkpointdatabase) | Synchronize WAL with file for (optional) database without interrupting transactions. |
+| [`coalesce(`*`expr`*`, `*`...`*`)`](#coalesceexpr-) | Return the first expression that evaluates to a non-`NULL` value. Accepts 1 or more parameters. Each expression can be a column, literal value, function result, or many others. |
+| [`constant_or_null(`*`arg1`*`, `*`arg2`*`)`](#constant_or_nullarg1-arg2) | If *`arg2`* is `NULL`, return `NULL`. Otherwise, return *`arg1`*. |
+| [`count_if(`*`x`*`)`](#count_ifx) | Returns 1 if *x* is `true` or a non-zero number. |
+| [`current_catalog()`](#current_catalog) | Return the name of the currently active catalog. Default is memory. |
+| [`current_schema()`](#current_schema) | Return the name of the currently active schema. Default is main. |
+| [`current_schemas(`*`boolean`*`)`](#current_schemasboolean) | Return list of schemas. Pass a parameter of `true` to include implicit schemas. |
+| [`current_setting(`*`'setting_name'`*`)`](#current_settingsetting_name) | Return the current value of the configuration setting. |
+| [`currval(`*`'sequence_name'`*`)`](#currvalsequence_name) | Return the current value of the sequence. Note that `nextval` must be called at least once prior to calling `currval`. |
+| [`error(`*`message`*`)`](#errormessage) | Throws the given error *`message`*. |
+| [`force_checkpoint(`*`database`*`)`](#force_checkpointdatabase) | Synchronize WAL with file for (optional) database interrupting transactions. |
+| [`gen_random_uuid()`](#gen_random_uuid) | Alias of `uuid`. Return a random UUID similar to this: `eeccb8c5-9943-b2bb-bb5e-222f4e14b687`. |
+| [`hash(`*`value`*`)`](#hashvalue) | Returns a `UBIGINT` with the hash of the *`value`*. |
+| [`icu_sort_key(`*`string`*`, `*`collator`*`)`](#icu_sort_keystring-collator) | Surrogate key used to sort special characters according to the specific locale. Collator parameter is optional. Valid only when ICU extension is installed. |
+| [`ifnull(`*`expr`*`, `*`other`*`)`](#ifnullexpr-other) | A two-argument version of coalesce. |
+| [`md5(`*`string`*`)`](#md5string) | Return an md5 one-way hash of the *`string`*. |
+| [`nextval(`*`'sequence_name'`*`)`](#nextvalsequence_name) | Return the following value of the sequence. |
+| [`nullif(`*`a`*`, `*`b`*`)`](#nullifa-b) | Return null if a = b, else return a. Equivalent to `CASE WHEN a = b THEN NULL ELSE a END`. |
+| [`pg_typeof(`*`expression`*`)`](#pg_typeofexpression) | Returns the lower case name of the data type of the result of the expression. For PostgreSQL compatibility. |
+| [`read_blob(`*`source`*`)`](#read_blobsource) | Returns the content from *`source`* (a filename, a list of filenames, or a glob pattern) as a `BLOB`. See the [`read_blob` guide](../../guides/import/read_file#read_blob) for more details. |
+| [`read_text(`*`source`*`)`](#read_textsource) | Returns the content from *`source`* (a filename, a list of filenames, or a glob pattern) as a `VARCHAR`. The file content is first validated to be valid UTF-8. If `read_text` attempts to read a file with invalid UTF-8 an error is thrown suggesting to use `read_blob` instead. See the [`read_text` guide](../../guides/import/read_file#read_text) for more details. |
+| [`sha256(`*`value`*`)`](#sha256value) | Returns a `VARCHAR` with the SHA-256 hash of the *`value`*. |
+| [`stats(`*`expression`*`)`](#statsexpression) | Returns a string with statistics about the expression. Expression can be a column, constant, or SQL expression. |
+| [`txid_current()`](#txid_current) | Returns the current transaction's ID (a `BIGINT`). It will assign a new one if the current transaction does not have one already. |
+| [`typeof(`*`expression`*`)`](#typeofexpression) | Returns the name of the data type of the result of the expression. |
+| [`uuid()`](#uuid) | Return a random UUID similar to this: `eeccb8c5-9943-b2bb-bb5e-222f4e14b687`. |
+| [`version()`](#version) | Return the currently active version of DuckDB in this format. |
+
+### `alias(`*`column`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Return the name of the column. |
+| **Example** | `alias(column1)` |
+| **Result** | `column1` |
+
+### `checkpoint(`*`database`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Synchronize WAL with file for (optional) database without interrupting transactions. |
+| **Example** | `checkpoint(my_db)` |
+| **Result** | success boolean |
+
+### `coalesce(`*`expr`*`, `*`...`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Return the first expression that evaluates to a non-`NULL` value. Accepts 1 or more parameters. Each expression can be a column, literal value, function result, or many others. |
+| **Example** | `coalesce(NULL, NULL, 'default_string')` |
+| **Result** | `default_string` |
+
+### `constant_or_null(`*`arg1`*`, `*`arg2`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | If *`arg2`* is `NULL`, return `NULL`. Otherwise, return *`arg1`*. |
+| **Example** | `constant_or_null(42, NULL)` |
+| **Result** | `NULL` |
+
+### `count_if(`*`x`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns 1 if *x* is `true` or a non-zero number. |
+| **Example** | `count_if(42)` |
+| **Result** | 1 |
+
+### `current_catalog()`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Return the name of the currently active catalog. Default is memory. |
+| **Example** | `current_catalog()` |
+| **Result** | `memory` |
+
+### `current_schema()`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Return the name of the currently active schema. Default is main. |
+| **Example** | `current_schema()` |
+| **Result** | `main` |
+
+### `current_schemas(`*`boolean`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Return list of schemas. Pass a parameter of `true` to include implicit schemas. |
+| **Example** | `current_schemas(true)` |
+| **Result** | `['temp', 'main', 'pg_catalog']` |
+
+### `current_setting(`*`'setting_name'`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Return the current value of the configuration setting. |
+| **Example** | `current_setting('access_mode')` |
+| **Result** | `automatic` |
+
+### `currval(`*`'sequence_name'`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Return the current value of the sequence. Note that `nextval` must be called at least once prior to calling `currval`. |
+| **Example** | `currval('my_sequence_name')` |
+| **Result** | `1` |
+
+### `error(`*`message`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Throws the given error *`message`*. |
+| **Example** | `error('access_mode')` |
+
+### `force_checkpoint(`*`database`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Synchronize WAL with file for (optional) database interrupting transactions. |
+| **Example** | `force_checkpoint(my_db)` |
+| **Result** | success boolean |
+
+### `gen_random_uuid()`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Alias of `uuid`. Return a random UUID similar to this: `eeccb8c5-9943-b2bb-bb5e-222f4e14b687`. |
+| **Example** | `gen_random_uuid()` |
+| **Result** | various |
+
+### `hash(`*`value`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns a `UBIGINT` with the hash of the *`value`*. |
+| **Example** | `hash('🦆')` |
+| **Result** | `2595805878642663834` |
+
+### `icu_sort_key(`*`string`*`, `*`collator`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Surrogate key used to sort special characters according to the specific locale. Collator parameter is optional. Valid only when ICU extension is installed. |
+| **Example** | `icu_sort_key('ö', 'DE')` |
+| **Result** | `460145960106` |
+
+### `ifnull(`*`expr`*`, `*`other`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | A two-argument version of coalesce. |
+| **Example** | `ifnull(NULL, 'default_string')` |
+| **Result** | `default_string` |
+
+### `md5(`*`string`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Return an md5 one-way hash of the *`string`*. |
+| **Example** | `md5('123')` |
+| **Result** | `202c...` |
+
+### `nextval(`*`'sequence_name'`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Return the following value of the sequence. |
+| **Example** | `nextval('my_sequence_name')` |
+| **Result** | `2` |
+
+### `nullif(`*`a`*`, `*`b`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Return null if a = b, else return a. Equivalent to `CASE WHEN a = b THEN NULL ELSE a END`. |
+| **Example** | `nullif(1+1, 2)` |
+| **Result** | `NULL` |
+
+### `pg_typeof(`*`expression`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns the lower case name of the data type of the result of the expression. For PostgreSQL compatibility. |
+| **Example** | `pg_typeof('abc')` |
+| **Result** | `varchar` |
+
+### `read_blob(`*`source`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns the content from *`source`* (a filename, a list of filenames, or a glob pattern) as a `BLOB`. See the [`read_blob` guide](../../guides/import/read_file#read_blob) for more details. |
+| **Example** | `read_blob('hello.bin')` |
+| **Result** | `hello\x0A` |
+
+### `read_text(`*`source`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns the content from *`source`* (a filename, a list of filenames, or a glob pattern) as a `VARCHAR`. The file content is first validated to be valid UTF-8. If `read_text` attempts to read a file with invalid UTF-8 an error is thrown suggesting to use `read_blob` instead. See the [`read_text` guide](../../guides/import/read_file#read_text) for more details. |
+| **Example** | `read_text('hello.txt')` |
+| **Result** | `hello\n` |
+
+### `sha256(`*`value`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns a `VARCHAR` with the SHA-256 hash of the *`value`*. |
+| **Example** | `sha-256('🦆')` |
+| **Result** | `d7a5...` |
+
+### `stats(`*`expression`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns a string with statistics about the expression. Expression can be a column, constant, or SQL expression. |
+| **Example** | `stats(5)` |
+| **Result** | `'[Min: 5, Max: 5][Has Null: false]'` |
+
+### `txid_current()`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns the current transaction's ID (a `BIGINT`). It will assign a new one if the current transaction does not have one already. |
+| **Example** | `txid_current()` |
+| **Result** | various |
+
+### `typeof(`*`expression`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns the name of the data type of the result of the expression. |
+| **Example** | `typeof('abc')` |
+| **Result** | `VARCHAR` |
+
+### `uuid()`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Return a random UUID similar to this: `eeccb8c5-9943-b2bb-bb5e-222f4e14b687`. |
+| **Example** | `uuid()` |
+| **Result** | various |
+
+### `version()`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Return the currently active version of DuckDB in this format. |
+| **Example** | `version()` |
+| **Result** | various |
 
 ## Utility Table Functions
 
@@ -44,7 +267,23 @@ A table function is used in place of a table in a `FROM` clause.
 
 <div class="narrow_table"></div>
 
-| Function | Description | Example | Result |
-|:--|:--|:---|:--|
-| `glob(`*`search_path`*`)` | Return filenames found at the location indicated by the *search_path* in a single column named `file`. The *search_path* may contain [glob pattern matching syntax](patternmatching). | `glob('*')` | (table of filenames) |
-| `repeat_row(`*`varargs`*`, `*`num_rows`*`)` | Returns a table with *`num_rows`* rows, each containing the fields defined in *`varargs`* | `repeat_row(1, 2, 'foo', num_rows = 3)` | 3 rows of `1, 2, 'foo'` |
+| Name | Description |
+|:--|:-------|
+| [`glob(`*`search_path`*`)`](#globsearch_path) | Return filenames found at the location indicated by the *search_path* in a single column named `file`. The *search_path* may contain [glob pattern matching syntax](patternmatching). |
+| [`repeat_row(`*`varargs`*`, `*`num_rows`*`)`](#repeat_rowvarargs-num_rows) | Returns a table with *`num_rows`* rows, each containing the fields defined in *`varargs`*. |
+
+### `glob(`*`search_path`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Return filenames found at the location indicated by the *search_path* in a single column named `file`. The *search_path* may contain [glob pattern matching syntax](patternmatching). |
+| **Example** | `glob('*')` |
+| **Result** | (table of filenames) |
+
+### `repeat_row(`*`varargs`*`, `*`num_rows`*`)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Returns a table with *`num_rows`* rows, each containing the fields defined in *`varargs`*. |
+| **Example** | `repeat_row(1, 2, 'foo', num_rows = 3)` |
+| **Result** | 3 rows of `1, 2, 'foo'` |

--- a/single-file-document/concatenate_to_single_file.py
+++ b/single-file-document/concatenate_to_single_file.py
@@ -178,6 +178,12 @@ def adjust_headers(doc_body, doc_header_label):
     return doc_body_with_new_headers
 
 
+def change_function_table_headers(doc_body):
+    return doc_body.replace("""| **Description** | """, """|   |   |
+|:--|:--------|
+| **Description** |""")
+
+
 def concatenate_page_to_output(of, header_level, docs_root, doc_file_path):
     # skip index files
     if doc_file_path.endswith("index"):
@@ -206,6 +212,7 @@ def concatenate_page_to_output(of, header_level, docs_root, doc_file_path):
         doc_body = replace_html_code_blocks(doc_body)
         doc_body = adjust_links_in_doc_body(doc_body)
         doc_body = adjust_headers(doc_body, doc_header_label)
+        doc_body = change_function_table_headers(doc_body)
         doc_body = change_link(doc_body, doc_file_path)
 
         # write to output


### PR DESCRIPTION
Reformat function tables to only have two columns (name/description) and link to individual function section which have more information (example code, example result, alias(es)).

This PR builds on the style introduced by PR #2529  and using code in #2488.