### PR TITLE
go.md: link to repository

### DIFF
--- a/docs/api/go.md
+++ b/docs/api/go.md
@@ -7,7 +7,7 @@ github_repository: https://github.com/marcboeker/go-duckdb
 The DuckDB Go driver, `go-duckdb`, allows using DuckDB via the `database/sql` interface.
 For examples on how to use this interface, see the [official documentation](https://pkg.go.dev/database/sql) and [tutorial](https://go.dev/doc/tutorial/database-access).
 
-> The Go client is a third-party library, development repository is at https://github.com/marcboeker/go-duckdb 
+> The Go client is a third-party library and its repository is hosted <https://github.com/marcboeker/go-duckdb>.
 
 ## Installation
 

--- a/docs/api/go.md
+++ b/docs/api/go.md
@@ -7,7 +7,7 @@ github_repository: https://github.com/marcboeker/go-duckdb
 The DuckDB Go driver, `go-duckdb`, allows using DuckDB via the `database/sql` interface.
 For examples on how to use this interface, see the [official documentation](https://pkg.go.dev/database/sql) and [tutorial](https://go.dev/doc/tutorial/database-access).
 
-> The Go client is provided as a third-party library.
+> The Go client is a third-party library, development repository is at https://github.com/marcboeker/go-duckdb 
 
 ## Installation
 


### PR DESCRIPTION
I navigated to go.md, and was expecting in some form to find the link to the repository. Unsure if that's the correct spot, or even if the phrase should be turned around, unsure.