### PR TITLE
Update constraints.md with composite key example

### DIFF
--- a/docs/archive/0.9/sql/constraints.md
+++ b/docs/archive/0.9/sql/constraints.md
@@ -45,6 +45,14 @@ INSERT INTO students VALUES (1, 'Student 2');
 -- Constraint Error: Duplicate key "id: 1" violates primary key constraint
 ```
 
+```sql
+CREATE TABLE students (id INTEGER, name VARCHAR, primary key (id, name));
+INSERT INTO students VALUES (1, 'Student 1');
+INSERT INTO students VALUES (1, 'Student 2');
+INSERT INTO students VALUES (1, 'Student 1');
+-- Constraint Error: Duplicate key "id: 1, name: Student 1" violates primary key constraint
+```
+
 In order to enforce this property efficiently, an [ART index is automatically created](indexes) for every primary key or unique constraint that is defined in the table.
 
 Primary key constraints and unique constraints are identical except for two points:

--- a/docs/sql/constraints.md
+++ b/docs/sql/constraints.md
@@ -43,6 +43,14 @@ INSERT INTO students VALUES (1, 'Student 2');
 -- Constraint Error: Duplicate key "id: 1" violates primary key constraint
 ```
 
+```sql
+CREATE TABLE students (id INTEGER, name VARCHAR, primary key (id, name));
+INSERT INTO students VALUES (1, 'Student 1');
+INSERT INTO students VALUES (1, 'Student 2');
+INSERT INTO students VALUES (1, 'Student 1');
+-- Constraint Error: Duplicate key "id: 1, name: Student 1" violates primary key constraint
+```
+
 In order to enforce this property efficiently, an [ART index is automatically created](indexes) for every primary key or unique constraint that is defined in the table.
 
 Primary key constraints and unique constraints are identical except for two points:


### PR DESCRIPTION
There was no example on how to set a primary key as an composite of several columns, even though it was mentioned in the text. In my opinion it helps greatly with clarity to give an example outright, as there is no other example (that I could find) that clearly shows a composite key.  

I reused the example for a single column primary key to outline the difference when a composite key is used:

Old example:
```sql
CREATE TABLE students(id INTEGER PRIMARY KEY, name VARCHAR);
INSERT INTO students VALUES (1, 'Student 1');
INSERT INTO students VALUES (1, 'Student 2');
-- Constraint Error: Duplicate key "id: 1" violates primary key constraint'
```

New example added after the old example, showing a composite primary key:
```sql
CREATE TABLE students (id INTEGER, name VARCHAR, primary key (id, name));
INSERT INTO students VALUES (1, 'Student 1');
INSERT INTO students VALUES (1, 'Student 2');
INSERT INTO students VALUES (1, 'Student 1');
-- Constraint Error: Duplicate key "id: 1, name: Student 1" violates primary key constraint

```