### PR TITLE
Update constraints.md with composite key example

### DIFF
--- a/docs/sql/constraints.md
+++ b/docs/sql/constraints.md
@@ -43,7 +43,7 @@ INSERT INTO students VALUES (1, 'Student 2');
 -- Constraint Error: Duplicate key "id: 1" violates primary key constraint
 ```
 ```sql
-CREATE TABLE students (id INTEGER, name VARCHAR, primary key (id, name));
+CREATE TABLE students (id INTEGER, name VARCHAR, PRIMARY KEY (id, name));
 INSERT INTO students VALUES (1, 'Student 1');
 INSERT INTO students VALUES (1, 'Student 2');
 INSERT INTO students VALUES (1, 'Student 1');

--- a/docs/sql/constraints.md
+++ b/docs/sql/constraints.md
@@ -61,10 +61,10 @@ The unique constraint prevents duplicates a column or combination of columns, bu
 CREATE TABLE students(id INTEGER PRIMARY KEY, name VARCHAR, email VARCHAR, UNIQUE(email));
 INSERT INTO students VALUES (1, 'Student 1', 'student1@uni.com');
 INSERT INTO students values (2, 'Student 2', 'student1@uni.com');
-Error: Constraint Error: Duplicate key "email: student1@uni.com" violates unique constraint.
+-- Constraint Error: Duplicate key "email: student1@uni.com" violates unique constraint.
 INSERT INTO students(id, name) VALUES (3, 'Student 3');
 INSERT INTO students(name, email) VALUES ('Student 3', 'student3@uni.com');
-Error: Constraint Error: NOT NULL constraint failed: students.id
+-- Constraint Error: NOT NULL constraint failed: students.id
 ```
 In order to enforce this property efficiently, an [ART index is automatically created](indexes) for every primary key or unique constraint that is defined in the table.
 

--- a/docs/sql/constraints.md
+++ b/docs/sql/constraints.md
@@ -62,7 +62,7 @@ CREATE TABLE students(id INTEGER PRIMARY KEY, name VARCHAR, email VARCHAR, UNIQU
 INSERT INTO students VALUES (1, 'Student 1', 'student1@uni.com');
 INSERT INTO students values (2, 'Student 2', 'student1@uni.com');
 Error: Constraint Error: Duplicate key "email: student1@uni.com" violates unique constraint.
-INSERT INTO students(id, name) VALUES ('3', 'Student 3');
+INSERT INTO students(id, name) VALUES (3, 'Student 3');
 INSERT INTO students(name, email) VALUES ('Student 3', 'student3@uni.com');
 Error: Constraint Error: NOT NULL constraint failed: students.id
 ```

--- a/docs/sql/constraints.md
+++ b/docs/sql/constraints.md
@@ -49,7 +49,23 @@ INSERT INTO students VALUES (1, 'Student 2');
 INSERT INTO students VALUES (1, 'Student 1');
 -- Constraint Error: Duplicate key "id: 1, name: Student 1" violates primary key constraint
 ```
-
+```sql
+CREATE TABLE students (id INTEGER, name VARCHAR, PRIMARY KEY (id, name));
+INSERT INTO students VALUES (1, 'Student 1');
+INSERT INTO students VALUES (1, 'Student 2');
+INSERT INTO students VALUES (1, 'Student 1');
+-- Constraint Error: Duplicate key "id: 1, name: Student 1" violates primary key constraint
+```
+The unique constraint prevents duplicates a column or combination of columns, but is allowed to be empty unlike the primary key. 
+```sql
+CREATE TABLE students(id INTEGER PRIMARY KEY, name VARCHAR, email VARCHAR, UNIQUE(email));
+INSERT INTO students VALUES (1, 'Student 1', 'student1@uni.com');
+INSERT INTO students values (2, 'Student 2', 'student1@uni.com');
+Error: Constraint Error: Duplicate key "email: student1@uni.com" violates unique constraint.
+INSERT INTO students(id, name) VALUES ('3', 'Student 3');
+INSERT INTO students(name, email) VALUES ('Student 3', 'student3@uni.com');
+Error: Constraint Error: NOT NULL constraint failed: students.id
+```
 In order to enforce this property efficiently, an [ART index is automatically created](indexes) for every primary key or unique constraint that is defined in the table.
 
 Primary key constraints and unique constraints are identical except for two points:

--- a/docs/sql/constraints.md
+++ b/docs/sql/constraints.md
@@ -70,9 +70,8 @@ INSERT INTO students VALUES (1, 'Student 1', 'student1@uni.com');
 INSERT INTO students values (2, 'Student 2', 'student1@uni.com');
 -- Constraint Error: Duplicate key "email: student1@uni.com" violates unique constraint.
 INSERT INTO students(id, name) VALUES (3, 'Student 3');
--- Constraint Error: NOT NULL constraint failed: students.id
 INSERT INTO students(name, email) VALUES ('Student 3', 'student3@uni.com');
-```
+-- Constraint Error: NOT NULL constraint failed: students.id```
 
 
 > Warning Indexes have certain limitations that might result in constraints being evaluated too eagerly, see the [indexes section for more details](indexes#index-limitations).

--- a/docs/sql/constraints.md
+++ b/docs/sql/constraints.md
@@ -55,23 +55,25 @@ INSERT INTO students VALUES (1, 'Student 1');
 INSERT INTO students VALUES (1, 'Student 2');
 INSERT INTO students VALUES (1, 'Student 1');
 -- Constraint Error: Duplicate key "id: 1, name: Student 1" violates primary key constraint
-```
-The unique constraint prevents duplicates a column or combination of columns, but is allowed to be empty unlike the primary key. 
-```sql
-CREATE TABLE students(id INTEGER PRIMARY KEY, name VARCHAR, email VARCHAR UNIQUE);
-INSERT INTO students VALUES (1, 'Student 1', 'student1@uni.com');
-INSERT INTO students values (2, 'Student 2', 'student1@uni.com');
--- Constraint Error: Duplicate key "email: student1@uni.com" violates unique constraint.
-INSERT INTO students(id, name) VALUES (3, 'Student 3');
-INSERT INTO students(name, email) VALUES ('Student 3', 'student3@uni.com');
--- Constraint Error: NOT NULL constraint failed: students.id
-```
+``` 
+
 In order to enforce this property efficiently, an [ART index is automatically created](indexes) for every primary key or unique constraint that is defined in the table.
 
 Primary key constraints and unique constraints are identical except for two points:
 
 * A table can only have one primary key constraint defined, but many unique constraints
 * A primary key constraint also enforces the keys to not be `NULL`.
+
+```sql
+CREATE TABLE students(id INTEGER PRIMARY KEY, name VARCHAR, email VARCHAR UNIQUE);
+INSERT INTO students VALUES (1, 'Student 1', 'student1@uni.com');
+INSERT INTO students values (2, 'Student 2', 'student1@uni.com');
+-- Constraint Error: Duplicate key "email: student1@uni.com" violates unique constraint.
+INSERT INTO students(id, name) VALUES (3, 'Student 3');
+-- Constraint Error: NOT NULL constraint failed: students.id
+INSERT INTO students(name, email) VALUES ('Student 3', 'student3@uni.com');
+```
+
 
 > Warning Indexes have certain limitations that might result in constraints being evaluated too eagerly, see the [indexes section for more details](indexes#index-limitations).
 

--- a/docs/sql/constraints.md
+++ b/docs/sql/constraints.md
@@ -58,7 +58,7 @@ INSERT INTO students VALUES (1, 'Student 1');
 ```
 The unique constraint prevents duplicates a column or combination of columns, but is allowed to be empty unlike the primary key. 
 ```sql
-CREATE TABLE students(id INTEGER PRIMARY KEY, name VARCHAR, email VARCHAR, UNIQUE(email));
+CREATE TABLE students(id INTEGER PRIMARY KEY, name VARCHAR, email VARCHAR UNIQUE);
 INSERT INTO students VALUES (1, 'Student 1', 'student1@uni.com');
 INSERT INTO students values (2, 'Student 2', 'student1@uni.com');
 -- Constraint Error: Duplicate key "email: student1@uni.com" violates unique constraint.

--- a/docs/sql/constraints.md
+++ b/docs/sql/constraints.md
@@ -71,7 +71,8 @@ INSERT INTO students values (2, 'Student 2', 'student1@uni.com');
 -- Constraint Error: Duplicate key "email: student1@uni.com" violates unique constraint.
 INSERT INTO students(id, name) VALUES (3, 'Student 3');
 INSERT INTO students(name, email) VALUES ('Student 3', 'student3@uni.com');
--- Constraint Error: NOT NULL constraint failed: students.id```
+-- Constraint Error: NOT NULL constraint failed: students.id
+```
 
 
 > Warning Indexes have certain limitations that might result in constraints being evaluated too eagerly, see the [indexes section for more details](indexes#index-limitations).

--- a/docs/sql/constraints.md
+++ b/docs/sql/constraints.md
@@ -42,6 +42,13 @@ INSERT INTO students VALUES (1, 'Student 1');
 INSERT INTO students VALUES (1, 'Student 2');
 -- Constraint Error: Duplicate key "id: 1" violates primary key constraint
 ```
+```sql
+CREATE TABLE students (id INTEGER, name VARCHAR, primary key (id, name));
+INSERT INTO students VALUES (1, 'Student 1');
+INSERT INTO students VALUES (1, 'Student 2');
+INSERT INTO students VALUES (1, 'Student 1');
+-- Constraint Error: Duplicate key "id: 1, name: Student 1" violates primary key constraint
+```
 
 In order to enforce this property efficiently, an [ART index is automatically created](indexes) for every primary key or unique constraint that is defined in the table.
 


### PR DESCRIPTION
There was no example on how to set a primary key as an composite of several columns, even though it was mentioned in the text. In my opinion it helps greatly with clarity to give an example outright, as there is no other example (that I could find) that clearly shows a composite key.

I reused the example for a single column primary key to outline the difference when a composite key is used.

Old example:
```sql
CREATE TABLE students(id INTEGER PRIMARY KEY, name VARCHAR);
INSERT INTO students VALUES (1, 'Student 1');
INSERT INTO students VALUES (1, 'Student 2');
-- Constraint Error: Duplicate key "id: 1" violates primary key constraint'
```

New example added after the old example, showing a composite primary key:
```sql
CREATE TABLE students (id INTEGER, name VARCHAR, PRIMARY KEY (id, name));
INSERT INTO students VALUES (1, 'Student 1');
INSERT INTO students VALUES (1, 'Student 2');
INSERT INTO students VALUES (1, 'Student 1');
-- Constraint Error: Duplicate key "id: 1, name: Student 1" violates primary key constraint
```


(Duplicate of https://github.com/duckdb/duckdb-web/pull/2568 as the PR was against an old version of the documentation by a mistake).

Added an example for the unique constraint:
----------------------------------------------------------------------------------------------------------------------------------
```sql
CREATE TABLE students(id INTEGER PRIMARY KEY, name VARCHAR, email VARCHAR UNIQUE;
INSERT INTO students VALUES (1, 'Student 1', 'student1@uni.com');
INSERT INTO students values (2, 'Student 2', 'student1@uni.com');
-- Constraint Error: Duplicate key "email: student1@uni.com" violates unique constraint.
INSERT INTO students(id, name) VALUES (3, 'Student 3');
INSERT INTO students(name, email) VALUES ('Student 3', 'student3@uni.com');
-- Constraint Error: NOT NULL constraint failed: students.id
```

Sorry for this being a bit patchy and rushed, but wanted to get it done.