### PR TITLE
Update constraints.md - removed duplicate of example

### DIFF
--- a/docs/sql/constraints.md
+++ b/docs/sql/constraints.md
@@ -49,13 +49,6 @@ INSERT INTO students VALUES (1, 'Student 2');
 INSERT INTO students VALUES (1, 'Student 1');
 -- Constraint Error: Duplicate key "id: 1, name: Student 1" violates primary key constraint
 ```
-```sql
-CREATE TABLE students (id INTEGER, name VARCHAR, PRIMARY KEY (id, name));
-INSERT INTO students VALUES (1, 'Student 1');
-INSERT INTO students VALUES (1, 'Student 2');
-INSERT INTO students VALUES (1, 'Student 1');
--- Constraint Error: Duplicate key "id: 1, name: Student 1" violates primary key constraint
-``` 
 
 In order to enforce this property efficiently, an [ART index is automatically created](indexes) for every primary key or unique constraint that is defined in the table.
 


### PR DESCRIPTION
Seems like I had duplicated an example in my previous commit:

```sql
CREATE TABLE students (id INTEGER, name VARCHAR, PRIMARY KEY (id, name));
INSERT INTO students VALUES (1, 'Student 1');
INSERT INTO students VALUES (1, 'Student 2');
INSERT INTO students VALUES (1, 'Student 1');
-- Constraint Error: Duplicate key "id: 1, name: Student 1" violates primary key constraint
```

Removed the duplicate.