### PR TITLE
Fix Bash comment in JSON Data Import page

### DIFF
--- a/_posts/2023-08-04-adbc.md
+++ b/_posts/2023-08-04-adbc.md
@@ -45,10 +45,10 @@ For this example, you must have a dynamic library from the latest bleeding-edge 
 
 **Note:** While DuckDB is already DB-API compliant in Python, what sets ADBC apart is that you do not need a DuckDB module installed and loaded. Additionally, unlike the DB-API, it does not utilize row-wise as its data transfer format of choice.
 
- ```bash
+```bash
 pip install pyarrow
 pip install adbc-driver-manager
- ```
+```
 
 ### Insert Data
 

--- a/docs/data/json/overview.md
+++ b/docs/data/json/overview.md
@@ -21,7 +21,7 @@ FROM read_json('todos.json',
 ```
 
 ```bash
--- read a JSON file from stdin, auto-infer options
+# read a JSON file from stdin, auto-infer options
 cat data/json/todos.json | duckdb -c "SELECT * FROM read_json_auto('/dev/stdin')"
 ```
 


### PR DESCRIPTION
Just a stray SQL comment that fled to a nearby Bash block.

I took a look at every other Bash annotation in the code base and it seems that this is the only place where the `--` escaped to. For reference:

```bash
rg --multiline ' *```bash(?:.*\n)*? *```' .
```