### PR TITLE
Move Guides under Documentation

### DIFF
--- a/_data/menu_docs_dev.json
+++ b/_data/menu_docs_dev.json
@@ -6,291 +6,7 @@
       "url": "index"
     },
     {
-      "page": "Guides",
-      "open": true,
-      "slug": "guides/",
-      "mainfolderitems": [
-        {
-          "page": "Overview",
-          "url": "index"
-        },
-        {
-          "page": "Data Import & Export",
-          "slug": "import",
-          "subfolderitems": [
-            {
-              "page": "Overview",
-              "url": "overview"
-            },
-            {
-              "page": "CSV Import",
-              "url": "csv_import"
-            },
-            {
-              "page": "CSV Export",
-              "url": "csv_export"
-            },
-            {
-              "page": "Parquet Import",
-              "url": "parquet_import"
-            },
-            {
-              "page": "Parquet Export",
-              "url": "parquet_export"
-            },
-            {
-              "page": "Querying Parquet Files",
-              "url": "query_parquet"
-            },
-            {
-              "page": "HTTP Parquet Import",
-              "url": "http_import"
-            },
-            {
-              "page": "S3 Parquet Import",
-              "url": "s3_import"
-            },
-            {
-              "page": "S3 Parquet Export",
-              "url": "s3_export"
-            },
-            {
-              "page": "S3 Iceberg Import",
-              "url": "s3_iceberg_import"
-            },
-            {
-              "page": "S3 Express One",
-              "url": "s3_express_one"
-            },
-            {
-              "page": "GCS Import",
-              "url": "gcs_import"
-            },
-            {
-              "page": "Cloudflare R2 Import",
-              "url": "cloudflare_r2_import"
-            },
-            {
-              "page": "JSON Import",
-              "url": "json_import"
-            },
-            {
-              "page": "JSON Export",
-              "url": "json_export"
-            },
-            {
-              "page": "Excel Import",
-              "url": "excel_import"
-            },
-            {
-              "page": "Excel Export",
-              "url": "excel_export"
-            },
-            {
-              "page": "MySQL Import",
-              "url": "query_mysql"
-            },
-            {
-              "page": "PostgreSQL Import",
-              "url": "query_postgres"
-            },
-            {
-              "page": "SQLite Import",
-              "url": "query_sqlite"
-            },
-            {
-              "page": "Directly Reading Files",
-              "url": "read_file"
-            }
-          ]
-        },
-        {
-          "page": "Performance",
-          "slug": "performance",
-          "subfolderitems": [
-            {
-              "page": "Overview",
-              "url": "overview"
-            },
-            {
-              "page": "Schema",
-              "url": "schema"
-            },
-            {
-              "page": "Indexing",
-              "url": "indexing"
-            },
-            {
-              "page": "Environment",
-              "url": "environment"
-            },
-            {
-              "page": "File Formats",
-              "url": "file_formats"
-            },
-            {
-              "page": "How to Tune Workloads",
-              "url": "how_to_tune_workloads"
-            },
-            {
-              "page": "My Workload Is Slow",
-              "url": "my_workload_is_slow"
-            },
-            {
-              "page": "Benchmarks",
-              "url": "benchmarks"
-            }
-          ]
-        },
-        {
-          "page": "Meta Queries",
-          "slug": "meta",
-          "subfolderitems": [
-            {
-              "page": "Describe Table",
-              "url": "describe"
-            },
-            {
-              "page": "EXPLAIN: Inspect Query Plans",
-              "url": "explain"
-            },
-            {
-              "page": "EXPLAIN ANALYZE: Profile Queries",
-              "url": "explain_analyze"
-            },
-            {
-              "page": "List Tables",
-              "url": "list_tables"
-            },
-            {
-              "page": "Summarize",
-              "url": "summarize"
-            },
-            {
-              "page": "DuckDB Environment",
-              "url": "duckdb_environment"
-            }
-          ]
-        },
-        {
-          "page": "ODBC",
-          "slug": "odbc",
-          "subfolderitems": [
-            {
-              "page": "ODBC Guide",
-              "url": "general"
-            }
-          ]
-        },
-        {
-          "page": "Python",
-          "slug": "python",
-          "subfolderitems": [
-            {
-              "page": "Installation",
-              "url": "install"
-            },
-            {
-              "page": "Executing SQL",
-              "url": "execute_sql"
-            },
-            {
-              "page": "Jupyter Notebooks",
-              "url": "jupyter"
-            },
-            {
-              "page": "SQL on Pandas",
-              "url": "sql_on_pandas"
-            },
-            {
-              "page": "Import from Pandas",
-              "url": "import_pandas"
-            },
-            {
-              "page": "Export to Pandas",
-              "url": "export_pandas"
-            },
-            {
-              "page": "SQL on Arrow",
-              "url": "sql_on_arrow"
-            },
-            {
-              "page": "Import from Arrow",
-              "url": "import_arrow"
-            },
-            {
-              "page": "Export to Arrow",
-              "url": "export_arrow"
-            },
-            {
-              "page": "Relational API on Pandas",
-              "url": "relational_api_pandas"
-            },
-            {
-              "page": "Multiple Python Threads",
-              "url": "multiple_threads"
-            },
-            {
-              "page": "Integration with Ibis",
-              "url": "ibis"
-            },
-            {
-              "page": "Integration with Polars",
-              "url": "polars"
-            },
-            {
-              "page": "Using fsspec Filesystems",
-              "url": "filesystems"
-            }
-          ]
-        },
-        {
-          "page": "SQL Features",
-          "slug": "sql_features",
-          "subfolderitems": [
-            {
-              "page": "Friendly SQL",
-              "url": "friendly_sql"
-            },
-            {
-              "page": "AsOf Join",
-              "url": "asof_join"
-            },
-            {
-              "page": "Full-Text Search",
-              "url": "full_text_search"
-            }
-          ]
-        },
-        {
-          "page": "SQL Editors",
-          "slug": "sql_editors",
-          "subfolderitems": [
-            {
-              "page": "DBeaver SQL IDE",
-              "url": "dbeaver"
-            }
-          ]
-        },
-        {
-          "page": "Data Viewers",
-          "slug": "data_viewers",
-          "subfolderitems": [
-            {
-              "page": "Tableau",
-              "url": "tableau"
-            },
-            {
-              "page": "CLI Charting with YouPlot",
-              "url": "youplot"
-            }
-          ]
-        }
-      ]
-    },
-    {
       "page": "Documentation",
-      "open": true,
       "slug": "",
       "mainfolderitems": [
         {
@@ -1230,7 +946,289 @@
               "url": "tpch"
             }
           ]
-        }
+        },
+        {
+          "page": "Guides",
+          "slug": "guides",
+          "subfolderitems": [
+            {
+              "page": "Overview",
+              "url": "overview"
+            },
+            {
+              "page": "Data Import & Export",
+              "slug": "import",
+              "subsubfolderitems": [
+                {
+                  "page": "Overview",
+                  "url": "overview"
+                },
+                {
+                  "page": "CSV Import",
+                  "url": "csv_import"
+                },
+                {
+                  "page": "CSV Export",
+                  "url": "csv_export"
+                },
+                {
+                  "page": "Parquet Import",
+                  "url": "parquet_import"
+                },
+                {
+                  "page": "Parquet Export",
+                  "url": "parquet_export"
+                },
+                {
+                  "page": "Querying Parquet Files",
+                  "url": "query_parquet"
+                },
+                {
+                  "page": "HTTP Parquet Import",
+                  "url": "http_import"
+                },
+                {
+                  "page": "S3 Parquet Import",
+                  "url": "s3_import"
+                },
+                {
+                  "page": "S3 Parquet Export",
+                  "url": "s3_export"
+                },
+                {
+                  "page": "S3 Iceberg Import",
+                  "url": "s3_iceberg_import"
+                },
+                {
+                  "page": "S3 Express One",
+                  "url": "s3_express_one"
+                },
+                {
+                  "page": "GCS Import",
+                  "url": "gcs_import"
+                },
+                {
+                  "page": "Cloudflare R2 Import",
+                  "url": "cloudflare_r2_import"
+                },
+                {
+                  "page": "JSON Import",
+                  "url": "json_import"
+                },
+                {
+                  "page": "JSON Export",
+                  "url": "json_export"
+                },
+                {
+                  "page": "Excel Import",
+                  "url": "excel_import"
+                },
+                {
+                  "page": "Excel Export",
+                  "url": "excel_export"
+                },
+                {
+                  "page": "MySQL Import",
+                  "url": "query_mysql"
+                },
+                {
+                  "page": "PostgreSQL Import",
+                  "url": "query_postgres"
+                },
+                {
+                  "page": "SQLite Import",
+                  "url": "query_sqlite"
+                },
+                {
+                  "page": "Directly Reading Files",
+                  "url": "read_file"
+                }
+              ]
+            },
+            {
+              "page": "Performance",
+              "slug": "performance",
+              "subsubfolderitems": [
+                {
+                  "page": "Overview",
+                  "url": "overview"
+                },
+                {
+                  "page": "Schema",
+                  "url": "schema"
+                },
+                {
+                  "page": "Indexing",
+                  "url": "indexing"
+                },
+                {
+                  "page": "Environment",
+                  "url": "environment"
+                },
+                {
+                  "page": "File Formats",
+                  "url": "file_formats"
+                },
+                {
+                  "page": "How to Tune Workloads",
+                  "url": "how_to_tune_workloads"
+                },
+                {
+                  "page": "My Workload Is Slow",
+                  "url": "my_workload_is_slow"
+                },
+                {
+                  "page": "Benchmarks",
+                  "url": "benchmarks"
+                }
+              ]
+            },
+            {
+              "page": "Meta Queries",
+              "slug": "meta",
+              "subsubfolderitems": [
+                {
+                  "page": "Describe Table",
+                  "url": "describe"
+                },
+                {
+                  "page": "EXPLAIN: Inspect Query Plans",
+                  "url": "explain"
+                },
+                {
+                  "page": "EXPLAIN ANALYZE: Profile Queries",
+                  "url": "explain_analyze"
+                },
+                {
+                  "page": "List Tables",
+                  "url": "list_tables"
+                },
+                {
+                  "page": "Summarize",
+                  "url": "summarize"
+                },
+                {
+                  "page": "DuckDB Environment",
+                  "url": "duckdb_environment"
+                }
+              ]
+            },
+            {
+              "page": "ODBC",
+              "slug": "odbc",
+              "subsubfolderitems": [
+                {
+                  "page": "ODBC Guide",
+                  "url": "general"
+                }
+              ]
+            },
+            {
+              "page": "Python",
+              "slug": "python",
+              "subsubfolderitems": [
+                {
+                  "page": "Installation",
+                  "url": "install"
+                },
+                {
+                  "page": "Executing SQL",
+                  "url": "execute_sql"
+                },
+                {
+                  "page": "Jupyter Notebooks",
+                  "url": "jupyter"
+                },
+                {
+                  "page": "SQL on Pandas",
+                  "url": "sql_on_pandas"
+                },
+                {
+                  "page": "Import from Pandas",
+                  "url": "import_pandas"
+                },
+                {
+                  "page": "Export to Pandas",
+                  "url": "export_pandas"
+                },
+                {
+                  "page": "SQL on Arrow",
+                  "url": "sql_on_arrow"
+                },
+                {
+                  "page": "Import from Arrow",
+                  "url": "import_arrow"
+                },
+                {
+                  "page": "Export to Arrow",
+                  "url": "export_arrow"
+                },
+                {
+                  "page": "Relational API on Pandas",
+                  "url": "relational_api_pandas"
+                },
+                {
+                  "page": "Multiple Python Threads",
+                  "url": "multiple_threads"
+                },
+                {
+                  "page": "Integration with Ibis",
+                  "url": "ibis"
+                },
+                {
+                  "page": "Integration with Polars",
+                  "url": "polars"
+                },
+                {
+                  "page": "Using fsspec Filesystems",
+                  "url": "filesystems"
+                }
+              ]
+            },
+            {
+              "page": "SQL Features",
+              "slug": "sql_features",
+              "subsubfolderitems": [
+                {
+                  "page": "Friendly SQL",
+                  "url": "friendly_sql"
+                },
+                {
+                  "page": "AsOf Join",
+                  "url": "asof_join"
+                },
+                {
+                  "page": "Full-Text Search",
+                  "url": "full_text_search"
+                }
+              ]
+            },
+            {
+              "page": "SQL Editors",
+              "slug": "sql_editors",
+              "subsubfolderitems": [
+                {
+                  "page": "DBeaver SQL IDE",
+                  "url": "dbeaver"
+                }
+              ]
+            },
+            {
+              "page": "Data Viewers",
+              "slug": "data_viewers",
+              "subsubfolderitems": [
+                {
+                  "page": "Tableau",
+                  "url": "tableau"
+                },
+                {
+                  "page": "CLI Charting with YouPlot",
+                  "url": "youplot"
+                }
+              ]
+            }
+          ]
+        }    
       ]
     }
   ]

--- a/_includes/breadcrumbs.html
+++ b/_includes/breadcrumbs.html
@@ -27,16 +27,7 @@
     {% assign offset = offset | plus:2 %}
   {% endif %}
 
-  {% if crumbs[offset] == "guides" %}
-    {% assign offset = offset | plus:1 %}
-    {% assign part = "Guides" %}
-  {% else %}
-    {% assign part = "Documentation" %}
-  {% endif %}
-
-  {% if crumbs.last != "docs" and crumbs.last != "guides" %}
-    <span>{{ part }}</span>
-  {% endif %}
+  <span>Documentation</span>
 
   {% for doc_entry in menudocfile %}
     {% assign crumb = crumbs[offset] %}
@@ -72,4 +63,3 @@
 
   <br/>
 </div>
-

--- a/docs/guides/overview.md
+++ b/docs/guides/overview.md
@@ -1,9 +1,12 @@
 ---
 layout: docu
 title: Guides
+redirect_from:
+  - /docs/guides
+  - /docs/guides/index
 ---
 
-The guides section contains compact how-to guides that are focused on achieving a single goal. For an in-depth reference see the Documentation section.
+The guides section contains compact how-to guides that are focused on achieving a single goal. For an API references and examples, see the rest of the documentation.
 
 Note that there are many tools using DuckDB, which are not covered in the official guides. To find a list of these tools, check out the [Awesome DuckDB repository](https://github.com/davidgasquez/awesome-duckdb).
 

--- a/single-file-document/concatenate_to_single_file.py
+++ b/single-file-document/concatenate_to_single_file.py
@@ -316,7 +316,6 @@ with open("../_data/menu_docs_dev.json") as menu_docs_file, open(f"duckdb-docs.m
         of.write(cover_page_file.read())
 
     add_to_documentation(docs_root, data, of, "Documentation")
-    add_to_documentation(docs_root, data, of, "Guides")
     add_under_the_hood_chapter(docs_root, data, of)
 
     with open("acknowledgments.md") as acknowledgments_file:


### PR DESCRIPTION
Guides are under Documentation in terms of URL (`/docs/guides`) but they have a separate place in the left sidebar. This PR moves them under Documentation to make their handling (highlighting the active one, etc.) simpler. URLs do not change.

The next step is moving the Developer Pages under documentation, and the next-next step is disentangling the new `/docs` a bit, may following [Diátaxis](https://diataxis.fr/).

Supersedes #2565