### PR TITLE
Remove empty Markdown tables

### DIFF
--- a/docs/extensions/mysql.md
+++ b/docs/extensions/mysql.md
@@ -196,6 +196,8 @@ INSERT INTO mysql_db.tmp VALUES (42);
 SELECT * FROM mysql_db.tmp;
 ```
 
+This returns:
+
 | i  |
 |---:|
 | 42 |
@@ -205,8 +207,7 @@ ROLLBACK;
 SELECT * FROM mysql_db.tmp;
 ```
 
-| i |
-|--:|
+This returns an empty table.
 
 > The DDL statements are not transactional in MySQL.
 

--- a/docs/extensions/postgres.md
+++ b/docs/extensions/postgres.md
@@ -237,6 +237,8 @@ INSERT INTO postgres_db.tmp VALUES (42);
 SELECT * FROM postgres_db.tmp;
 ```
 
+This returns:
+
 | i  |
 |---:|
 | 42 |
@@ -246,8 +248,7 @@ ROLLBACK;
 SELECT * FROM postgres_db.tmp;
 ```
 
-| i |
-|--:|
+This returns an empty table.
 
 ## Running SQL Queries in Postgres
 


### PR DESCRIPTION
They are rendered incorrectly by Jekyll, making the output unreadable