### PR TITLE
Update aggregates.md

### DIFF
--- a/docs/sql/aggregates.md
+++ b/docs/sql/aggregates.md
@@ -142,11 +142,11 @@ as the first argument.
 
 | Function | Equivalent |
 |:---|:---|
-| `mode() WITHIN GROUP (ORDER BY column [(ASC|DESC)])` | `mode(column ORDER BY column [(ASC|DESC)])` |
-| `percentile_cont(fraction) WITHIN GROUP (ORDER BY column [(ASC|DESC)])` | `quantile_cont(column, fraction ORDER BY column [(ASC|DESC)])` |
-| `percentile_cont(fractions) WITHIN GROUP (ORDER BY column [(ASC|DESC)])` | `quantile_cont(column, fractions ORDER BY column [(ASC|DESC)])` |
-| `percentile_disc(fraction) WITHIN GROUP (ORDER BY column [(ASC|DESC)])` | `quantile_disc(column, fraction ORDER BY column [(ASC|DESC)])` |
-| `percentile_disc(fractions) WITHIN GROUP (ORDER BY column [(ASC|DESC)])` | `quantile_disc(column, fractions ORDER BY column [(ASC|DESC)])` |
+| `mode() WITHIN GROUP (ORDER BY column [(ASC&#124;DESC)])` | `mode(column ORDER BY column [(ASC&#124;DESC)])` |
+| `percentile_cont(fraction) WITHIN GROUP (ORDER BY column [(ASC&#124;DESC)])` | `quantile_cont(column, fraction ORDER BY column [(ASC&#124;DESC)])` |
+| `percentile_cont(fractions) WITHIN GROUP (ORDER BY column [(ASC&#124;DESC)])` | `quantile_cont(column, fractions ORDER BY column [(ASC&#124;DESC)])` |
+| `percentile_disc(fraction) WITHIN GROUP (ORDER BY column [(ASC&#124;DESC)])` | `quantile_disc(column, fraction ORDER BY column [(ASC&#124;DESC)])` |
+| `percentile_disc(fractions) WITHIN GROUP (ORDER BY column [(ASC&#124;DESC)])` | `quantile_disc(column, fractions ORDER BY column [(ASC&#124;DESC)])` |
 
 ## Miscellaneous Aggregate Functions
 

--- a/docs/sql/aggregates.md
+++ b/docs/sql/aggregates.md
@@ -142,11 +142,12 @@ as the first argument.
 
 | Function | Equivalent |
 |:---|:---|
-| `mode() WITHIN GROUP (ORDER BY column [(ASC&#124;DESC)])` | `mode(column ORDER BY column [(ASC&#124;DESC)])` |
-| `percentile_cont(fraction) WITHIN GROUP (ORDER BY column [(ASC&#124;DESC)])` | `quantile_cont(column, fraction ORDER BY column [(ASC&#124;DESC)])` |
-| `percentile_cont(fractions) WITHIN GROUP (ORDER BY column [(ASC&#124;DESC)])` | `quantile_cont(column, fractions ORDER BY column [(ASC&#124;DESC)])` |
-| `percentile_disc(fraction) WITHIN GROUP (ORDER BY column [(ASC&#124;DESC)])` | `quantile_disc(column, fraction ORDER BY column [(ASC&#124;DESC)])` |
-| `percentile_disc(fractions) WITHIN GROUP (ORDER BY column [(ASC&#124;DESC)])` | `quantile_disc(column, fractions ORDER BY column [(ASC&#124;DESC)])` |
+| <code>mode() WITHIN GROUP (ORDER BY column [(ASC&#124;DESC)])</code> | <code>mode(column ORDER BY column [(ASC&#124;DESC)])</code> |
+| <code>percentile_cont(fraction) WITHIN GROUP (ORDER BY column [(ASC&#124;DESC)])</code> | <code>quantile_cont(column, fraction ORDER BY column [(ASC&#124;DESC)])</code> |
+| <code>percentile_cont(fractions) WITHIN GROUP (ORDER BY column [(ASC&#124;DESC)])</code> | <code>quantile_cont(column, fractions ORDER BY column [(ASC&#124;DESC)])</code> |
+| <code>percentile_disc(fraction) WITHIN GROUP (ORDER BY column [(ASC&#124;DESC)])</code> | <code>quantile_disc(column, fraction ORDER BY column [(ASC&#124;DESC)])</code> |
+| <code>percentile_disc(fractions) WITHIN GROUP (ORDER BY column [(ASC&#124;DESC)])</code> | <code>quantile_disc(column, fractions ORDER BY column [(ASC&#124;DESC)])</code> |
+
 
 ## Miscellaneous Aggregate Functions
 

--- a/docs/sql/aggregates.md
+++ b/docs/sql/aggregates.md
@@ -142,11 +142,11 @@ as the first argument.
 
 | Function | Equivalent |
 |:---|:---|
-| `mode() WITHIN GROUP (ORDER BY sort_expression)` | `mode(sort_expression)` |
-| `percentile_cont(fraction) WITHIN GROUP (ORDER BY sort_expression)` | `quantile_cont(sort_expression, fraction)` |
-| `percentile_cont(fractions) WITHIN GROUP (ORDER BY sort_expression)` | `quantile_cont(sort_expression, fractions)` |
-| `percentile_disc(fraction) WITHIN GROUP (ORDER BY sort_expression)` | `quantile_disc(sort_expression, fraction)` |
-| `percentile_disc(fractions) WITHIN GROUP (ORDER BY sort_expression)` | `quantile_disc(sort_expression, fractions)` |
+| `mode() WITHIN GROUP (ORDER BY column [(ASC|DESC)])` | `mode(column ORDER BY column [(ASC|DESC)])` |
+| `percentile_cont(fraction) WITHIN GROUP (ORDER BY column [(ASC|DESC)])` | `quantile_cont(column, fraction ORDER BY column [(ASC|DESC)])` |
+| `percentile_cont(fractions) WITHIN GROUP (ORDER BY column [(ASC|DESC)])` | `quantile_cont(column, fractions ORDER BY column [(ASC|DESC)])` |
+| `percentile_disc(fraction) WITHIN GROUP (ORDER BY column [(ASC|DESC)])` | `quantile_disc(column, fraction ORDER BY column [(ASC|DESC)])` |
+| `percentile_disc(fractions) WITHIN GROUP (ORDER BY column [(ASC|DESC)])` | `quantile_disc(column, fractions ORDER BY column [(ASC|DESC)])` |
 
 ## Miscellaneous Aggregate Functions
 


### PR DESCRIPTION
```sql
SELECT 
mode() WITHIN GROUP (ORDER BY x),
mode(x),
mode(x ORDER BY x),
FROM 
(VALUES (2), (1)) _(x)
```
```
┌───────────────────────────────────┬─────────┬────────────────────┐
│ mode() WITHIN GROUP ( ORDER BY x) │ mode(x) │ mode(x ORDER BY x) │
│               int32               │  int32  │       int32        │
├───────────────────────────────────┼─────────┼────────────────────┤
│                                 1 │       2 │                  1 │
└───────────────────────────────────┴─────────┴────────────────────┘
```
shows that the `WITHIN GROUP` aggregate is converted to something more involved than what was previously claimed.

EDIT: Related ticket at  https://github.com/duckdb/duckdb/issues/11419, but I still think this PR makes the docs more correct than they currently are even without that ticket being resolved yet.