### PR TITLE
Add aarch64 R package installation warning

### DIFF
--- a/_includes/installation.html
+++ b/_includes/installation.html
@@ -90,6 +90,8 @@ print(cursor.execute('SELECT 42').fetchall()){% endhighlight %}
 
 	<div class="stable r">
 		{% highlight r %}install.packages("duckdb"){% endhighlight %}
+		<br/><br/>
+		On aarch64, if the DuckDB R package does not successfully compile, you may need to <a href="https://github.com/duckdb/duckdb/issues/3049">change your R environment's make variables</a>.
 	</div>
 
 	<div class="stable java package_manager">
@@ -245,6 +247,8 @@ print(cursor.execute('SELECT 42').fetchall()){% endhighlight %}
 
 	<div class="main r">
 		{% highlight r %}install.packages('duckdb', repos=c('https://duckdb.r-universe.dev', 'https://cloud.r-project.org')){% endhighlight %}
+		<br/><br/>
+		On aarch64, if the DuckDB R package does not successfully compile, you may need to <a href="https://github.com/duckdb/duckdb/issues/3049">change your R environment's make variables</a>.
 	</div>
 
 	<div class="main java package_manager">


### PR DESCRIPTION
There is an issue when installing the duckdb R package on aarch64 systems. For example, on Apple Silicon this:

```bash
docker run --rm -it debian:latest
```
```bash
apt update && apt install -y r-base build-essential
R -e "install.packages('duckdb')"
```
fails with this error:
```
database.o: in function `cpp11::._anon_102::get_preserve_list()':
/tmp/Rtmp2GQPNE/R.INSTALL1b663a54c21c/duckdb/src/../inst/include/cpp11/protect.hpp:397:(.text+0x78): relocation truncated to fit: R_AARCH64_LD64_GOTPAGE_LO15 against symbol `R_NilValue' defined in .bss section in /usr/lib/R/lib/libR.so
/usr/bin/ld: database.o: in function `get_preserve_xptr_addr':
/tmp/Rtmp2GQPNE/R.INSTALL1b663a54c21c/duckdb/src/../inst/include/cpp11/protect.hpp:397: warning: too many GOT entries for -fpic, please recompile with -fPIC
collect2: error: ld returned 1 exit status
make: *** [/usr/share/R/share/make/shlib.mk:10: duckdb.so] Error 1
ERROR: compilation failed for package 'duckdb'
```

This is because some distro's R installs, including Debian's, override the `make` CXX flags to `-fpic` instead of `-fPIC` which causes compilation failure on aarch64. Here is the relevant duckdb issue: https://github.com/duckdb/duckdb/issues/3049. This is not a fault in duckdb, but rather of R's package installer. Ideally this would be fixed in the distros packages or R, but even if done so that would take a while to roll out.

This PR adds this warning to the R package install page (in a similar way to https://github.com/duckdb/duckdb-web/pull/2757):

> On aarch64, if the DuckDB R package does not successfully compile, you may need to [change your R environment's make variables](https://github.com/duckdb/duckdb/issues/3049).
