### PR TITLE
Reshuffle rows in tables detailing window function

### DIFF
--- a/docs/sql/window_functions.md
+++ b/docs/sql/window_functions.md
@@ -51,24 +51,24 @@ The table below shows the available general window functions.
 
 <div class="nostroke_table"></div>
 
-| **Return Type** | `DOUBLE` |
 | **Description** | The cumulative distribution: (number of partition rows preceding or peer with current row) / total partition rows. |
+| **Return Type** | `DOUBLE` |
 | **Example** | `cume_dist()` |
 
 ### `dense_rank()`
 
 <div class="nostroke_table"></div>
 
-| **Return Type** | `BIGINT` |
 | **Description** | The rank of the current row *without gaps*; this function counts peer groups. |
+| **Return Type** | `BIGINT` |
 | **Example** | `dense_rank()` |
 
 ### `first(expr[ IGNORE NULLS])`
 
 <div class="nostroke_table"></div>
 
-| **Return Type** | Same type as `expr` |
 | **Description** | Returns `expr` evaluated at the row that is the first row (with a non-null value of `expr` if `IGNORE NULLS` is set) of the window frame. |
+| **Return Type** | Same type as `expr` |
 | **Example** | `first(column)` |
 | **Alias** | `first_value(column)` |
 
@@ -76,8 +76,8 @@ The table below shows the available general window functions.
 
 <div class="nostroke_table"></div>
 
-| **Return Type** | Same type as `expr` |
 | **Description** | Returns `expr` evaluated at the row that is the first row (with a non-null value of `expr` if `IGNORE NULLS` is set) of the window frame. |
+| **Return Type** | Same type as `expr` |
 | **Example** | `first_value(column)` |
 | **Alias** | `first(column)` |
 
@@ -85,16 +85,16 @@ The table below shows the available general window functions.
 
 <div class="nostroke_table"></div>
 
-| **Return Type** | Same type as `expr` |
 | **Description** | Returns `expr` evaluated at the row that is `offset` rows (among rows with a non-null value of `expr` if `IGNORE NULLS` is set) before the current row within the window frame; if there is no such row, instead return `default` (which must be of the Same type as `expr`). Both `offset` and `default` are evaluated with respect to the current row. If omitted, `offset` defaults to `1` and default to `NULL`. |
+| **Return Type** | Same type as `expr` |
 | **Aliases** | `lag(column, 3, 0)` |
 
 ### `last(expr[ IGNORE NULLS])`
 
 <div class="nostroke_table"></div>
 
-| **Return Type** | Same type as `expr` |
 | **Description** | Returns `expr` evaluated at the row that is the last row  (among rows with a non-null value of `expr` if `IGNORE NULLS` is set) of the window frame. |
+| **Return Type** | Same type as `expr` |
 | **Example** | `last(column)` |
 | **Alias** | `last_value(column)` |
 
@@ -102,8 +102,8 @@ The table below shows the available general window functions.
 
 <div class="nostroke_table"></div>
 
-| **Return Type** | Same type as `expr` |
 | **Description** | Returns `expr` evaluated at the row that is the last row  (among rows with a non-null value of `expr` if `IGNORE NULLS` is set) of the window frame. |
+| **Return Type** | Same type as `expr` |
 | **Example** | `last_value(column)` |
 | **Alias** | `last(column)` |
 
@@ -111,40 +111,40 @@ The table below shows the available general window functions.
 
 <div class="nostroke_table"></div>
 
-| **Return Type** | Same type as `expr` |
 | **Description** | Returns `expr` evaluated at the row that is `offset` rows after the current row (among rows with a non-null value of `expr` if `IGNORE NULLS` is set) within the window frame; if there is no such row, instead return `default` (which must be of the Same type as `expr`). Both `offset` and `default` are evaluated with respect to the current row. If omitted, `offset` defaults to `1` and default to `NULL`. |
+| **Return Type** | Same type as `expr` |
 | **Aliases** | `lead(column, 3, 0)` |
 
 ### `nth_value(expr, nth[ IGNORE NULLS])`
 
 <div class="nostroke_table"></div>
 
-| **Return Type** | Same type as `expr` |
 | **Description** | Returns `expr` evaluated at the nth row (among rows with a non-null value of `expr` if `IGNORE NULLS` is set) of the window frame (counting from 1); `NULL` if no such row. |
+| **Return Type** | Same type as `expr` |
 | **Aliases** | `nth_value(column, 2)` |
 
 ### `ntile(num_buckets)`
 
 <div class="nostroke_table"></div>
 
-| **Return Type** | `BIGINT` |
 | **Description** | An integer ranging from 1 to `num_buckets`, dividing the partition as equally as possible. |
+| **Return Type** | `BIGINT` |
 | **Example** | `ntile(4)` |
 
 ### `percent_rank()`
 
 <div class="nostroke_table"></div>
 
-| **Return Type** | `DOUBLE` |
 | **Description** | The relative rank of the current row: `(rank() - 1) / (total partition rows - 1)`. |
+| **Return Type** | `DOUBLE` |
 | **Example** | `percent_rank()` |
 
 ### `rank_dense()`
 
 <div class="nostroke_table"></div>
 
-| **Return Type** | `BIGINT` |
 | **Description** | The rank of the current row *with gaps*; same as `row_number` of its first peer. |
+| **Return Type** | `BIGINT` |
 | **Example** | `rank_dense()` |
 | **Alias** | `rank()` |
 
@@ -152,8 +152,8 @@ The table below shows the available general window functions.
 
 <div class="nostroke_table"></div>
 
-| **Return Type** | `BIGINT` |
 | **Description** | The rank of the current row *with gaps*; same as `row_number` of its first peer. |
+| **Return Type** | `BIGINT` |
 | **Example** | `rank()` |
 | **Alias** | `rank_dense()` |
 
@@ -161,8 +161,8 @@ The table below shows the available general window functions.
 
 <div class="nostroke_table"></div>
 
-| **Return Type** | `BIGINT` |
 | **Description** | The number of the current row within the partition, counting from 1. |
+| **Return Type** | `BIGINT` |
 | **Example** | `row_number()` |
 
 ## Aggregate Window Functions


### PR DESCRIPTION
This change is required... headerless tables current must start with a "Description" field to be rendered correctly in the documentation, see https://github.com/duckdb/duckdb-web/blob/1f6f81d189ddb6d779fe4b6280dff169c6f40be5/single-file-document/concatenate_to_single_file.py#L181-L184

Since starting the tables with the "Description" field makes perfect sense for one that give details window functions, it's easier to make this change than to adjust the script.