### PR TITLE
Simplify JDBC example

### DIFF
--- a/docs/api/java.md
+++ b/docs/api/java.md
@@ -77,13 +77,13 @@ Connection conn = DriverManager.getConnection("jdbc:duckdb:/tmp/my_database", co
 DuckDB supports the standard JDBC methods to send queries and retrieve result sets. First a `Statement` object has to be created from the `Connection`, this object can then be used to send queries using `execute` and `executeQuery`. `execute()` is meant for queries where no results are expected like `CREATE TABLE` or `UPDATE` etc. and `executeQuery()` is meant to be used for queries that produce results (e.g., `SELECT`). Below two examples. See also the JDBC [`Statement`](https://docs.oracle.com/javase/7/docs/api/java/sql/Statement.html) and [`ResultSet`](https://docs.oracle.com/javase/7/docs/api/java/sql/ResultSet.html) documentations.
 
 ```java
-import org.duckdb.DuckDBConnection;
+import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 
-DuckDBConnection conn = (DuckDBConnection) DriverManager.getConnection("jdbc:duckdb:");
+Connection conn = DriverManager.getConnection("jdbc:duckdb:");
 
 // create a table
 Statement stmt = conn.createStatement();


### PR DESCRIPTION
Remove `DuckDBConnection` as it's not used in the example.