### PR TITLE
add $ before bash code blocks

### DIFF
--- a/css/syntax_highlighting.scss
+++ b/css/syntax_highlighting.scss
@@ -59,6 +59,10 @@
 	color: #c5a332;
 }
 
+.language-bash code:before {
+  content: '$ ';
+}
+
 // keywords in table headers
 th .k {
 	color: #fff;

--- a/js/copy_button.js
+++ b/js/copy_button.js
@@ -2,12 +2,14 @@ $(document).ready(function() {
     var codeBlocks = [].concat(...document.querySelectorAll('pre.highlight'), ...document.querySelectorAll('figure.highlight'));
 
     codeBlocks.forEach(function (codeBlock) {
-        var copyButton = document.createElement('button');
-        copyButton.className = 'copy';
-        copyButton.type = 'button';
-        copyButton.ariaLabel = 'Copy code to clipboard';
-        copyButton.innerHTML = '<span class="copy"></span>';
-        codeBlock.append(copyButton);
+        if (!$(codeBlock).parents().hasClass('language-console')) {
+            var copyButton = document.createElement('button');
+            copyButton.className = 'copy';
+            copyButton.type = 'button';
+            copyButton.ariaLabel = 'Copy code to clipboard';
+            copyButton.innerHTML = '<span class="copy"></span>';
+            codeBlock.append(copyButton);
+        }
     });
     
     $('main').on('click', 'button.copy', function() {


### PR DESCRIPTION
- will add $ before all bash code blocks via css. 
- remove copy button on error code blocks.

@szarnyasg important: you need to remove the manually added "$" from the codes. 