### PR TITLE
Simplify Bash code blocks

### DIFF
--- a/docs/api/adbc.md
+++ b/docs/api/adbc.md
@@ -136,7 +136,7 @@ StatementExecuteQuery(&adbc_statement, nullptr, nullptr, &adbc_error);
 
 The first thing to do is to use `pip` and install the ADBC Driver manager. You will also need to install the `pyarrow` to directly access Apache Arrow formatted result sets (such as using `fetch_arrow_table`).
 
-```shell
+```bash
 pip install adbc_driver_manager pyarrow
 ```
 

--- a/docs/api/cli/overview.md
+++ b/docs/api/cli/overview.md
@@ -26,7 +26,7 @@ If in a PowerShell or POSIX shell environment, use the command `./duckdb` instea
 The typical usage of the `duckdb` command is the following:
 
 ```bash
-$ duckdb [OPTIONS] [FILENAME]
+duckdb [OPTIONS] [FILENAME]
 ```
 
 ### Options
@@ -45,7 +45,7 @@ When no `[FILENAME]` argument is provided, the DuckDB CLI will open a temporary 
 You will see DuckDB's version number, the information on the connection and a prompt starting with a `D`.
 
 ```bash
-$ duckdb
+duckdb
 ```
 
 ```text
@@ -202,7 +202,7 @@ Note that the duck head is built with Unicode characters and does not work in al
 To invoke that file on initialization, use this command:
 
 ```bash
-$ duckdb -init prompt.sql
+duckdb -init prompt.sql
 ```
 
 This outputs:
@@ -221,13 +221,13 @@ Use ".open FILENAME" to reopen on a persistent database.
 To read/process a file and exit immediately, pipe the file contents in to `duckdb`:
 
 ```bash
-$ duckdb < select_example.sql
+duckdb < select_example.sql
 ```
 
 To execute a command with SQL text passed in directly from the command line, call `duckdb` with two arguments: the database location (or `:memory:`), and a string with the SQL statement to execute.
 
 ```bash
-$ duckdb :memory: "SELECT 42 AS the_answer"
+duckdb :memory: "SELECT 42 AS the_answer"
 ```
 
 ## Loading Extensions
@@ -255,7 +255,7 @@ COPY (SELECT 42 AS woot UNION ALL SELECT 43 AS woot) TO 'test.csv' (HEADER);
 First, read a file and pipe it to the `duckdb` CLI executable. As arguments to the DuckDB CLI, pass in the location of the database to open, in this case, an in-memory database, and a SQL command that utilizes `/dev/stdin` as a file location.
 
 ```bash
-$ cat test.csv | duckdb :memory: "SELECT * FROM read_csv('/dev/stdin')"
+cat test.csv | duckdb :memory: "SELECT * FROM read_csv('/dev/stdin')"
 ```
 
 | woot |
@@ -266,7 +266,7 @@ $ cat test.csv | duckdb :memory: "SELECT * FROM read_csv('/dev/stdin')"
 To write back to stdout, the copy command can be used with the `/dev/stdout` file location.
 
 ```sql
-$ cat test.csv | duckdb :memory: "COPY (SELECT * FROM read_csv('/dev/stdin')) TO '/dev/stdout' WITH (FORMAT 'csv', HEADER)"
+cat test.csv | duckdb :memory: "COPY (SELECT * FROM read_csv('/dev/stdin')) TO '/dev/stdout' WITH (FORMAT 'csv', HEADER)"
 ```
 
 ```csv

--- a/docs/dev/sqllogictest/debugging.md
+++ b/docs/dev/sqllogictest/debugging.md
@@ -59,10 +59,17 @@ build/debug/test/unittest --start-offset-percentage=10 --end-offset-percentage=2
 The set of tests to run can also be loaded from a file containing one test name per line, and loaded using the `-f` command.
 
 ```bash
-$ cat test.list
+cat test.list
+```
+
+```text
 test/sql/join/full_outer/test_full_outer_join_issue_4252.test
 test/sql/join/full_outer/full_outer_join_cache.test
 test/sql/join/full_outer/test_full_outer_join.test
-# run only the tests labeled in the file
-$ build/debug/test/unittest -f test.list
+```
+
+To run only the tests labeled in the file:
+
+```bash
+build/debug/test/unittest -f test.list
 ```

--- a/docs/guides/data_viewers/tableau.md
+++ b/docs/guides/data_viewers/tableau.md
@@ -8,8 +8,10 @@ In addition to a large number of built in connectors,
 it also provides generic database connectivity via ODBC and JDBC connectors.
 
 Tableau has two main versions: Desktop and Online (Server).
+
 * For Desktop, connecting to a DuckDB database is similar to working in an embedded environment like Python.
 * For Online, since DuckDB is in-process, the data needs to be either on the server itself
+
 or in a remote data bucket that is accessible from the server.
 
 ## Database Creation
@@ -85,10 +87,14 @@ On Linux, copy the Taco file to `/opt/tableau/connectors`.
 On Windows, copy the Taco file to `C:\Program Files\Tableau\Connectors`.
 Then issue these commands to disable signature validation:
 
-```sh
-$ tsm configuration set -k native_api.disable_verify_connector_plugin_signature -v true
-$ tsm pending-changes apply
+```bash
+tsm configuration set -k native_api.disable_verify_connector_plugin_signature -v true
 ```
+
+```bash
+tsm pending-changes apply
+```
+
 The last command will restart the server with the new settings.
 
 ### macOS
@@ -96,8 +102,8 @@ The last command will restart the server with the new settings.
 Copy the Taco file to the `/Users/[User]/Documents/My Tableau Repository/Connectors` folder.
 Then launch Tableau Desktop from the Terminal with the command line argument to disable signature validation:
 
-```sh
-$ /Applications/Tableau\ Desktop\ ⟨year⟩.⟨quarter⟩.app/Contents/MacOS/Tableau -DDisableVerifyConnectorPluginSignature=true
+```bash
+/Applications/Tableau\ Desktop\ ⟨year⟩.⟨quarter⟩.app/Contents/MacOS/Tableau -DDisableVerifyConnectorPluginSignature=true
 ```
 
 You can also package this up with AppleScript by using the following script:

--- a/docs/internals/storage.md
+++ b/docs/internals/storage.md
@@ -27,11 +27,10 @@ To move your database(s) to newer format you only need the older and the newer D
 Open your database file with the older DuckDB and run the SQL statement `EXPORT DATABASE 'tmp'`. This allows you to save the whole state of the current database in use inside folder `tmp`.
 The content of the `tmp` folder will be overridden, so choose an empty/non yet existing location. Then, start the newer DuckDB and execute `IMPORT DATABASE 'tmp'` (pointing to the previously populated folder) to load the database, which can be then saved to the file you pointed DuckDB to.
 
-A bash two-liner (to be adapted with the file names and executable locations) is:
+A bash one-liner (to be adapted with the file names and executable locations) is:
 
 ```bash
-$ /older/version/duckdb mydata.db -c "EXPORT DATABASE 'tmp'"
-$ /newer/duckdb mydata.new.db -c "IMPORT DATABASE 'tmp'"
+/older/version/duckdb mydata.db -c "EXPORT DATABASE 'tmp'" && /newer/duckdb mydata.new.db -c "IMPORT DATABASE 'tmp'"
 ```
 
 After this `mydata.db` will be untouched with the old format, `mydata.new.db` will contain the same data but in a format accessible from more recent DuckDB, and folder `tmp` will old the same data in an universal format as different files.
@@ -43,7 +42,10 @@ Check [`EXPORT` documentation](../sql/statements/export) for more details on the
 DuckDB files start with a `uint64_t` which contains a checksum for the main header, followed by four magic bytes (`DUCK`), followed by the storage version number in a `uint64_t`.
 
 ```bash
-$ hexdump -n 20 -C mydata.db
+hexdump -n 20 -C mydata.db
+```
+
+```text
 00000000  01 d0 e2 63 9c 13 39 3e  44 55 43 4b 2b 00 00 00  |...c..9>DUCK+...|
 00000010  00 00 00 00                                       |....|
 00000014


### PR DESCRIPTION
* drop the `$`
* make sure they are one-liners
* make sure to use the `bash` language tag