### PR TITLE
Fix cpp example to conform to current version QueryResult class.

### DIFF
--- a/docs/api/cpp.md
+++ b/docs/api/cpp.md
@@ -36,9 +36,11 @@ con.Query("CREATE TABLE integers (i INTEGER, j INTEGER)");
 // insert three rows into the table
 con.Query("INSERT INTO integers VALUES (3, 4), (5, 6), (7, NULL)");
 
-MaterializedQueryResult result = con.Query("SELECT * FROM integers");
-if (!result->success) {
-    cerr << result->error;
+auto result = con.Query("SELECT * FROM integers");
+if (result->HasError()) {
+    cerr << result->GetError() << endl;
+} else {
+    cout << result->ToString() << endl;
 }
 ```
 


### PR DESCRIPTION
I tried running the C++ example in the docs, and it gives errors using the current version of the QueryResult class. I have updated the basic example to use the current version of the class and added a simple print for the output.