### PR TITLE
Bump Bundler version and concurrent-ruby

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
     coffee-script-source (1.11.1)
     colorator (1.1.0)
     commonmarker (0.23.10)
-    concurrent-ruby (1.2.3)
+    concurrent-ruby (1.3.1)
     dnsruby (1.72.1)
       simpleidn (~> 0.2.1)
     em-websocket (0.5.3)
@@ -265,4 +265,4 @@ DEPENDENCIES
   word_wrap (~> 1.0)
 
 BUNDLED WITH
-   2.5.9
+   2.5.11


### PR DESCRIPTION
Makes the repo work with the latest Ruby/Bundler in brew, and also fixes the Docker image (fixes #2937)