### PR TITLE
Fix small copy-paste error (list_position example)

### DIFF
--- a/docs/sql/functions/nested.md
+++ b/docs/sql/functions/nested.md
@@ -248,7 +248,7 @@ This section describes functions and operators for examining and manipulating ne
 <div class="nostroke_table"></div>
 
 | **Description** | Returns the index of the element if the list contains the element. |
-| **Example** | `list_contains([1, 2, NULL], 2)` |
+| **Example** | `list_position([1, 2, NULL], 2)` |
 | **Result** | `2` |
 | **Aliases** | `list_indexof`, `array_position`, `array_indexof` |
 


### PR DESCRIPTION
Hi,

the example of `list_position` contained a copy paste error. In the example it said `list_contains` instead of `list_position`.