### PR TITLE
Move offline section to a separate guide page

### DIFF
--- a/_data/menu_docs_dev.json
+++ b/_data/menu_docs_dev.json
@@ -1312,6 +1312,10 @@
             {
               "page": "Glossary of Terms",
               "url": "glossary"
+            },
+            {
+              "page": "Browse Offline",
+              "url": "offline-copy"
             }
           ]
         },

--- a/docs/guides/offline-copy.md
+++ b/docs/guides/offline-copy.md
@@ -1,0 +1,16 @@
+---
+layout: docu
+title: Browse Offline
+---
+
+You can browse the DuckDB documentation offline in two formats:
+
+* As a [single-file PDF](/duckdb-docs.pdf) (approx. 4 MB)
+
+* As a [website packaged in a single ZIP file](/duckdb-docs.zip) (approx. 40 MB). To browse the website locally, decompress the package, navigate to the `duckdb-docs` directory, and run:
+
+  ```bash
+  python -m http.server
+  ```
+
+    Then, connect to <http://localhost:8000/>.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,10 +7,7 @@ Welcome to the DuckDB documentation!
 
 ## Offline Copy
 
-You can browse the DuckDB documentation offline:
-
-* As a <a href="/duckdb-docs.pdf">single-file PDF</a> (approx. 4 MB)
-* As a <a href="/duckdb-docs.zip">website packaged in a single ZIP file</a> (approx. 40 MB). To browse the website locally, decompress the package, run `python -m http.server` in the `duckdb-docs` directory, and connect to <http://localhost:8000/>.
+You can [browse the DuckDB documentation offline](/docs/guides/offline-copy).
 
 ## Sitemap
 


### PR DESCRIPTION
The current implementation is taking up too much prime real-estate, let's move it to a guide.