### PR TITLE
CI: Add site build step for PRs

### DIFF
--- a/.github/workflows/build-stable-documentation.yml
+++ b/.github/workflows/build-stable-documentation.yml
@@ -1,0 +1,21 @@
+name: Build stable documentation
+on: pull_request
+
+jobs:
+  # Build job
+  build_html:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3' # Not needed with a .ruby-version file
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          cache-version: 0 # Increment this number if you need to re-download cached gems
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+      - name: Build with Jekyll
+        run: bundle exec jekyll build --config _config.yml,_config_exclude_archive.yml


### PR DESCRIPTION
As we are now specifying links with {% link ... %} Jekyll tags, which fail the site build if the link is incorrect, it makes sense to actually check these for PRs. This will prevent broken internal links to be merged in the repository and will save time in the long run.