### PR TITLE
Fixed download link for: Nightly + CLI + Linux + Direct + x86_64

### DIFF
--- a/_includes/installation.html
+++ b/_includes/installation.html
@@ -294,8 +294,8 @@ print(cursor.execute('SELECT 42').fetchall()){% endhighlight %}
 		<a href="https://artifacts.duckdb.org/latest/duckdb-binaries-linux-aarch64.zip" target="_blank">https://artifacts.duckdb.org/latest/duckdb-binaries-linux-aarch64.zip</a>
 	</div>
 
-	<div class="main cli cplusplus binary macos direct">
-		<a href="https://artifacts.duckdb.org/latest/duckdb-binaries-osx.zip" target="_blank">https://artifacts.duckdb.org/latest/duckdb-binaries-osx.zip</a>
+	<div class="main cli cplusplus binary linux x86_64 direct">
+		<a href="https://artifacts.duckdb.org/latest/duckdb-binaries-linux.zip" target="_blank">https://artifacts.duckdb.org/latest/duckdb-binaries-linux.zip</a>
 	</div>
 
 	<div class="main cli cplusplus binary macos direct">


### PR DESCRIPTION
The download link showed the "odbc" download for the combination of: _Nightly + CLI + Linux + Direct + x86_64._

See screenshot (highlight from me):

<img width="869" alt="Screenshot 2024-07-05 at 10 42 53" src="https://github.com/duckdb/duckdb-web/assets/118010/40b126bc-565f-40cf-a96b-81359297e4bd">
