### PR TITLE
CI: Disable update docs job

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -1,6 +1,4 @@
 on:
-  schedule:
-    - cron: "0 5 * * 1"  # run every Monday day at 5AM
   workflow_dispatch: {}  # allow running manually from the github ui
 
 env:


### PR DESCRIPTION
The current [C API Reference](https://duckdb.org/docs/api/c/api) documents the v1.0.0 page, therefore, it should not be updated with functions from the latest build (v1.1.0-dev).