### PR TITLE
Fix nodejs docs gen

### DIFF
--- a/scripts/generate_nodejs_docs.js
+++ b/scripts/generate_nodejs_docs.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-const jsdoc2md = require('jsdoc-to-markdown');
-const fs = require('fs');
+const jsdoc2md = require("jsdoc-to-markdown");
+const fs = require("fs/promises");
 
 const duckdb = process.argv[2];
 if (!duckdb) {
@@ -9,15 +9,17 @@ if (!duckdb) {
     process.exit(1);
 }
 
-let docs = jsdoc2md.renderSync({ files: duckdb + '/lib/*.js' });
+async function generate_docs() {
+  let docs = await jsdoc2md.render({ files: duckdb + "/lib/*.js" });
 
-// Add newline after headers to conform to the Markdown linter's rules.
-// To achieve this, the regex looks for headers starting with two or more # characters,
-// that are followed by a non-empty line, using global and multi-line matching.
-add_newline_after_headers = /^(##+ .*\n)([^\n])/gm
-docs = docs.replace(add_newline_after_headers, "$1\n$2");
+  // Add newline after headers to conform to the Markdown linter's rules.
+  // To achieve this, the regex looks for headers starting with two or more # characters,
+  // that are followed by a non-empty line, using global and multi-line matching.
+  add_newline_after_headers = /^(##+ .*\n)([^\n])/gm;
+  docs = docs.replace(add_newline_after_headers, "$1\n$2");
 
-docs = `\
+  docs =
+    `\
 ---
 layout: docu
 title: Node.js API
@@ -25,4 +27,10 @@ title: Node.js API
 
 ` + docs;
 
-fs.writeFileSync(__dirname + '/../docs/api/nodejs/reference.md', docs);
+  await fs.writeFile(__dirname + "/../docs/api/nodejs/reference.md", docs);
+}
+
+generate_docs().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
new version (https://github.com/duckdb/duckdb-web/pull/3511) of jsdoc 2 markdown no longer supports sync generation