### PR TITLE
Clarify memory allocation limit

### DIFF
--- a/docs/operations_manual/limits.md
+++ b/docs/operations_manual/limits.md
@@ -10,7 +10,7 @@ This pages contains DuckDB's built-in limit values.
 | Array size | 100000 | - |
 | BLOB size | 4 GB | - |
 | Expression depth | 1000 | [`max_expression_depth`]({% link docs/configuration/overview.md %}) |
-| Memory allocation | 128 GB | - |
+| Memory allocation for a vector | 128 GB | - |
 | Memory use | 80% of RAM | [`memory_limit`]({% link docs/configuration/overview.md %}) |
 | String size | 4 GB | - |
 | Temporary directory size | unlimited | [`max_temp_directory_size`]({% link docs/configuration/overview.md %}) |


### PR DESCRIPTION
Clarifies limit discussed in [#2859](https://github.com/duckdb/duckdb-web/issues/2859#issuecomment-2326825319)