### PR TITLE
Add section on disabling autoinstalling/autoloading

### DIFF
--- a/docs/operations_manual/securing_duckdb/securing_extensions.md
+++ b/docs/operations_manual/securing_duckdb/securing_extensions.md
@@ -51,6 +51,22 @@ Despite this, installing and loading DuckDB extensions from the community extens
 SET allow_community_extensions = false;
 ```
 
+## Disabling Autoinstalling and Autoloading Known Extensions
+
+By default, DuckDB automatically installs and loads known extensions.
+
+To disable autoinstalling known extensions, run:
+
+```sql
+SET autoinstall_known_extensions = true;
+```
+
+To disable autoloading known extensions, run:
+
+```sql
+SET autoload_known_extensions = true;
+```
+
 ## Always Require Signed Extensions
 
 By default, DuckDB requires extensions to be either signed as core extensions (created by the DuckDB developers) or community extensions (created by third-party developers but distributed by the DuckDB developers). The `allow_unsigned_extensions` setting can be enabled on start-up to allow running extensions that are not signed at all. While useful for extension development, enabling this setting will allow DuckDB to load any extensions, which means more care must be taken to ensure malicious extensions are not loaded.

--- a/docs/operations_manual/securing_duckdb/securing_extensions.md
+++ b/docs/operations_manual/securing_duckdb/securing_extensions.md
@@ -67,6 +67,12 @@ To disable autoloading known extensions, run:
 SET autoload_known_extensions = true;
 ```
 
+To lock this configuration, use the [`lock_configuration` option]({% link docs/operations_manual/securing_duckdb/overview.md %}#locking-configurations):
+
+```sql
+SET lock_configuration = true;
+```
+
 ## Always Require Signed Extensions
 
 By default, DuckDB requires extensions to be either signed as core extensions (created by the DuckDB developers) or community extensions (created by third-party developers but distributed by the DuckDB developers). The `allow_unsigned_extensions` setting can be enabled on start-up to allow running extensions that are not signed at all. While useful for extension development, enabling this setting will allow DuckDB to load any extensions, which means more care must be taken to ensure malicious extensions are not loaded.


### PR DESCRIPTION
These are important security configuration flags that were so far omitted from the "Securing DuckDB" part of the docs – they were only mentioned in the blog and in the configuration flags overview.