### PR TITLE
fix link to duckdb-node-neo

### DIFF
--- a/docs/dev/repositories.md
+++ b/docs/dev/repositories.md
@@ -17,7 +17,7 @@ Several components of DuckDB are maintained in separate repositories.
 
 * [`duckdb-java`](https://github.com/duckdb/duckdb-java): Java (JDBC) client
 * [`duckdb-node`](https://github.com/duckdb/duckdb-node): Node.js client
-* [`duckdb-node-neo`](https://github.com/duckdb/duckdb-node): Node.js client, second iteration (currently experimental)
+* [`duckdb-node-neo`](https://github.com/duckdb/duckdb-node-neo): Node.js client, second iteration (currently experimental)
 * [`duckdb-odbc`](https://github.com/duckdb/duckdb-odbc): ODBC client
 * [`duckdb-r`](https://github.com/duckdb/duckdb-r): R client
 * [`duckdb-rs`](https://github.com/duckdb/duckdb-rs): Rust client


### PR DESCRIPTION
Link was erroneously to duckdb-node repo. This PR corrects the link