### PR TITLE
[Copy] Update the `copy.md` page

### DIFF
--- a/docs/sql/statements/copy.md
+++ b/docs/sql/statements/copy.md
@@ -204,12 +204,17 @@ The below options are applicable to all formats written with `COPY`.
 
 | Name | Description | Type | Default |
 |:--|:-----|:-|:-|
-| `FILE_SIZE_BYTES` | If this parameter is set, the `COPY` process creates a directory which will contain the exported files. If a file exceeds the set limit (specified as bytes such as `1000` or in human-readable format such as `1k`), the process creates a new file in the directory. This parameter works in combination with `PER_THREAD_OUTPUT`. Note that the size is used as an approximation, and files can be occasionally slightly over the limit. | `VARCHAR` or `BIGINT` | (empty) |
-| `FORMAT` | Specifies the copy function to use. The default is selected from the file extension (e.g., `.parquet` results in a Parquet file being written/read). If the file extension is unknown `CSV` is selected. Available options are `CSV`, `PARQUET` and `JSON`. | `VARCHAR` | auto |
-| `OVERWRITE_OR_IGNORE` | Whether or not to allow overwriting a directory if one already exists. Only has an effect when used with `partition_by`. | `BOOL` | `false` |
-| `PARTITION_BY` | The columns to partition by using a Hive partitioning scheme, see the [partitioned writes section]({% link docs/data/partitioning/partitioned_writes.md %}). | `VARCHAR[]` | (empty) |
-| `PER_THREAD_OUTPUT` | Generate one file per thread, rather than one file in total. This allows for faster parallel writing. | `BOOL` | `false` |
+| `FORMAT` | Specifies the copy function to use. The default is selected from the file extension (e.g., `.parquet` results in a Parquet file being written/read). If the file extension is unknown `CSV` is selected. Vanilla DuckDB provides `CSV`, `PARQUET` and `JSON` but additional copy functions can be added by [`extensions`]({% link docs/extensions/overview.md %}). | `VARCHAR` | `auto` |
 | `USE_TMP_FILE` | Whether or not to write to a temporary file first if the original file exists (`target.csv.tmp`). This prevents overwriting an existing file with a broken file in case the writing is cancelled. | `BOOL` | `auto` |
+| `OVERWRITE_OR_IGNORE` | Whether or not to allow overwriting files if they already exist. Only has an effect when used with `partition_by`. | `BOOL` | `false` |
+| `OVERWRITE` | When set, all existing files inside targeted directories will be removed (not supported on remote filesystems). Only has an effect when used with `partition_by`. | `BOOL` | `false` |
+| `APPEND` | When set, in the event a filename pattern is generated that already exists, the path will be regenerated to ensure no existing files are overwritten. Only has an effect when used with `partition_by`. | `BOOL` | `false` |
+| `FILENAME_PATTERN` | Set a pattern to use for the filename, can optionally contain `{uuid}` to be filled in with a generated UUID or `{id}` which is replaced by an incrementing index. Only has an effect when used with `partition_by`. | `VARCHAR` | `auto` |
+| `FILE_EXTENSION` | Set the file extension that should be assigned to the generated file(s). | `VARCHAR` | `auto` |
+| `PER_THREAD_OUTPUT` | Generate one file per thread, rather than one file in total. This allows for faster parallel writing. | `BOOL` | `false` |
+| `FILE_SIZE_BYTES` | If this parameter is set, the `COPY` process creates a directory which will contain the exported files. If a file exceeds the set limit (specified as bytes such as `1000` or in human-readable format such as `1k`), the process creates a new file in the directory. This parameter works in combination with `PER_THREAD_OUTPUT`. Note that the size is used as an approximation, and files can be occasionally slightly over the limit. | `VARCHAR` or `BIGINT` | (empty) |
+| `PARTITION_BY` | The columns to partition by using a Hive partitioning scheme, see the [partitioned writes section]({% link docs/data/partitioning/partitioned_writes.md %}). | `VARCHAR[]` | (empty) |
+| `RETURN_FILES` | Whether or not to include the created filepath(s) (as a `Files VARCHAR[]` column) in the query result. | `BOOL` | `false` |
 | `WRITE_PARTITION_COLUMNS` | Whether or not to write partition columns into files. Only has an effect when used with `partition_by`. | `BOOL` | `false` |
 
 ### Syntax

--- a/js/railroad.js
+++ b/js/railroad.js
@@ -1602,7 +1602,7 @@ function GenerateCopyFromOptions(options) {
 			Keyword("("),
 			OneOrMore(Choice(0, [
 				Sequence([Keyword("FORMAT"), Expression("format-type")]),
-				Sequence([Keyword("<format-specific-option>"), Expression("value")])
+				Sequence([Keyword("⟨format-specific-option⟩"), Expression("value")])
 			]), ",", "skip"),
 			Keyword(")")
 		]), "skip")
@@ -1616,7 +1616,7 @@ function GenerateCopyToOptions(options) {
 			Keyword("("),
 			OneOrMore(Choice(0, [
 				Sequence([Keyword("FORMAT"), Expression("format-type")]),
-				Sequence([Keyword("<format-specific-option>"), Expression("value")]),
+				Sequence([Keyword("⟨format-specific-option⟩"), Expression("value")]),
 				Sequence([Keyword("USE_TMP_FILE"), Choice(0, [Keyword("true"), Keyword("false")])]),
 				Sequence([Keyword("OVERWRITE_OR_IGNORE"), Choice(0, [Keyword("true"), Keyword("false")])]),
 				Sequence([Keyword("OVERWRITE"), Choice(0, [Keyword("true"), Keyword("false")])]),

--- a/js/railroad.js
+++ b/js/railroad.js
@@ -1588,13 +1588,11 @@ function GenerateColumnConstraints(options) {
 
 
 function GenerateColumnList(options) {
-	return Optional(
-		Sequence([
-			Keyword("("),
-			OneOrMore(Expression("column-name"), ","),
-			Keyword(")")
-		]), "skip"
-	)
+	return Sequence([
+		Keyword("("),
+		OneOrMore(Expression("column-name"), ","),
+		Keyword(")")
+	])
 }
 
 function GenerateCopyFromOptions(options) {
@@ -1604,20 +1602,7 @@ function GenerateCopyFromOptions(options) {
 			Keyword("("),
 			OneOrMore(Choice(0, [
 				Sequence([Keyword("FORMAT"), Expression("format-type")]),
-				Sequence([Keyword("DELIMITER"), Expression("delimiter")]),
-				Sequence([Keyword("NULL"), Expression("null-string")]),
-				Sequence([Keyword("HEADER"), Choice(0, [new Skip(), Keyword("true"), Keyword("false")])]),
-				Sequence([Keyword("QUOTE"), Expression("quote-string")]),
-				Sequence([Keyword("ESCAPE"), Expression("escape-string")]),
-				Sequence([Keyword("DATEFORMAT"), Expression("date-format")]),
-				Sequence([Keyword("TIMESTAMPFORMAT"), Expression("timestamp-format")]),
-				Sequence([Keyword("FORCE_NOT_NULL"), GenerateColumnList()]),
-				Sequence([Keyword("ENCODING"), Expression("UTF8")]),
-				Sequence([Keyword("AUTO_DETECT"),  Choice(0, [new Skip(), Keyword("true"), Keyword("false")])]),
-				Sequence([Keyword("SAMPLE_SIZE"), Expression("sample-size")]),
-				Sequence([Keyword("ALL_VARCHAR"), Choice(0, [new Skip(), Keyword("true"), Keyword("false")])]),
-				Sequence([Keyword("COMPRESSION"), Choice(0, [Expression('UNCOMPRESSED'),Expression('SNAPPY'),Expression('GZIP'),Expression('ZSTD')])]),
-				Sequence([Keyword("CODEC"), Choice(0, [Expression('UNCOMPRESSED'),Expression('SNAPPY'),Expression('GZIP'),Expression('ZSTD')])]),
+				Sequence([Keyword("<format-specific-option>"), Expression("value")])
 			]), ",", "skip"),
 			Keyword(")")
 		]), "skip")
@@ -1631,18 +1616,21 @@ function GenerateCopyToOptions(options) {
 			Keyword("("),
 			OneOrMore(Choice(0, [
 				Sequence([Keyword("FORMAT"), Expression("format-type")]),
-				Sequence([Keyword("DELIMITER"), Expression("delimiter")]),
-				Sequence([Keyword("NULL"), Expression("null-string")]),
-				Sequence([Keyword("HEADER"), Choice(0, [new Skip(), Keyword("true"), Keyword("false")])]),
-				Sequence([Keyword("QUOTE"), Expression("quote-string")]),
-				Sequence([Keyword("ESCAPE"), Expression("escape-string")]),
-				Sequence([Keyword("DATEFORMAT"), Expression("date-format")]),
-				Sequence([Keyword("TIMESTAMPFORMAT"), Expression("timestamp-format")]),
-				Sequence([Keyword("FORCE_QUOTE"), Choice(0, [GenerateColumnList(), Keyword("*")])]),
-				Sequence([Keyword("ENCODING"), Expression("UTF8")]),
-				Sequence([Keyword("COMPRESSION"), Choice(0, [Expression('UNCOMPRESSED'), Expression('SNAPPY'), Expression('GZIP'), Expression('ZSTD')])]),
-				Sequence([Keyword("CODEC"), Choice(0, [Expression('UNCOMPRESSED'), Expression('SNAPPY'), Expression('GZIP'), Expression('ZSTD')])]),
-				Sequence([Keyword("ROW_GROUP_SIZE"), Expression("parquet-row_group_size")]),
+				Sequence([Keyword("<format-specific-option>"), Expression("value")]),
+				Sequence([Keyword("USE_TMP_FILE"), Choice(0, [Keyword("true"), Keyword("false")])]),
+				Sequence([Keyword("OVERWRITE_OR_IGNORE"), Choice(0, [Keyword("true"), Keyword("false")])]),
+				Sequence([Keyword("OVERWRITE"), Choice(0, [Keyword("true"), Keyword("false")])]),
+				Sequence([Keyword("APPEND"), Choice(0, [Keyword("true"), Keyword("false")])]),
+				Sequence([Keyword("FILENAME_PATTERN"), Expression("filename-pattern")]),
+				Sequence([Keyword("FILE_EXTENSION"), Expression("file-extension")]),
+				Sequence([Keyword("PER_THREAD_OUTPUT"), Choice(0, [Keyword("true"), Keyword("false")])]),
+				Sequence([Keyword("FILE_SIZE_BYTES"), Choice(0, [
+					Expression("size-as-string"),
+					Expression("bytes"),
+				])]),
+				Sequence([Keyword("PARTITION_BY"), Choice(0, [GenerateColumnList(), Expression("column-name")])]),
+				Sequence([Keyword("RETURN_FILES"), Choice(0, [Keyword("true"), Keyword("false")])]),
+				Sequence([Keyword("WRITE_PARTITION_COLUMNS"), Choice(0, [Keyword("true"), Keyword("false")])]),
 			]), ",", "skip"),
 			Keyword(")")
 		]), "skip")

--- a/js/statements/copy.js
+++ b/js/statements/copy.js
@@ -14,7 +14,6 @@ function GenerateCopyFrom(options = {}) {
 	])
 }
 
-
 function GenerateCopyTo(options = {}) {
 	return Diagram([
 		AutomaticStack([
@@ -38,7 +37,6 @@ function GenerateCopyTo(options = {}) {
 		])
 	])
 }
-
 
 function GenerateCopyFromDatabase(options = {}) {
 	return Diagram([


### PR DESCRIPTION
I've updated both the documentation detailing the list of generic `COPY ... TO` options as well as update the railroad diagram displaying the `COPY ... TO` + `FROM` options, removing ones that are not generic.

Fixes the following issues:
- [APPEND](https://github.com/duckdb/duckdb-web/issues/2910)
- [OVERWRITE / OVERWRITE_OR_IGNORE](https://github.com/duckdb/duckdb-web/issues/2901)
- [FILENAME_PATTERN](https://github.com/duckdb/duckdb-web/issues/2053) (previously fixed but `FILENAME_PATTERN` was not added yet)
- [RETURN_FILES](https://github.com/duckdb/duckdb-web/issues/2924)