### PR TITLE
Update introduction.md to point to "current" version of Postgres

### DIFF
--- a/docs/sql/introduction.md
+++ b/docs/sql/introduction.md
@@ -5,7 +5,7 @@ title: SQL Introduction
 
 Here we provide an overview of how to perform simple operations in SQL.
 This tutorial is only intended to give you an introduction and is in no way a complete tutorial on SQL.
-This tutorial is adapted from the [PostgreSQL tutorial](https://www.postgresql.org/docs/11/tutorial-sql-intro.html).
+This tutorial is adapted from the [PostgreSQL tutorial](https://www.postgresql.org/docs/current/tutorial-sql-intro.html).
 
 > DuckDB's SQL dialect closely follows the conventions of the PostgreSQL dialect.
 > The few exceptions to this are listed on the [PostgreSQL compatibility page]({% link docs/sql/dialect/postgresql_compatibility.md %}).


### PR DESCRIPTION
DuckDB's documentation right now points to Postgres version 11 instead of Postgres "current".