### PR TITLE
remove BUILD_INET

### DIFF
--- a/docs/dev/building/building_extensions.md
+++ b/docs/dev/building/building_extensions.md
@@ -67,10 +67,6 @@ When this flag is set, the [`jemalloc` extension]({% link docs/extensions/jemall
 
 When this flag is set, the [`json` extension]({% link docs/extensions/json.md %}) is built.
 
-#### `BUILD_INET`
-
-When this flag is set, the [`inet` extension]({% link docs/extensions/inet.md %}) is built.
-
 ### Debug Flags
 
 #### `CRASH_ON_ASSERT`


### PR DESCRIPTION
I want to remove the introduction of `BUILD_INET` flag because INET now is a out source tree extension and  in fact  `BUILD_INET` now is not exist.