### PR TITLE
Remove hard-coded ToCs from blog posts

### DIFF
--- a/_posts/2024-02-13-announcing-duckdb-0100.md
+++ b/_posts/2024-02-13-announcing-duckdb-0100.md
@@ -19,23 +19,6 @@ To install the new version, please visit the [installation guide]({% link docs/i
 
 There have been too many changes to discuss them each in detail, but we would like to highlight several particularly exciting features!
 
-* [What's New in 0.10.0](#whats-new-in-0100)
-* [Breaking SQL Changes](#breaking-sql-changes)
-* [Backward Compatibility](#backward-compatibility)
-* [Forward Compatibility](#forward-compatibility)
-* [CSV Reader Rework](#csv-reader-rework)
-* [Fixed-Length Arrays](#fixed-length-arrays)
-* [Multi-Database Support](#multi-database-support)
-* [Secret Manager](#secret-manager)
-* [Temporary Memory Manager](#temporary-memory-manager)
-* [Adaptive Lossless Floating-Point Compression (ALP)](#adaptive-lossless-floating-point-compression-alp)
-* [CLI Improvements](#cli-improvements)
-* [Final Thoughts](#final-thoughts)
-  * [New Features](#new-features)
-  * [New Functions](#new-functions)
-  * [Storage Improvements](#storage-improvements)
-  * [Optimizations](#optimizations)
-
 Below is a summary of those new features with examples, starting with a change in our SQL dialect that is designed to produce more intuitive results by default.
 
 ## Breaking SQL Changes

--- a/_posts/2024-06-20-cli-data-processing-using-duckdb-as-a-unix-tool.md
+++ b/_posts/2024-06-20-cli-data-processing-using-duckdb-as-a-unix-tool.md
@@ -11,24 +11,6 @@ We solve several problems requiring operations such as projection and filtering 
 In the process, we will show off some cool features such as DuckDB's [powerful CSV reader]({% link docs/data/csv/overview.md %}) and the [positional join operator](#duckdb-positional-join).
 Let's get started!
 
-## Table of Contents
-
-* [Table of Contents](#table-of-contents)
-* [The Unix Philosophy](#the-unix-philosophy)
-* [Portability and Usability](#portability-and-usability)
-* [Data Processing with Unix Tools and DuckDB](#data-processing-with-unix-tools-and-duckdb)
-  * [Datasets](#datasets)
-  * [Projecting Columns](#projecting-columns)
-  * [Sorting Files](#sorting-files)
-  * [Intersecting Columns](#intersecting-columns)
-  * [Pasting Rows Together](#pasting-rows-together)
-  * [Filtering](#filtering)
-  * [Joining Files](#joining-files)
-  * [Replacing Strings](#replacing-strings)
-  * [Reading JSON](#reading-json)
-* [Performance](#performance)
-* [Summary](#summary)
-
 ## The Unix Philosophy
 
 To set the stage, let's recall the [Unix philosophy](https://en.wikipedia.org/wiki/Unix_philosophy). This states that programs should:

--- a/_posts/2024-09-09-announcing-duckdb-110.md
+++ b/_posts/2024-09-09-announcing-duckdb-110.md
@@ -18,25 +18,7 @@ a dabbling duck that occurs only on two very remote island groups in the souther
 ## What's New in 1.1.0
 
 There have been far too many changes to discuss them each in detail, but we would like to highlight several particularly exciting features!
-
 Below is a summary of those new features with examples.
-
-* [Breaking SQL Changes](#breaking-sql-changes)
-* [Community Extensions](#community-extensions)
-* [Friendly SQL](#friendly-sql)
-    * [Unpacked Columns](#unpacked-columns)
-    * [`query` and `query_table` Functions](#query-and-query_table-functions)
-* [Performance](#performance)
-    * [Dynamic Filter Pushdown from Joins](#dynamic-filter-pushdown-from-joins)
-    * [Automatic CTE Materialization](#automatic-cte-materialization)
-    * [Parallel Streaming Queries](#parallel-streaming-queries)
-    * [Parallel Union By Name](#parallel-union-by-name)
-    * [Nested ART Rework (Foreign Key Load Speed-Up)](#nested-art-rework-foreign-key-load-speed-up)
-    * [Window Function Improvements](#window-function-improvements)
-* [Spatial Features](#spatial-features)
-    * [GeoParquet](#geoparquet)
-    * [R-Tree](#r-tree)
-* [Final Thoughts](#final-thoughts)
 
 ## Breaking SQL Changes
 


### PR DESCRIPTION
We have a built-in table of contents ("in this article") now, so these ToCs are redundant.