### PR TITLE
Describes the current fact that the read_csv function and the COPY statement support different parameters.

### DIFF
--- a/docs/data/csv/overview.md
+++ b/docs/data/csv/overview.md
@@ -82,7 +82,7 @@ The DuckDB CSV reader can automatically infer which configuration flags to use b
 
 ## Parameters
 
-Below are parameters that can be passed to the CSV reader. These parameters are accepted by both the [`COPY` statement]({% link docs/sql/statements/copy.md %}#copy-to) and the [`read_csv` function](#csv-functions).
+Below are parameters that can be passed to the CSV reader. These parameters are accepted by the [`read_csv` function](#csv-functions). But not all parameters are accepted by the [`COPY` statement]({% link docs/sql/statements/copy.md %}#copy-to)).
 
 | Name | Description | Type | Default |
 |:--|:-----|:-|:-|


### PR DESCRIPTION
Describes the current fact that the read_csv function and the COPY statement support different parameters.