### PR TITLE
Describe null handling in anti join

### DIFF
--- a/docs/sql/query_syntax/from.md
+++ b/docs/sql/query_syntax/from.md
@@ -274,7 +274,7 @@ Semi joins return rows from the left table that have at least one match in the r
 Anti joins return rows from the left table that have _no_ matches in the right table.
 When using a semi or anti join the result will never have more rows than the left hand side table.
 Semi joins provide the same logic as [`IN`]({% link docs/sql/expressions/in.md %}) statements.
-Anti joins provide the same logic as `NOT IN` statements, except anti joins ignore NULL values from the right table.
+Anti joins provide the same logic as `NOT IN` statements, except anti joins ignore `NULL` values from the right table.
 
 #### Semi Join Example
 

--- a/docs/sql/query_syntax/from.md
+++ b/docs/sql/query_syntax/from.md
@@ -273,7 +273,8 @@ USING (iata);
 Semi joins return rows from the left table that have at least one match in the right table.
 Anti joins return rows from the left table that have _no_ matches in the right table.
 When using a semi or anti join the result will never have more rows than the left hand side table.
-Semi and anti joins provide the same logic as [`IN`]({% link docs/sql/expressions/in.md %}) and `NOT IN` statements, respectively.
+Semi joins provide the same logic as [`IN`]({% link docs/sql/expressions/in.md %}) statements.
+Anti joins provide the same logic as `NOT IN` statements, except anti joins ignore NULL values from the right table.
 
 #### Semi Join Example
 
@@ -320,7 +321,7 @@ This query is equivalent with:
 ```sql
 SELECT *
 FROM city_airport
-WHERE iata NOT IN (SELECT iata FROM airport_names);
+WHERE iata NOT IN (SELECT iata FROM airport_names WHERE iata IS NOT NULL);
 ```
 
 ### Lateral Joins


### PR DESCRIPTION
### Current state
The documentation says an ANTI JOIN and WHERE NOT IN (...) are equivalent. This is not true when the right table of the ANTI JOIN / subquery of the NOT IN (...) does contain NULL values. 

### Detailed demonstration

```sql
create table t1 (id1 integer);
create table t2 (id1 integer);
insert into t1 select id1 from generate_series(1, 1000) tmp1(id1);
insert into t2 select id1 from generate_series(1, 100) tmp1(id1);
insert into t2 values(null);  -- a null value on the right side is the key here
```
```sql
select count(*) as q1 from t1 where id1 not in (select id1 from t2);  
--> q1: 0
```
```sql
select count(*) as q2 from t1 anti join t2 using (id1);
--> q2: 900
--> i.e. WHERE id1 NOT IN (...) is not equivalent to ANTI JOIN
```
```sql
select count(*) as q3 from t1 where id1 not in (select id1 from t2 where id1 is not null);
--> q3: 900
--> i.e. we can fix this by excluding NULLs from the subquery which do not match in the anti join.
```

### Verification using Postgres
To make sure I did not step on a bug in DuckDB, I tried q1 and q3 in Postgres (online tool, PostgreSQL 14.11). The results were the same as in DuckDB 1.1.1. Please note that Postgres parses ANTI JOIN syntax in q2, but does definitely not apply an ANTI JOIN, but an INNER JOIN.