### PR TITLE
Revert hackery of scrolling to top via iframe include

### DIFF
--- a/_posts/2024-10-02-pyodide.md
+++ b/_posts/2024-10-02-pyodide.md
@@ -5,22 +5,6 @@ author: "Alex Monahan"
 thumb: "/images/blog/thumbs/241002.svg"
 excerpt: "Run DuckDB in an in-browser Python environment to enable simple querying on remote files, interactive documentation, and easy to use training materials."
 ---
-{::nomarkdown}
-
-<script>
-    document.addEventListener("DOMContentLoaded", async function() {
-        for (let i=0; i<150; i++) {
-            window.scrollTo({
-                top: 0,
-                left: 0,
-                behavior: 'instant',
-            });
-            await new Promise(r => setTimeout(r, 10));
-        }
-    });
-</script>
-
-{:/nomarkdown}
 
 ## Time to “Hello World”
 
@@ -142,11 +126,7 @@ Here is an example of using an `iframe` that points to a JupyterLite environment
 This is a fully interactive Python notebook environment, with DuckDB running inside. 
 Feel free to give it a run!
 
-{::nomarkdown}
-
-<iframe src="https://alex-monahan.github.io/jupyterlite_duckdb_demo/notebooks/index.html?path=hello_duckdb.ipynb" style="height: 600px; width: 100%;"></iframe>
-
-{:/nomarkdown}
+{% include iframe.html src="https://alex-monahan.github.io/jupyterlite_duckdb_demo/notebooks/index.html?path=hello_duckdb.ipynb" %}
 
 Configuring a full JupyterLite environment is only a few steps!
 The JupyterLite folks have built a demo page that serves as a template and have some [great documentation](https://jupyterlite.readthedocs.io/en/latest/quickstart/deploy.html).
@@ -173,11 +153,7 @@ This example uses the [`magic-duckdb` Jupyter extension](https://github.com/iqmo
 <iframe src="https://alex-monahan.github.io/jupyterlite_duckdb_demo/notebooks/index.html?path=magic_duckdb.ipynb" style="height: 600px; width: 100%;"></iframe>
 ```
 
-{::nomarkdown}
-
-<iframe src="https://alex-monahan.github.io/jupyterlite_duckdb_demo/notebooks/index.html?path=magic_duckdb.ipynb" style="height: 600px; width: 100%;"></iframe>
-
-{:/nomarkdown}
+{% include iframe.html src="https://alex-monahan.github.io/jupyterlite_duckdb_demo/notebooks/index.html?path=magic_duckdb.ipynb" %}
 
 ## Architecture of DuckDB in Pyodide
 


### PR DESCRIPTION
Code in _include/iframe.html, looks like:
```html
<div style="position:relative; padding-bottom:60%; width: 100%">
    <iframe src="{{ include.src }}" title="{{ include.title }}" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe>
</div>
```
This is the same used for embedding the Wasm shell.

Unsure why hackery was needed, I guess to reduce flickering?
If that's the case, this seems to work the same on my side, but would need to be double checked / possibly there are other considerations in place.