### PR TITLE
Add Dart wrapper for DuckDB to API overview documentation.

### DIFF
--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -27,6 +27,7 @@ There are also contributed third-party DuckDB wrappers, which currently do not h
 * [C#](https://github.com/Giorgi/DuckDB.NET) by [Giorgi](https://github.com/Giorgi)
 * [Common Lisp](https://github.com/ak-coram/cl-duckdb) by [ak-coram](https://github.com/ak-coram)
 * [Crystal](https://github.com/amauryt/crystal-duckdb) by [amauryt](https://github.com/amauryt)
+* [Dart](https://github.com/TigerEyeLabs/duckdb-dart) by [TigerEye](https://www.tigereye.com/)
 * [Elixir](https://github.com/AlexR2D2/duckdbex) by [AlexR2D2](https://github.com/AlexR2D2/duckdbex)
 * [Ruby](https://github.com/suketa/ruby-duckdb) by [suketa](https://github.com/suketa)
 * [Zig](https://github.com/karlseguin/zuckdb.zig) by [karlseguin](https://github.com/karlseguin)


### PR DESCRIPTION
add an entry for dart to the third-party duckdb api section.