### PR TITLE
CSS: Force table headers to be left-aligned

### DIFF
--- a/css/docu.scss
+++ b/css/docu.scss
@@ -941,6 +941,9 @@ td.icon{
 		height: auto!important;
 	}
 }
+table thead th {
+	text-align: left !important;
+}
 .media_table + table thead {
 	display: none;
 }


### PR DESCRIPTION
We use table headers with left-aligned text.

However, the Markdown to HTML used by Jekyll renders the `text-align` attributes inline. So the following Markdown

```markdown
|  a   | b  |
|-----:|---:|
| 32   | 42 |
| NULL | 22 |
```

gets translated to:c

```html
<table>
  <thead>
    <tr>
      <th style="text-align: right">a</th>
      <th style="text-align: right">b</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td style="text-align: right">32</td>
      <td style="text-align: right">42</td>
    </tr>
    <tr>
      <td style="text-align: right">NULL</td>
      <td style="text-align: right">22</td>
    </tr>
  </tbody>
</table>
```

This is rendered as follows:
![image](https://github.com/user-attachments/assets/e3597e8e-21f1-4fc0-a46a-5b6c2fff62ba)

This PR forces left-align for all table headers, resulting in:
![image](https://github.com/user-attachments/assets/bbfa7337-b65a-4a4b-ab66-cb661bbe9d0c)
