### PR TITLE
Add extension path example to LOAD

### DIFF
--- a/js/statements/load_and_install.js
+++ b/js/statements/load_and_install.js
@@ -1,8 +1,11 @@
 function GenerateLoad(options = {}) {
     return Diagram([
         AutomaticStack([
-            Keyword("LOAD"),
-            Expression("extension-name")
+            Keyword("LOAD"),            
+            Choice(0, [
+                Expression("extension-name"),
+                Expression("'extension-path'")
+            ]),
         ])
     ])
 }


### PR DESCRIPTION
Looking at the current page it's not clear that we can load extensions from a specified path. This fixes that.