### PR TITLE
Fix excel link in data_sources.md

### DIFF
--- a/docs/data/data_sources.md
+++ b/docs/data/data_sources.md
@@ -10,7 +10,7 @@ DuckDB sources several data sources, including file formats, network protocols, 
 * [Cloudflare R2]({% link docs/guides/network_cloud_storage/cloudflare_r2_import.md %})
 * [CSV]({% link docs/data/csv/overview.md %})
 * [Delta Lake]({% link docs/extensions/delta.md %})
-* [Excel (via the `spatial` extension)]({% link docs/extensions/mysql.md %})
+* Excel (via the [`spatial` extension]({% link docs/extensions/spatial/overview.md %})): see the [Excel Import]({% link docs/guides/file_formats/excel_import.md %}) and [Excel Export]({% link docs/guides/file_formats/excel_export.md %})
 * [httpfs]({% link docs/extensions/httpfs/https.md %})
 * [Iceberg]({% link docs/extensions/iceberg.md %})
 * [JSON]({% link docs/data/json/overview.md %})


### PR DESCRIPTION
The previous Excel link incorrectly led to the MySQL documentation page. It has now been updated to include three distinct links:
  * one for the spatial extension
  * one for importing Excel files
  * and another for exporting Excel files.