### PR TITLE
Add UPDATE EXTENSIONS page

### DIFF
--- a/docs/sql/statements/update_extensions.md
+++ b/docs/sql/statements/update_extensions.md
@@ -3,38 +3,43 @@ layout: docu
 title: UPDATE EXTENSIONS
 ---
 
-## `UPDATE EXTENSIONS`
+The `UPDATE EXTENSIONS` statement allows to sychronize the local installed extension state with the repository that published a given extension.
 
-The `UPDATE EXTENSIONS` allows to syncronize local installed extension state with the repository that published a given extension.
+This statement is the recommended way to keep up to date with new feature or bug fixed being rolled out by extension developers.
 
-`UPDATE EXTENSIONS` is implemented by storing, if available, the Etag information, and sending a GET download request conditional on the fact that the remote extension is different (using Etag as proxy) than the local available one.
-
-This makes so that update extensions is on consecutive instructions (if no remote state has changed) somewhat inexpensive.
-
-This statement is the reccomened way to keep up to date with new feature or bug fixed being rolled out by extension developers.
-
-### Examples
+## Updating All Extensions
 
 Say you want to automatically check for updates for all extensions (for the current DuckDB version and platform) currently installed in the `extension_directory`.
-```
-UPDATE EXTENSIONS;
-```
-Will iterate over the extensions, and inform user on which ones have been bumped
-
-Update extensions will use the information about where a given extension has been sourced, and try to fetch it only from there.
-
-## `UPDATE EXTENSIONS (name_a, name_b, name_c)
-
-You can provide a list of extension names to be updated. This allow more fine grained control
-
-### Examples
 
 ```sql
-INSTALL spatial;
+UPDATE EXTENSIONS;
 ```
-Then say that a week pass by, what if some improvements (deemed to be at the same level of stability) are rolled out?
 
+This will iterate over the extensions, and inform user on which ones have been bumped.
+
+`UPDATE EXTENSIONS` will use the information about where a given extension has been sourced, and try to fetch it only from there.
+
+## Updating Selected Extensions
+
+You can provide a list of extension names to be updated. This allow more fine grained control:
+
+```sql
+UPDATE EXTENSIONS (name_a, name_b, name_c);
 ```
-UPDATE EXTENSIONS (spatial);
+
+## How It Works
+
+`UPDATE EXTENSIONS` is implemented by storing, if available, the [ETag](https://en.wikipedia.org/wiki/HTTP_ETag) information, and sending a GET request conditional on the fact that the remote extension is different (using the ETag as proxy) than the local available one. This ensures that `UPDATE EXTENSIONS` on consecutive instructions (if the remote state has not changed) is rather inexpensive.
+
+If a change is found for a given extension, DuckDB performs the following operation. For example, if `name_a` and `name_c` changed, then:
+
+```sql
+UPDATE EXTENSIONS (name_a, name_b, name_c);
 ```
-Will either be equivalent to `FORCE INSTALL spatial` if changes are detected, or no change the local extension directory.
+
+will result in the following commands:
+
+```sql
+FORCE INSTALL name_a;
+FORCE INSTALL name_c;
+```

--- a/docs/sql/statements/update_extensions.md
+++ b/docs/sql/statements/update_extensions.md
@@ -1,0 +1,40 @@
+---
+layout: docu
+title: UPDATE EXTENSIONS
+---
+
+## `UPDATE EXTENSIONS`
+
+The `UPDATE EXTENSIONS` allows to syncronize local installed extension state with the repository that published a given extension.
+
+`UPDATE EXTENSIONS` is implemented by storing, if available, the Etag information, and sending a GET download request conditional on the fact that the remote extension is different (using Etag as proxy) than the local available one.
+
+This makes so that update extensions is on consecutive instructions (if no remote state has changed) somewhat inexpensive.
+
+This statement is the reccomened way to keep up to date with new feature or bug fixed being rolled out by extension developers.
+
+### Examples
+
+Say you want to automatically check for updates for all extensions (for the current DuckDB version and platform) currently installed in the `extension_directory`.
+```
+UPDATE EXTENSIONS;
+```
+Will iterate over the extensions, and inform user on which ones have been bumped
+
+Update extensions will use the information about where a given extension has been sourced, and try to fetch it only from there.
+
+## `UPDATE EXTENSIONS (name_a, name_b, name_c)
+
+You can provide a list of extension names to be updated. This allow more fine grained control
+
+### Examples
+
+```sql
+INSTALL spatial;
+```
+Then say that a week pass by, what if some improvements (deemed to be at the same level of stability) are rolled out?
+
+```
+UPDATE EXTENSIONS (spatial);
+```
+Will either be equivalent to `FORCE INSTALL spatial` if changes are detected, or no change the local extension directory.


### PR DESCRIPTION
Informations are already available at https://duckdb.org/docs/extensions/versioning_of_extensions#updating-extensions, but I think feature might use it's own page.

To be considered adding an explanation of the various return-code, and merging both versions / linking this from INSTALL/LOAD page and possibly elsewhere.