### PR TITLE
Remove BUILD_ from the documented options

### DIFF
--- a/docs/dev/benchmark.md
+++ b/docs/dev/benchmark.md
@@ -13,7 +13,7 @@ When making changes that have potential performance implications, it is importan
 To build the benchmark suite, run the following command in the [DuckDB repository](https://github.com/duckdb/duckdb):
 
 ```bash
-BUILD_BENCHMARK=1 BUILD_TPCH=1 make
+BUILD_BENCHMARK=1 CORE_EXTENSIONS='tpch' make
 ```
 
 ## Listing Benchmarks

--- a/docs/dev/building/build_configuration.md
+++ b/docs/dev/building/build_configuration.md
@@ -53,7 +53,7 @@ Core extensions can be built as part of DuckDB via the `CORE_EXTENSION` flag, th
 CORE_EXTENSION='tpcd;httpfs;fts;json;parquet' make
 ```
 
-More on this topic at [building duckdb extensions]({% link ../building_extensions.md %}).
+More on this topic at [building duckdb extensions]({% link docs/dev/building/building_extensions.md %}).
 
 ## Package Flags
 

--- a/docs/dev/building/build_configuration.md
+++ b/docs/dev/building/build_configuration.md
@@ -44,6 +44,17 @@ This doesn't actually create a build, but uses the following format checkers to 
 
 The CI will also run this check, causing it to fail if this check fails.
 
+## Extension selection
+[Core DuckDB extensions]({% link docs/extensions/core_extensions.md %}) are that are the one maintaned by the DuckDB team, that are hosted in the duckdb GitHub repository, and are served by the `core` extension repository.
+
+Core extensions can be built as part of DuckDB via the `CORE_EXTENSION` flag, then listing the names of the extensions that are to be built.
+
+```bash
+CORE_EXTENSION='tpcd;httpfs;fts;json;parquet' make
+```
+
+More on this topic at [building duckdb extensions]({% link ../building_extensions.md %}).
+
 ## Package Flags
 
 For every package that is maintained by core DuckDB, there exists a flag in the Makefile to enable building the package.

--- a/docs/dev/building/build_instructions.md
+++ b/docs/dev/building/build_instructions.md
@@ -135,7 +135,7 @@ For example:
 mkdir build
 cd build
 cmake .. \
-    -DBUILD_EXTENSIONS="httpfs;json;parquet" \
+    -DCORE_EXTENSIONS="httpfs;json;parquet" \
     -DDUCKDB_EXTRA_LINK_FLAGS="-latomic"
 make -j4
 ```

--- a/docs/dev/building/building_extensions.md
+++ b/docs/dev/building/building_extensions.md
@@ -7,65 +7,25 @@ title: Building Extensions
 
 ## Building Extensions Using Build Flags
 
-To build using extension flags, set the corresponding [`BUILD_[EXTENSION_NAME]` extension flag](#extension-flags) when running the build, then use the `INSTALL` command.
+To build using extension flags, set the `CORE_EXTENSIONS` flag to the list of extensions that you want to be buiold.
 
-For example, to install the [`httpfs` extension]({% link docs/extensions/httpfs/overview.md %}), run the following script:
+Extension will in most cases by directly linked the resulting DuckDB executable.
 
-```bash
-GEN=ninja BUILD_HTTPFS=1 make
-```
-
-For release builds:
+For example, to build DuckDB with the [`httpfs` extension]({% link docs/extensions/httpfs/overview.md %}), run the following script:
 
 ```bash
-build/release/duckdb -c "INSTALL 'build/release/extension/httpfs/httpfs.duckdb_extension';"
+GEN=ninja CORE_EXTENSIONS='httpfs' make
 ```
 
-For debug builds:
-
-```bash
-build/debug/duckdb -c "INSTALL 'build/debug/extension/httpfs/httpfs.duckdb_extension';"
-```
-
-### Extension Flags
-
-For every in-tree extension that is maintained by core DuckDB there exists a flag to enable building and statically linking the extension into the build.
-
-#### `BUILD_AUTOCOMPLETE`
-
-When this flag is set, the [`autocomplete` extension]({% link docs/extensions/autocomplete.md %}) is built.
-
-#### `BUILD_ICU`
-
-When this flag is set, the [`icu` extension]({% link docs/extensions/icu.md %}) is built.
-
-#### `BUILD_TPCH`
-
-When this flag is set, the [`tpch` extension]({% link docs/extensions/tpch.md %}) is built, this enables TPCH-H data generation and query support using `dbgen`.
-
-#### `BUILD_TPCDS`
-
-When this flag is set, the [`tpcds` extension]({% link docs/extensions/tpcds.md %}) is built, this enables TPC-DS data generation and query support using `dsdgen`.
-
-#### `BUILD_TPCE`
-
-When this flag is set, the [TPCE](https://www.tpc.org/tpce/) extension is built. Unlike TPC-H and TPC-DS this does not enable data generation and query support. Instead, it enables tests for TPC-E through our test suite.
-
-#### `BUILD_FTS`
-
-When this flag is set, the [`fts` (full text search) extension]({% link docs/extensions/full_text_search.md %}) is built.
-
-#### `BUILD_HTTPFS`
-
-When this flag is set, the [`httpfs` extension]({% link docs/extensions/httpfs/overview.md %}) is built.
+### Special Extension Flags
 
 #### `BUILD_JEMALLOC`
 
 When this flag is set, the [`jemalloc` extension]({% link docs/extensions/jemalloc.md %}) is built.
 
-#### `BUILD_JSON`
+#### `BUILD_TPCE`
 
-When this flag is set, the [`json` extension]({% link docs/data/json/overview.md %}) is built.
+When this flag is set, the [TPCE](https://www.tpc.org/tpce/) libray is built. Unlike TPC-H and TPC-DS this is not a proper extension and it's not distributed as such. Enablign this allows TPC-E enabled queries through our test suite.
 
 ### Debug Flags
 

--- a/docs/dev/building/building_extensions.md
+++ b/docs/dev/building/building_extensions.md
@@ -104,7 +104,6 @@ To build using a CMake configuration file, create an extension configuration fil
 ```cmake
 duckdb_extension_load(autocomplete)
 duckdb_extension_load(fts)
-duckdb_extension_load(httpfs/overview)
 duckdb_extension_load(inet)
 duckdb_extension_load(icu)
 duckdb_extension_load(json)

--- a/docs/dev/building/troubleshooting.md
+++ b/docs/dev/building/troubleshooting.md
@@ -76,7 +76,7 @@ To work around this, navigate to a different directory (e.g., `cd ..`) and try r
 The build fails on macOS when both the [`httpfs` extension]({% link docs/extensions/httpfs/overview.md %}) and the Python package are included:
 
 ```bash
-GEN=ninja BUILD_PYTHON=1 BUILD_HTTPFS=1 make
+GEN=ninja BUILD_PYTHON=1 CORE_EXTENSIONS="httpfs" make
 ```
 
 ```console
@@ -93,7 +93,7 @@ If you would like to build DuckDB from source, avoid using the `BUILD_PYTHON=1` 
 Instead, first build the `httpfs` extension (if required), then build and install the Python package separately using pip:
 
 ```bash
-GEN=ninja BUILD_HTTPFS=1 make
+GEN=ninja CORE_EXTENSIONS="httpfs" make
 ```
 
 If the next line complains about pybind11 being missing, or `--use-pep517` not being supported, make sure you're using a modern version of pip and setuptools.
@@ -125,5 +125,5 @@ sudo apt-get install -y libssl-dev
 Then, build with:
 
 ```bash
-GEN=ninja BUILD_HTTPFS=1 make
+GEN=ninja CORE_EXTENSIONS="httpfs" make
 ```


### PR DESCRIPTION
Connected to this PR https://github.com/duckdb/duckdb/pull/14531 (and other that might follow).

Since already 1.1.0 the `CORE_EXTENSIONS='a;b;c'` is the suggested way to build extensions, and the older BUILD_TPCD & co should be phased out going to 1.2.x. I think it's safe to just remove mentions of `BUILD_`, moving to the new methods. Possibly to be considered a warning tab saying:
> BUILD_HTTPFS=1 & co are being discontinued (although they will still might work).