### PR TITLE
Clarify that NULLs are skipped, not treated as '', in concat_ws

### DIFF
--- a/docs/sql/functions/char.md
+++ b/docs/sql/functions/char.md
@@ -27,8 +27,8 @@ This section describes functions and operators for examining and manipulating [`
 | [`bar(x, min, max[, width])`](#barx-min-max-width) | Draw a band whose width is proportional to (`x - min`) and equal to `width` characters when `x` = `max`. `width` defaults to 80. |
 | [`bit_length(string)`](#bit_lengthstring) | Number of bits in a string. |
 | [`chr(x)`](#chrx) | Returns a character which is corresponding the ASCII code value or Unicode code point. |
-| [`concat_ws(separator, string, ...)`](#concat_wsseparator-string-) | Concatenate many strings, separated by `separator`. NULL inputs are treated as empty strings. |
-| [`concat(string, ...)`](#concatstring-) | Concatenate many strings. NULL inputs are treated as empty strings. See also [`string || string`](#string--string). |
+| [`concat_ws(separator, string, ...)`](#concat_wsseparator-string-) | Concatenate many strings, separated by `separator`. NULL inputs are skipped. |
+| [`concat(string, ...)`](#concatstring-) | Concatenate many strings. NULL inputs are skipped. See also [`string || string`](#string--string). |
 | [`contains(string, search_string)`](#containsstring-search_string) | Return true if `search_string` is found within `string`. |
 | [`ends_with(string, search_string)`](#ends_withstring-search_string) | Return true if `string` ends with `search_string`. |
 | [`format_bytes(bytes)`](#format_bytesbytes) | Converts bytes to a human-readable representation using units based on powers of 2 (KiB, MiB, GiB, etc.). |
@@ -220,7 +220,7 @@ SELECT
 
 <div class="nostroke_table"></div>
 
-| **Description** | Concatenate many strings, separated by `separator`. NULL inputs are treated as empty strings. |
+| **Description** | Concatenate many strings, separated by `separator`. NULL inputs are skipped. |
 | **Example** | `concat_ws(', ', 'Banana', 'Apple', NULL, 'Melon')` |
 | **Result** | `Banana, Apple, Melon` |
 
@@ -228,7 +228,7 @@ SELECT
 
 <div class="nostroke_table"></div>
 
-| **Description** | Concatenate many strings. NULL inputs are treated as empty strings. See also [`string || string`](#string--string). |
+| **Description** | Concatenate many strings. NULL inputs are skipped. See also [`string || string`](#string--string). |
 | **Example** | `concat('Hello', ' ', NULL, 'World')` |
 | **Result** | `Hello World` |
 

--- a/docs/sql/functions/list.md
+++ b/docs/sql/functions/list.md
@@ -17,7 +17,7 @@ title: List Functions
 | [`list_aggregate(list, name)`](#list_aggregatelist-name) | Executes the aggregate function `name` on the elements of `list`. See the [List Aggregates]({% link docs/sql/functions/list.md %}#list-aggregates) section for more details. |
 | [`list_any_value(list)`](#list_any_valuelist) | Returns the first non-null value in the list. |
 | [`list_append(list, element)`](#list_appendlist-element) | Appends `element` to `list`. |
-| [`list_concat(list1, list2)`](#list_concatlist1-list2) | Concatenate two lists. NULL inputs are treated as empty lists. See `||` |
+| [`list_concat(list1, list2)`](#list_concatlist1-list2) | Concatenate two lists. NULL inputs are skipped. See also `||` |
 | [`list_contains(list, element)`](#list_containslist-element) | Returns true if the list contains the element. |
 | [`list_cosine_similarity(list1, list2)`](#list_cosine_similaritylist1-list2) | Compute the cosine similarity between two lists. |
 | [`list_cosine_distance(list1, list2)`](#list_cosine_distancelist1-list2) | Compute the cosine distance between two lists. Equivalent to `1.0 - list_cosine_similarity`. |
@@ -138,7 +138,7 @@ title: List Functions
 
 <div class="nostroke_table"></div>
 
-| **Description** | Concatenate two lists. NULL inputs are treated as empty lists. See also `||`  |
+| **Description** | Concatenate two lists. NULL inputs are skipped. See also `||`  |
 | **Example** | `list_concat([2, 3], [4, 5, 6])` |
 | **Result** | `[2, 3, 4, 5, 6]` |
 | **Aliases** | `list_cat`, `array_concat`, `array_cat` |


### PR DESCRIPTION
Followup to https://github.com/duckdb/duckdb-web/pull/4011, particulary this comment thread https://github.com/duckdb/duckdb-web/pull/4011#discussion_r1828028459

eg `concat_ws(', ', 'Banana', 'Apple', NULL, 'Melon')` results in 'Banana, Apple, Melon', not 'Banana, Apple, , Melon',