### PR TITLE
CLI overview: fix CSV examples

### DIFF
--- a/docs/api/cli/overview.md
+++ b/docs/api/cli/overview.md
@@ -259,7 +259,7 @@ COPY (SELECT 42 AS woot UNION ALL SELECT 43 AS woot) TO 'test.csv' (HEADER);
 First, read a file and pipe it to the `duckdb` CLI executable. As arguments to the DuckDB CLI, pass in the location of the database to open, in this case, an in-memory database, and a SQL command that utilizes `/dev/stdin` as a file location.
 
 ```bash
-cat test.csv | duckdb "SELECT * FROM read_csv('/dev/stdin')"
+cat test.csv | duckdb -c "SELECT * FROM read_csv('/dev/stdin')"
 ```
 
 | woot |
@@ -271,7 +271,7 @@ To write back to stdout, the copy command can be used with the `/dev/stdout` fil
 
 ```bash
 cat test.csv | \
-    duckdb "COPY (SELECT * FROM read_csv('/dev/stdin')) TO '/dev/stdout' WITH (FORMAT 'csv', HEADER)"
+    duckdb -c "COPY (SELECT * FROM read_csv('/dev/stdin')) TO '/dev/stdout' WITH (FORMAT 'csv', HEADER)"
 ```
 
 ```csv


### PR DESCRIPTION
In the CLI API overview:

The `-c` arg was missing from some example commands, leading to errors:

    $ cat test.csv | duckdb "SELECT * FROM read_csv('/dev/stdin')"
    Error: unable to open database "SELECT * FROM read_csv('/dev/stdin')":
    IO Error: Cannot open file "SELECT * FROM read_csv('/dev/stdin')": No such file or directory

This updates the example commands to include `-c` as in [docs/data/csv/overview.md](https://github.com/duckdb/duckdb-web/blob/0115a7df26b790c08542fa1d90ae5d29212987d4/docs/data/csv/overview.md?plain=1#L36) and elsewhere.

Note: this also applies to `docs/archive/1.0/api/cli/overview.md`, which was left unmodified [per CONTRIBUTING.md](https://github.com/duckdb/duckdb-web/blob/0115a7df26b790c08542fa1d90ae5d29212987d4/CONTRIBUTING.md?plain=1#L147).