### PR TITLE
Add column selection via list to star expression page

### DIFF
--- a/docs/sql/expressions/star.md
+++ b/docs/sql/expressions/star.md
@@ -60,6 +60,13 @@ SELECT COLUMNS('number\d+')
 FROM addresses;
 ```
 
+Select columns using a list:
+
+```sql
+SELECT COLUMNS(['city', 'zip_code'])
+FROM addresses;
+```
+
 ## Syntax
 
 <div id="rrdiagram"></div>


### PR DESCRIPTION
Mentioned how the COLUMNS expression can accept a list of column names. It is already implicitly covered when documenting the expansion of columns expressions, but having it at the top-level examples is more visible.