### PR TITLE
Update order_preservation.md

### DIFF
--- a/docs/sql/dialect/order_preservation.md
+++ b/docs/sql/dialect/order_preservation.md
@@ -58,7 +58,7 @@ The following operations **do not** guarantee that the row order is preserved:
 * `SAMPLE`
 * `UNION`
 * `GROUP BY` (in particular, the output order is undefined and the order in which rows are fed into [order-sensitive aggregate functions](https://duckdb.org/docs/sql/functions/aggregates.html#order-by-clause-in-aggregate-functions) is undefined unless explicitly specified in the aggregate function)
-* `ORDER BY` (specifically, `ORDER BY` does not use a [stable algorithm]( https://en.m.wikipedia.org/wiki/Stable_algorithm))
+* `ORDER BY` (specifically, `ORDER BY` may not use a [stable algorithm](https://en.m.wikipedia.org/wiki/Stable_algorithm))
 
 ## Insertion Order
 

--- a/docs/sql/dialect/order_preservation.md
+++ b/docs/sql/dialect/order_preservation.md
@@ -57,8 +57,8 @@ The following operations **do not** guarantee that the row order is preserved:
 * `JOIN`
 * `SAMPLE`
 * `UNION`
-* `GROUP BY`
-* `ORDER BY`
+* `GROUP BY` (in particular, the output order is undefined and the order in which rows are fed into [order-sensitive aggregate functions](https://duckdb.org/docs/sql/functions/aggregates.html#order-by-clause-in-aggregate-functions) is undefined unless explicitly specified in the aggregate function)
+* `ORDER BY` (specifically, `ORDER BY` does not use a [stable algorithm]( https://en.m.wikipedia.org/wiki/Stable_algorithm))
 
 ## Insertion Order
 


### PR DESCRIPTION
follow up to https://github.com/duckdb/duckdb-web/issues/4035 to explicitly answer misunderstandings exhibited in https://github.com/duckdb/duckdb/issues/14755 and https://github.com/duckdb/duckdb/issues/14941


By the way: Do you folks have recommendations for the common situation that one has a large table that's sorted by multiple columns (C1,...,Cn) and one wants to successively perform aggregations over Cn then Cn-1, ...?  In that situation, there would be a trivial O(N) solution to doing each of the aggregations by hand, simply by checking group boundaries on the fly and producing aggregate values in an order preserving manner. Feels like the following duckdb snippet
```sql
SELECT  
  agg1(x)
FROM
(
  SELECT 
    agg2(x) AS x
  FROM 
  (
     ...
  )
  GROUP BY C2
)
GROUP BY C1


 would be inefficient in comparison?