### PR TITLE
Update order_preservation.md

### DIFF
--- a/docs/sql/dialect/order_preservation.md
+++ b/docs/sql/dialect/order_preservation.md
@@ -50,7 +50,7 @@ The following clauses guarantee that the original row order is preserved:
 * `SELECT`
 * `UNION ALL`
 * `WHERE`
-* `row_number() OVER ()` (this allows turning the original row order into an explicit column that can be referenced in the operations below that don't preserve orw order by default)
+* `row_number() OVER ()` (this allows turning the original row order into an explicit column that can be referenced in the operations below that don't preserve row order by default)
 
 The following operations **do not** guarantee that the row order is preserved:
 

--- a/docs/sql/dialect/order_preservation.md
+++ b/docs/sql/dialect/order_preservation.md
@@ -50,7 +50,7 @@ The following clauses guarantee that the original row order is preserved:
 * `SELECT`
 * `UNION ALL`
 * `WHERE`
-* `ARRAY` 
+* `row_number() OVER ()` (this allows turning the original row order into an explicit column that can be referenced in the operations below that don't preserve orw order by default)
 
 The following operations **do not** guarantee that the row order is preserved:
 

--- a/docs/sql/dialect/order_preservation.md
+++ b/docs/sql/dialect/order_preservation.md
@@ -50,6 +50,7 @@ The following clauses guarantee that the original row order is preserved:
 * `SELECT`
 * `UNION ALL`
 * `WHERE`
+* `ARRAY` 
 
 The following operations **do not** guarantee that the row order is preserved:
 


### PR DESCRIPTION
Claim that `row_number()` preserves the order of a table (at least without partition)

I verified this by experiment but please check if it's actually true! 

If not, I think there absolutely should be *some* way to achieve this. 
(I know that the `rowid` pseudo-column exists but (1) I'm not sure to what extent it can be used for this purpose (2) it can't be used when the table has a column named `rowid` (shouldn't `rowid` therefore be made a function instead of a pseudo-column?))