### PR TITLE
Update iceberg.md to reflect new version handling

### DIFF
--- a/docs/extensions/iceberg.md
+++ b/docs/extensions/iceberg.md
@@ -85,9 +85,9 @@ FROM iceberg_snapshots('data/iceberg/lineitem_iceberg');
 
 ### Selecting Metadata versions
 
-By default, the `iceberg` extension will look for a `version-hint.text` file to identify the proper metadata version to use. This can be overridedden by explicitly supplying a version number via the `version` parameter to iceberg table functions. By default, this will look for both `v{version}.metadata.json` and `{version}.metadata.json files, or `v{verison}.gz.metadata.json` and `{version}.gz.metadata.json` when `metadata_compression_codec='gzip'`. Other compression codecs are not supported.
+By default, the `iceberg` extension will look for a `version-hint.text` file to identify the proper metadata version to use. This can be overridden by explicitly supplying a version number via the `version` parameter to iceberg table functions. By default, this will look for both `v{version}.metadata.json` and `{version}.metadata.json files, or `v{verison}.gz.metadata.json` and `{version}.gz.metadata.json` when `metadata_compression_codec='gzip'`. Other compression codecs are not supported.
 
-Additionally, if any `.text` or .txt` file is provided as a version, it is opened and treated as a version-hint file. The `iceberg` extension will open this file and use the **entire contents** of the file as a provided version number.
+Additionally, if any `.text` or `.txt` file is provided as a version, it is opened and treated as a version-hint file. The `iceberg` extension will open this file and use the **entire contents** of the file as a provided version number.
 
 > The entire contents of the `version-hint.txt` file will be treated as a literal version name, with no encoding, escaping or trimming. This includes any whitespace, or unsafe characters  which will be explicitly passed formatted into filenames in the logic described below.
 
@@ -104,7 +104,7 @@ FROM iceberg_snapshots('data/iceberg/lineitem_iceberg', version='1', allow_moved
 
 ### Working with Alternative Metadata Naming Conventions
 
-The `iceberg` extension can handle different metadata naming convetions by specifying them as a comma-delimited list of format strings via the `version_name_format` parameter. Each format string must take two `%s` parameters. The first is location of the the version number in the metadata filename and the second is the location of the `metadata_compression_codec` extension. The behavior described above is provided by the default value of `"v%s%s.metadata.gz,%s%smetadata.gz`. In the event you had an alternatively named metadata file with such as `rev-2.metadata.json.gz`, the table could be read via the follow statement.
+The `iceberg` extension can handle different metadata naming convetions by specifying them as a comma-delimited list of format strings via the `version_name_format` parameter. Each format string must take two `%s` parameters. The first is the location of the version number in the metadata filename and the second is the location of the `metadata_compression_codec` extension. The behavior described above is provided by the default value of `"v%s%s.metadata.gz,%s%smetadata.gz`. In the event you had an alternatively named metadata file with such as `rev-2.metadata.json.gz`, the table could be read via the follow statement.
 
 ```sql
 SELECT *

--- a/docs/extensions/iceberg.md
+++ b/docs/extensions/iceberg.md
@@ -19,6 +19,15 @@ LOAD iceberg;
 
 To test the examples, download the [`iceberg_data.zip`](/data/iceberg_data.zip) file and unzip it.
 
+### Common Parameters
+
+| Parameter                    | Type      | Default                                    | Description                                                |
+|------------------------------|-----------|--------------------------------------------|------------------------------------------------------------|
+| `allow_moved_paths`          | `boolean` | `false`                                    | Allows scanning Iceberg tables that are moved.             |
+| `metadata_compression_codec` | `varchar` | `''`                                       | Treats metadata files as when set to `'gzip'`.             |
+| `version`                    | `varchar` | `'?'`                                      | Provides an explicit version string, hint file or guessing |
+| `version_name_format`        | `varchar` | `'v%s%s.metadata.json,%s%s.metadata.json'` | Controls how versions are converted to metadata file names |
+
 ### Querying Individual Tables
 
 ```sql
@@ -73,6 +82,58 @@ FROM iceberg_snapshots('data/iceberg/lineitem_iceberg');
 |-----------------|---------------------|-------------------------|------------------------------------------------------------------------------------------------|
 | 1               | 3776207205136740581 | 2023-02-15 15:07:54.504 | lineitem_iceberg/metadata/snap-3776207205136740581-1-cf3d0be5-cf70-453d-ad8f-48fdc412e608.avro |
 | 2               | 7635660646343998149 | 2023-02-15 15:08:14.73  | lineitem_iceberg/metadata/snap-7635660646343998149-1-10eaca8a-1e1c-421e-ad6d-b232e5ee23d3.avro |
+
+### Selecting Metadata versions
+
+By default, the `iceberg` extension will look for a `version-hint.text` file to identify the proper metadata version to use. This can be overridedden by explicitly supplying a version number via the `version` parameter to iceberg table functions. By default, this will look for both `v{version}.metadata.json` and `{version}.metadata.json files, or `v{verison}.gz.metadata.json` and `{version}.gz.metadata.json` when `metadata_compression_codec='gzip'`. Other compression codecs are not supported.
+
+Additionally, if any `.text` or .txt` file is provided as a version, it is opened and treated as a version-hint file. The `iceberg` extension will open this file and use the **entire contents** of the file as a provided version number.
+
+> The entire contents of the `version-hint.txt` file will be treated as a literal version name, with no encoding, escaping or trimming. This includes any whitespace, or unsafe characters  which will be explicitly passed formatted into filenames in the logic described below.
+
+```sql
+SELECT *
+FROM iceberg_snapshots('data/iceberg/lineitem_iceberg', version='1', allow_moved_paths=true);
+```
+
+<div class="narrow_table monospace_table"></div>
+
+| count_star() |
+|-------------:|
+| 60175        |
+
+### Working with Alternative Metadata Naming Conventions
+
+The `iceberg` extension can handle different metadata naming convetions by specifying them as a comma-delimited list of format strings via the `version_name_format` parameter. Each format string must take two `%s` parameters. The first is location of the the version number in the metadata filename and the second is the location of the `metadata_compression_codec` extension. The behavior described above is provided by the default value of `"v%s%s.metadata.gz,%s%smetadata.gz`. In the event you had an alternatively named metadata file with such as `rev-2.metadata.json.gz`, the table could be read via the follow statement.
+
+```sql
+SELECT *
+FROM iceberg_snapshots('data/iceberg/alternative_metadata_gz_naming', version='2', version_name_format='rev-%s.metadata.json%s', metadata_compression_codec='gzip', allow_moved_paths=true);
+```
+
+<div class="narrow_table monospace_table"></div>
+
+| count_star() |
+|-------------:|
+| 60175        |
+
+### "Guessing" Metadata Versions
+
+By default, either a table version number or a `version-hint.text` **must** be provided for the `iceberg` extension to read a table. This is typically provided by an external data catalog. In the event neither is present, the `iceberg` extension can attempt to guess the latest version by passing "?" as the table version. The "latest" version is assumed to be the filename that is lexographically largest when sorting the filenames. Collations are not considered. This behavior is not enabled by default as it may potentially violate ACID constraints. It can be enabled by setting `unsafe_enable_version_guessing` to `true`. When this is set, `iceberg` functions will attempt to guess the latest version by default before failing.
+
+```sql
+SET unsafe_enable_version_guessing=true;
+SELECT count(*)
+FROM iceberg_scan('data/iceberg/lineitem_iceberg_no_hint', allow_moved_paths = true);
+-- Or explicitly as:
+-- .. FROM iceberg_scan('data/iceberg/lineitem_iceberg_no_hint', version='?', allow_moved_paths = true);
+```
+
+<div class="narrow_table monospace_table"></div>
+
+| count_star() |
+|--------------|
+| 51793        |
 
 ## Limitations
 


### PR DESCRIPTION
Update the duckdb_iceberg documentation to better describe some of the optional version resolution functionality and document the version guessing behavior provided by https://github.com/duckdb/duckdb_iceberg/pull/79. Also add a table of common parameters at the top of the document for easier reference.