### PR TITLE
Update typecasting.md

### DIFF
--- a/docs/sql/data_types/typecasting.md
+++ b/docs/sql/data_types/typecasting.md
@@ -12,11 +12,17 @@ Explicit typecasting is performed by using a `CAST` expression. For example, `CA
 
 ## Implicit Casting
 
-In many situations, the system will add casts by itself. This is called *implicit* casting. This happens for example when a function is called with an argument that does not match the type of the function, but can be casted to the desired type.
+When a function is called with an argument that does not match the type of the function, but can be casted to the desired type, the system will add an  *implicit* cast.
+
+Implicit casts can only be added for a number of type combinations, and is generally only possible when the cast cannot fail. For example, an implicit cast can be added from `INTEGER` to `DOUBLE` – but not from `DOUBLE` to `INTEGER`.
 
 Consider the function `sin(DOUBLE)`. This function takes as input argument a column of type `DOUBLE`, however, it can be called with an integer as well: `sin(1)`. The integer is converted into a double before being passed to the `sin` function.
 
-Implicit casts can only be added for a number of type combinations, and is generally only possible when the cast cannot fail. For example, an implicit cast can be added from `INTEGER` to `DOUBLE` – but not from `DOUBLE` to `INTEGER`.
+### Combination casting
+
+When values of different types need to be combined to an unspecified joint parent type, the system will perform implicit casts to an automatically selected parent type. The implicit casts performed in this situation are more lenient than regular implicit casts; for example, a `BOOL` value may be cast to `INT` (with `true` mapping to `1` and `false` to `0`) even though this is not possible for regular implicit casts.
+
+This *combination casting* occurs for comparisons (`==` / `<` / `>`), set operations (`UNION` / `EXCEPT` / `INTERSECT`), and nested type constructors (`list_value` / `[...]` / `MAP`).
 
 ## Casting Operations Matrix
 

--- a/docs/sql/data_types/typecasting.md
+++ b/docs/sql/data_types/typecasting.md
@@ -12,7 +12,7 @@ Explicit typecasting is performed by using a `CAST` expression. For example, `CA
 
 ## Implicit Casting
 
-When a function is called with an argument that does not match the type of the function, but can be casted to the desired type, the system will add an  *implicit* cast.
+In many situations, the system will add casts by itself. This is called *implicit* casting and happens, for example, when a function is called with an argument that does not match the type of the function but can be casted to the required type.
 
 Implicit casts can only be added for a number of type combinations, and is generally only possible when the cast cannot fail. For example, an implicit cast can be added from `INTEGER` to `DOUBLE` – but not from `DOUBLE` to `INTEGER`.
 
@@ -20,7 +20,7 @@ Consider the function `sin(DOUBLE)`. This function takes as input argument a col
 
 ### Combination casting
 
-When values of different types need to be combined to an unspecified joint parent type, the system will perform implicit casts to an automatically selected parent type. The implicit casts performed in this situation are more lenient than regular implicit casts; for example, a `BOOL` value may be cast to `INT` (with `true` mapping to `1` and `false` to `0`) even though this is not possible for regular implicit casts.
+When values of different types need to be combined to an unspecified joint parent type, the system will perform implicit casts to an automatically selected parent type. For example, `list_value(1::INT64, 1::UINT64)` creates a list of type `INT128[]`. The implicit casts performed in this situation are sometimes more lenient than regular implicit casts. For example, a `BOOL` value may be cast to `INT` (with `true` mapping to `1` and `false` to `0`) even though this is not possible for regular implicit casts.
 
 This *combination casting* occurs for comparisons (`==` / `<` / `>`), set operations (`UNION` / `EXCEPT` / `INTERSECT`), and nested type constructors (`list_value` / `[...]` / `MAP`).
 


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/13847 (sadly).

From what I can tell, `BOOL -> INTEGERTYPES` is the only example of this special type of casting?

Maybe one should get one final confirmation whether it's worth documenting this special type of cast rather than simply dropping it and gaining more [PostgreSQL compatibility]( https://duckdb.org/docs/sql/dialect/postgresql_compatibility.html) for it (just to reiterate: I'm all for  implicit casts to programatically selected parent types, I just question the value of allowing *more* implicit casts in this situation than in other implicit cast situations.) 

By the way: do you have the HTML for the typecasting matrix?  I'd like to resolve https://github.com/duckdb/duckdb-web/issues/2791 too by adding `INTEGER_LITERAL` / `STRING_LITERAL` / `NUMERIC_LITERAL` to the table (at which point I'd also add the "combination cast" from bool to int to the table)