### PR TITLE
Clarify Rust shutdown documentation

### DIFF
--- a/docs/api/rust.md
+++ b/docs/api/rust.md
@@ -20,7 +20,7 @@ use duckdb::{params, Connection, Result};
 let conn = Connection::open_in_memory()?;
 ```
 
-You can `conn.close()` the `Connection` manually, or just leave it out of scope, we had implement the `Drop` trait which will automatically close the underlining db connection for you.
+The `Connection` will automatically close the underlining db connection for you when goes out of scope (via `Drop`). You can also explicitly close the `Connection` with `conn.close()`. This is not much difference between these in the typical case, but in case there is an error, you'll have the chance to handle it with the explicit close.
 
 ### Querying
 


### PR DESCRIPTION
I noticed a bit of funky grammar here, so I took a moment to improve it.