### PR TITLE
Most things are headline-capitalized

### DIFF
--- a/docs/api/c/vector.md
+++ b/docs/api/c/vector.md
@@ -100,7 +100,7 @@ Enums are stored as unsigned integer values internally. The exact native type de
 
 <div class="narrow_table monospace_table"></div>
 
-| Dictionary Size | NativeType |
+| Dictionary size | NativeType |
 |-----------------|------------|
 | <= 255          | uint8_t    |
 | <= 65535        | uint16_t   |

--- a/docs/api/cli/syntax_highlighting.md
+++ b/docs/api/cli/syntax_highlighting.md
@@ -16,7 +16,7 @@ Below is a list of components that can be configured.
 
 <div class="narrow_table"></div>
 
-|          Type           |   Command   |  Default Color  |
+|          Type           |   Command   |  Default color  |
 |-------------------------|-------------|-----------------|
 | Keywords                | `.keyword`  | `green`         |
 | Constants ad literals   | `.constant` | `yellow`        |
@@ -29,7 +29,7 @@ The components can be configured using either a supported color name (e.g., `.ke
 
 <div class="narrow_table"></div>
 
-|     Color     | Terminal Code |
+|     Color     | Terminal code |
 |---------------|---------------|
 | red           | `\033[31m`    |
 | green         | `\033[32m`    |

--- a/docs/extensions/spatial/r-tree_indexes.md
+++ b/docs/extensions/spatial/r-tree_indexes.md
@@ -134,7 +134,7 @@ The following options can be passed to the `WITH` clause when creating an R-tree
 
 The `rtree_index_dump(VARCHAR)` table function can be used to return all the nodes within an R-tree index which might come on handy when debugging, profiling or otherwise just inspecting the structure of the index. The function takes the name of the R-tree index as an argument and returns a table with the following columns:
 
-| Column Name | Type | Description |
+| Column name | Type | Description |
 |-------------|------|-------------|
 | `level`     | `INTEGER` | The level of the node in the R-tree. The root node has level 0. |
 | `bounds`    | `BOX_2DF` | The bounding box of the node. |

--- a/docs/guides/performance/file_formats.md
+++ b/docs/guides/performance/file_formats.md
@@ -79,7 +79,7 @@ CSV files are often distributed in compressed format such as GZIP archives (`.cs
 
 <div class="narrow_table"></div>
 
-| Schema | Load Time |
+| Schema | Load time |
 |---|--:|
 | Load from GZIP-compressed CSV files (`.csv.gz`) | 107.1 s |
 | Decompressing (using parallel `gunzip`) and loading from decompressed CSV files | 121.3 s |


### PR DESCRIPTION
But table headers are not! Amending this critical issue