### PR TITLE
Fix LIKE query at where.md

### DIFF
--- a/docs/sql/query_syntax/where.md
+++ b/docs/sql/query_syntax/where.md
@@ -21,7 +21,7 @@ Select all rows that match the given case-insensitive `LIKE` expression:
 ```sql
 SELECT *
 FROM table_name
-WHERE name ILIKE '%mark%';
+WHERE name LIKE '%mark%';
 ```
 
 Select all rows that match the given composite expression:


### PR DESCRIPTION
The LIKE operator was written as ILIKE in the example.