### PR TITLE
Prefer user selected theme over system theme

### DIFF
--- a/_layouts/community_extension_doc.html
+++ b/_layouts/community_extension_doc.html
@@ -23,15 +23,7 @@
 
 	{% seo title=false %}
 	
-	<script>
-		var userPrefersDark = localStorage.getItem('mode') === 'dark';
-		var systemPrefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-		if (userPrefersDark || systemPrefersDark) {
-			document.documentElement.classList.add('darkmode');
-			document.documentElement.classList.add('disable-transitions');
-		}
-	</script>
-
+	<script src="{{ site.baseurl }}/js/determine_color_scheme.js?{{ site.data['hash'] }}"></script>
 </head>
 
 <body class="documentation communityextensions{% if page.body_class %} {{ page.body_class }} {% endif %}">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -32,15 +32,7 @@
 
 	{% seo title=false %}
 	
-	<script>
-		var userPrefersDark = localStorage.getItem('mode') === 'dark';
-		var systemPrefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-		if (userPrefersDark || systemPrefersDark) {
-			document.documentElement.classList.add('darkmode');
-			document.documentElement.classList.add('disable-transitions');
-		}
-	</script>
-	
+	<script src="{{ site.baseurl }}/js/determine_color_scheme.js?{{ site.data['hash'] }}"></script>
 </head>
 <body {% if page.body_class %} class="{{ page.body_class }}" {% endif %}>
 

--- a/_layouts/docu.html
+++ b/_layouts/docu.html
@@ -31,16 +31,8 @@
 	<meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
 
 	{% seo title=false %}
-	
-	<script>
-		var userPrefersDark = localStorage.getItem('mode') === 'dark';
-		var systemPrefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-		if (userPrefersDark || systemPrefersDark) {
-			document.documentElement.classList.add('darkmode');
-			document.documentElement.classList.add('disable-transitions');
-		}
-	</script>
 
+	<script src="{{ site.baseurl }}/js/determine_color_scheme.js?{{ site.data['hash'] }}"></script>
 </head>
 
 {% capture issue_title %}Issue found on page '{{ page.title }}'{% endcapture %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -36,15 +36,7 @@
 		{% seo title=false %}
 	{% endif %}
 	
-	<script>
-		var userPrefersDark = localStorage.getItem('mode') === 'dark';
-		var systemPrefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-		if (userPrefersDark || systemPrefersDark) {
-			document.documentElement.classList.add('darkmode');
-			document.documentElement.classList.add('disable-transitions');
-		}
-	</script>
-
+	<script src="{{ site.baseurl }}/js/determine_color_scheme.js?{{ site.data['hash'] }}"></script>
 </head>
 <body {% if page.body_class %} class="{{ page.body_class }}" {% endif %}>
 	

--- a/_layouts/postarchive.html
+++ b/_layouts/postarchive.html
@@ -36,15 +36,7 @@
 		{% seo title=false %}
 	{% endif %}
 	
-	<script>
-		var userPrefersDark = localStorage.getItem('mode') === 'dark';
-		var systemPrefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-		if (userPrefersDark || systemPrefersDark) {
-			document.documentElement.classList.add('darkmode');
-			document.documentElement.classList.add('disable-transitions');
-		}
-	</script>
-
+	<script src="{{ site.baseurl }}/js/determine_color_scheme.js?{{ site.data['hash'] }}"></script>
 </head>
 <body {% if page.body_class %} class="{{ page.body_class }}" {% endif %}>
 	

--- a/js/determine_color_scheme.js
+++ b/js/determine_color_scheme.js
@@ -1,0 +1,18 @@
+(function() {
+    function setDarkMode() {
+        document.documentElement.classList.add("darkmode");
+        document.documentElement.classList.add('disable-transitions')
+    }
+
+    const userColorSchemePref = localStorage.getItem("mode");
+    if (userColorSchemePref !== null) {
+        // Use user preference
+        return userColorSchemePref === 'dark' && setDarkMode();
+    }
+
+    // Fallback to system preference
+    var systemPrefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    if (systemPrefersDark) {
+        setDarkMode()
+    }
+})();


### PR DESCRIPTION
This PR fixes #4269 

It seems the core issue is this piece of code present in the various HTML templates in the [_layouts](https://github.com/duckdb/duckdb-web/tree/main/_layouts) folder:
```html
<script>
	var userPrefersDark = localStorage.getItem('mode') === 'dark';
	var systemPrefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
	if (userPrefersDark || systemPrefersDark) {
		document.documentElement.classList.add('darkmode');
		document.documentElement.classList.add('disable-transitions');
	}
</script>
```

It checks if the user prefers the dark theme, and even if they don't (with the light theme set explicitly), it stills ends up using the dark theme if the system is set to the dark color scheme. 

I have updated this bit of code to check the user preference, use the dark/light theme if the preference is set and only fallback to the system color scheme if it doesn't exist. I have also extracted the snippet into a separate script to avoid duplication.