### PR TITLE
docs: replace broken `SET GLOBAL` example

### DIFF
--- a/docs/sql/statements/set.md
+++ b/docs/sql/statements/set.md
@@ -38,10 +38,10 @@ Retrieve configuration value:
 SELECT current_setting('threads');
 ```
 
-Set the default catalog search path globally:
+Set the default sort order globally:
 
 ```sql
-SET GLOBAL search_path = 'db1,db2'
+SET GLOBAL sort_order = 'desc';
 ```
 
 Set the default collation for the session:


### PR DESCRIPTION
Search path does not support being set globally:

```
D set global search_path = 'foo';
Catalog Error: option "search_path" cannot be set globally
```

See https://github.com/duckdb/duckdb/blob/aa3787b0/src/main/config.cpp#L154.