### PR TITLE
iFrame (YouTube) in Blog Posts too wide for mobile

### DIFF
--- a/css/blog.scss
+++ b/css/blog.scss
@@ -723,7 +723,10 @@ footer{
 			}
 		}
 	}
-
+	.newswrap .postwrap .postcontent iframe{
+		width: 100%;
+		height: auto;
+	}
 	.filterbar {
 		flex-wrap: wrap;
 		margin-bottom: 30px;


### PR DESCRIPTION
- set iframes to 100% on mobile devices