### PR TITLE
Fixed s3-parquet.sql Binder Error

### DIFF
--- a/_includes/landing-page/sql/s3-parquet.sql
+++ b/_includes/landing-page/sql/s3-parquet.sql
@@ -1,6 +1,6 @@
 -- Directly query Parquet file in S3
 SELECT
-    station,
+    station_name,
     count(*) AS num_services
 FROM 's3://duckdb-blobs/train_services.parquet'
 GROUP BY ALL


### PR DESCRIPTION
Hi dear DuckDB team,

I discovered that the s3 query on the landing page returned a Binder Error, as one column name was incorrect. I am not 100% sure if my change affects the landing page query, but I could not fine the query elsewhere. 

Best regards,
Paul