### PR TITLE
Standardize Jekyll Server Startup when using Dev Containers method

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,7 +22,7 @@
 	],
 
 	// Uncomment the next line to run commands after the container is created.
-	"postCreateCommand": "bundler"
+	"postCreateCommand": "bundle exec jekyll serve --host 0.0.0.0 --incremental --livereload"
 
 	// Configure tool-specific properties.
 	// "customizations": {},


### PR DESCRIPTION
Updated the post-create command in `devcontainer.json` to start Jekyll server, aligning it with our standard Docker run method.

Here I am making it [identical to the docker run method](https://github.com/duckdb/duckdb-web/blob/main/scripts/docker-serve.sh#L21-L24).

The current implementation does not work anyway.