### PR TITLE
node neo typo fix

### DIFF
--- a/docs/api/node_neo/overview.md
+++ b/docs/api/node_neo/overview.md
@@ -143,7 +143,7 @@ Read chunk data (row-major):
 
 ```ts
 // array of rows, each as an array of values
-const columns = chunk.getRows(); 
+const rows = chunk.getRows(); 
 ```
 
 Read chunk data (one value at a time):


### PR DESCRIPTION
Just a one-line typo fix in the Node Neo docs. @szarnyasg 