### PR TITLE
Update node-neo API doc snippet with null chunk API change

### DIFF
--- a/docs/api/node_neo/overview.md
+++ b/docs/api/node_neo/overview.md
@@ -125,7 +125,7 @@ const chunks = [];
 while (true) {
   const chunk = await result.fetchChunk();
   // Last chunk will have zero rows.
-  if (chunk.rowCount === 0) {
+  if (!chunk || chunk.rowCount === 0) {
     break;
   }
   chunks.push(chunk);


### PR DESCRIPTION
Chunks can be null as of this commit:

https://github.com/duckdb/duckdb-node-neo/commit/09d2dddf839fe753552bda3d10012f0a7fb343f2

This PR updates a snippet on the node neo page to match the API changes.