### PR TITLE
Patch 83

### DIFF
--- a/docs/sql/data_types/interval.md
+++ b/docs/sql/data_types/interval.md
@@ -86,7 +86,7 @@ SELECT
 ;
 ```
 
-> Adding an `INTERVAL` to a `DATE` returns a `TIMESTAMP` even when the `INTERVAL` has no microseconds component. The result is the same as if the `DATE` was first cast to a `TIMESTAMP` (which sets the time component to `00:00:00`) before adding the `INTERVAL`.
+> Adding an `INTERVAL` to a `DATE` returns a `TIMESTAMP` even when the `INTERVAL` has no microseconds component. The result is the same as if the `DATE` was cast to a `TIMESTAMP` (which sets the time component to `00:00:00`) before adding the `INTERVAL`.
 
 Conversely, subtracting two `TIMESTAMP`s or two `TIMESTAMPTZ`s from one another creates an `INTERVAL` describing the difference between the timestamps with only the *days and microseconds* components. For example:
 

--- a/docs/sql/data_types/interval.md
+++ b/docs/sql/data_types/interval.md
@@ -86,7 +86,7 @@ SELECT
 ;
 ```
 
-> Warning Addition or subtraction of an `INTERVAL` value with a `DATE` value will return a `TIMESTAMP` with the time component set to `00:00:00.000000`.
+> Adding an `INTERVAL` to a `DATE` returns a `TIMESTAMP` even when the `INTERVAL` has no microseconds component. The result is the same as if the `DATE` was first cast to a `TIMESTAMP` (which sets the time component to `00:00:00`) before adding the `INTERVAL`.
 
 Conversely, subtracting two `TIMESTAMP`s or two `TIMESTAMPTZ`s from one another creates an `INTERVAL` describing the difference between the timestamps with only the *days and microseconds* components. For example:
 

--- a/docs/sql/functions/date.md
+++ b/docs/sql/functions/date.md
@@ -16,11 +16,11 @@ The table below shows the available mathematical operators for `DATE` types.
 | Operator | Description | Example | Result |
 |:-|:--|:---|:--|
 | `+` | addition of days (integers) | `DATE '1992-03-22' + 5` | `1992-03-27` |
-| `+` | addition of an `INTERVAL` | `DATE '1992-03-22' + INTERVAL 5 DAY` | `1992-03-27 00:00:00.000000` |
-| `+` | addition of a variable `INTERVAL` | `SELECT DATE '1992-03-22' + INTERVAL (d.days) DAY FROM (VALUES (5), (11)) AS d(days)` | `1992-03-27 00:00:00.000000` and `1992-04-02 00:00:00.000000` |
+| `+` | addition of an `INTERVAL` | `DATE '1992-03-22' + INTERVAL 5 DAY` | `1992-03-27 00:00:00` |
+| `+` | addition of a variable `INTERVAL` | `SELECT DATE '1992-03-22' + INTERVAL (d.days) DAY FROM (VALUES (5), (11)) AS d(days)` | `1992-03-27 00:00:00` and `1992-04-02 00:00:00` |
 | `-` | subtraction of `DATE`s | `DATE '1992-03-27' - DATE '1992-03-22'` | `5` |
-| `-` | subtraction of an `INTERVAL` | `DATE '1992-03-27' - INTERVAL 5 DAY` | `1992-03-22 00:00:00.000000` |
-| `-` | subtraction of a variable `INTERVAL` | `SELECT DATE '1992-03-27' - INTERVAL (d.days) DAY FROM (VALUES (5), (11)) AS d(days)` | `1992-03-22 00:00:00.000000` and `1992-03-16 00:00:00.000000` |
+| `-` | subtraction of an `INTERVAL` | `DATE '1992-03-27' - INTERVAL 5 DAY` | `1992-03-22 00:00:00` |
+| `-` | subtraction of a variable `INTERVAL` | `SELECT DATE '1992-03-27' - INTERVAL (d.days) DAY FROM (VALUES (5), (11)) AS d(days)` | `1992-03-22 00:00:00` and `1992-03-16 00:00:00` |
 
 Adding to or subtracting from [infinite values]({% link docs/sql/data_types/date.md %}#special-values) produces the same infinite value.
 


### PR DESCRIPTION
1. Remove trailing `000000` since the clients don't show it either.
2. Rephrase warning box since it is currently saying that the time component is always zero no matter the contents!
3. Downgrade warning to hint since I don't see the risk in getting wrong results from this (and it couldn't be any other way, since the column type can't depend on the contents of individual rows)
