### PR TITLE
Added Documentation for `weighted_avg(arg, weight)`

### DIFF
--- a/docs/sql/functions/aggregates.md
+++ b/docs/sql/functions/aggregates.md
@@ -153,6 +153,7 @@ The table below shows the available general aggregate functions.
 | [`product(arg)`](#productarg) | Calculates the product of all non-null values in `arg`. |
 | [`string_agg(arg, sep)`](#string_aggarg-sep) | Concatenates the column string values with a separator. This function is [affected by ordering](#order-by-clause-in-aggregate-functions). |
 | [`sum(arg)`](#sumarg) | Calculates the sum of all non-null values in `arg`. |
+| [`weighted_avg(arg, weight)`](#weighted_avgarg-weight)     | Calculates the weighted average all non-null values in `arg`, where each value is scaled by its corresponding `weight`. If `weight` is `NULL`, the corresponding `arg` value will be skipped |                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 
 #### `any_value(arg)`
 
@@ -457,6 +458,14 @@ The table below shows the available general aggregate functions.
 | **Description** | Calculates the sum of all non-null values in `arg`. |
 | **Example** | `sum(A)` |
 | **Alias(es)** | - |
+
+#### `weighted_avg(arg, weight)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Calculates the weighted average of all non-null values in `arg`, where each value is scaled by its corresponding `weight`. If `weight` is `NULL`, the value will be skipped. |
+| **Example** | `weighted_avg(A, W)` |
+| **Alias(es)** | `wavg(arg, weight)` |
 
 ## Approximate Aggregates
 

--- a/docs/sql/functions/aggregates.md
+++ b/docs/sql/functions/aggregates.md
@@ -153,7 +153,7 @@ The table below shows the available general aggregate functions.
 | [`product(arg)`](#productarg) | Calculates the product of all non-null values in `arg`. |
 | [`string_agg(arg, sep)`](#string_aggarg-sep) | Concatenates the column string values with a separator. This function is [affected by ordering](#order-by-clause-in-aggregate-functions). |
 | [`sum(arg)`](#sumarg) | Calculates the sum of all non-null values in `arg`. |
-| [`weighted_avg(arg, weight)`](#weighted_avgarg-weight) | Calculates the weighted average all non-null values in `arg`, where each value is scaled by its corresponding `weight`. If `weight` is `NULL`, the corresponding `arg` value will be skipped |
+| [`weighted_avg(arg, weight)`](#weighted_avgarg-weight) | Calculates the weighted average all non-null values in `arg`, where each value is scaled by its corresponding `weight`. If `weight` is `NULL`, the corresponding `arg` value will be skipped. |
 
 #### `any_value(arg)`
 

--- a/docs/sql/functions/aggregates.md
+++ b/docs/sql/functions/aggregates.md
@@ -153,7 +153,7 @@ The table below shows the available general aggregate functions.
 | [`product(arg)`](#productarg) | Calculates the product of all non-null values in `arg`. |
 | [`string_agg(arg, sep)`](#string_aggarg-sep) | Concatenates the column string values with a separator. This function is [affected by ordering](#order-by-clause-in-aggregate-functions). |
 | [`sum(arg)`](#sumarg) | Calculates the sum of all non-null values in `arg`. |
-| [`weighted_avg(arg, weight)`](#weighted_avgarg-weight)     | Calculates the weighted average all non-null values in `arg`, where each value is scaled by its corresponding `weight`. If `weight` is `NULL`, the corresponding `arg` value will be skipped |                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| [`weighted_avg(arg, weight)`](#weighted_avgarg-weight) | Calculates the weighted average all non-null values in `arg`, where each value is scaled by its corresponding `weight`. If `weight` is `NULL`, the corresponding `arg` value will be skipped |
 
 #### `any_value(arg)`
 


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb-web/issues/4504.

I added documentation for the `weighted_avg(arg, weight)` function in the `General Aggregate Functions` table, let me know if you think this is a good place, I am also happy to move it. 
