### PR TITLE
Update list_reduce to use (acc, x) instead of (x, y) parameters

### DIFF
--- a/docs/sql/dialect/sql_quirks.md
+++ b/docs/sql/dialect/sql_quirks.md
@@ -17,8 +17,6 @@ On empty groups, the aggregate functions `sum`, `list`, and `string_agg` all ret
 
 To comply with standard SQL, one-based indexing is used almost everywhere, e.g., array and string indexing and slicing, and window functions (`row_number`, `rank`, `dense_rank`). However, similarly to PostgreSQL, [JSON features use a zero-based indexing]({% link docs/data/json/overview.md %}#indexing).
 
-> While list functions use a 1-based indexing, `list_reduce` uses a 0-based indexing. This is a [known issue](https://github.com/duckdb/duckdb/issues/14619).
-
 ## Expressions
 
 ### Results That May Surprise You

--- a/docs/sql/functions/lambda.md
+++ b/docs/sql/functions/lambda.md
@@ -13,7 +13,7 @@ For example, the following are all valid lambda functions:
 
 * `param -> param > 1`
 * `s -> contains(concat(s, 'DB'), 'duck')`
-* `(x, y) -> x + y`
+* `(acc, x) -> acc + x`
 
 ## Scalar Functions That Accept Lambda Functions
 
@@ -46,7 +46,7 @@ For example, the following are all valid lambda functions:
 <div class="nostroke_table"></div>
 
 | **Description** | Reduces all elements of the input list into a single value by executing the lambda function on a running result and the next list element. The list must have at least one element – the use of an initial accumulator value is currently not supported. For more information, see [Reduce](#reduce). |
-| **Example** | `list_reduce([4, 5, 6], (x, y) -> x + y)` |
+| **Example** | `list_reduce([4, 5, 6], (acc, x) -> acc + x)` |
 | **Result** | `15` |
 | **Aliases** | `array_reduce`, `reduce` |
 
@@ -102,7 +102,7 @@ SELECT apply([1, 2], x -> apply([4], x -> x + tbl.x)[1] + x) FROM tbl;
 ## Indexes as Parameters
 
 All lambda functions accept an optional extra parameter that represents the index of the current element.
-This is always the last parameter of the lambda function (e.g., `i` in `(x, y, i)`), and is 1-based (i.e., the first element has index 1).
+This is always the last parameter of the lambda function (e.g., `i` in `(x, i)`), and is 1-based (i.e., the first element has index 1).
 
 Get all elements that are larger than their index:
 
@@ -244,7 +244,7 @@ The list must have at least one element.
 Sum of all list elements:
 
 ```sql
-SELECT list_reduce([1, 2, 3, 4], (x, y) -> x + y);
+SELECT list_reduce([1, 2, 3, 4], (acc, x) -> acc + x);
 ```
 
 ```text
@@ -254,7 +254,7 @@ SELECT list_reduce([1, 2, 3, 4], (x, y) -> x + y);
 Only add up list elements if they are greater than 2:
 
 ```sql
-SELECT list_reduce(list_filter([1, 2, 3, 4], x -> x > 2), (x, y) -> x + y);
+SELECT list_reduce(list_filter([1, 2, 3, 4], x -> x > 2), (acc, x) -> acc + x);
 ```
 
 ```text
@@ -264,7 +264,7 @@ SELECT list_reduce(list_filter([1, 2, 3, 4], x -> x > 2), (x, y) -> x + y);
 Concat all list elements:
 
 ```sql
-SELECT list_reduce(['DuckDB', 'is', 'awesome'], (x, y) -> concat(x, ' ', y));
+SELECT list_reduce(['DuckDB', 'is', 'awesome'], (acc, x) -> concat(acc, ' ', x));
 ```
 
 ```text

--- a/docs/sql/functions/list.md
+++ b/docs/sql/functions/list.md
@@ -33,7 +33,7 @@ title: List Functions
 | [`list_intersect(list1, list2)`](#list_intersectlist1-list2) | Returns a list of all the elements that exist in both `l1` and `l2`, without duplicates. |
 | [`list_position(list, element)`](#list_positionlist-element) | Returns the index of the element if the list contains the element. If the element is not found, it returns `NULL`. |
 | [`list_prepend(element, list)`](#list_prependelement-list) | Prepends `element` to `list`. |
-| [`list_reduce(list, lambda)`](#list_reducelist-lambda) | Returns a single value that is the result of applying the lambda function to each element of the input list. See the [Lambda Functions]({% link docs/sql/functions/lambda.md %}#reduce) page for more details. While list functions use a 1-based indexing, `list_reduce` uses a 0-based indexing. This is a [known issue](https://github.com/duckdb/duckdb/issues/14619). |
+| [`list_reduce(list, lambda)`](#list_reducelist-lambda) | Returns a single value that is the result of applying the lambda function to each element of the input list. See the [Lambda Functions]({% link docs/sql/functions/lambda.md %}#reduce) page for more details. |
 | [`list_resize(list, size[, value])`](#list_resizelist-size-value) | Resizes the list to contain `size` elements. Initializes new elements with `value` or `NULL` if `value` is not set. |
 | [`list_reverse_sort(list)`](#list_reverse_sortlist) | Sorts the elements of the list in reverse order. See the [Sorting Lists]({% link docs/sql/functions/list.md %}#sorting-lists) section for more details about the `NULL` sorting order. |
 | [`list_reverse(list)`](#list_reverselist) | Reverses the list. |
@@ -279,8 +279,8 @@ title: List Functions
 
 <div class="nostroke_table"></div>
 
-| **Description** | Returns a single value that is the result of applying the lambda function to each element of the input list. See the [Lambda Functions]({% link docs/sql/functions/lambda.md %}#reduce) page for more details. While list functions use a 1-based indexing, `list_reduce` uses a 0-based indexing. This is a [known issue](https://github.com/duckdb/duckdb/issues/14619). |
-| **Example** | `list_reduce([4, 5, 6], (x, y) -> x + y)` |
+| **Description** | Returns a single value that is the result of applying the lambda function to each element of the input list. See the [Lambda Functions]({% link docs/sql/functions/lambda.md %}#reduce) page for more details. |
+| **Example** | `list_reduce([4, 5, 6], (acc, x) -> acc + x)` |
 | **Result** | `15` |
 | **Aliases** | `array_reduce`, `reduce` |
 


### PR DESCRIPTION
Fixes #4518