### PR TITLE
Use read_json_objects in read_json_objects docs

### DIFF
--- a/docs/data/json/loading_json.md
+++ b/docs/data/json/loading_json.md
@@ -91,7 +91,7 @@ With `'unstructured'`, the top-level JSON is read, e.g. for `birds.json`:
 ```
 
 ```sql
-FROM read_json('birds.json', format = 'unstructured');
+FROM read_json_objects('birds.json', format = 'unstructured');
 ```
 
 will result in two objects being read:


### PR DESCRIPTION
`read_json` results in a different output and is discussed later in the document