### PR TITLE
Improve CSV parameter descriptions

### DIFF
--- a/docs/data/csv/overview.md
+++ b/docs/data/csv/overview.md
@@ -100,13 +100,13 @@ Below are parameters that can be passed to the [`read_csv` function](#csv-functi
 | `delim` | Delimiter character used to separate columns within each line. Alias for `sep`. | `VARCHAR` | `,` |
 | `delimiter` | Alias for `delim`; only available in the `COPY` statement. | `VARCHAR` | `,` |
 | `escape` | String used to escape the `quote` character within quoted values. | `VARCHAR` | `"` |
-| `encoding` | Encoding used by the CSV file.  | `VARCHAR` | `utf-8` |
+| `encoding` | Encoding used by the CSV file. Not available in the `COPY` statement. | `VARCHAR` | `utf-8` |
 | `filename` | Add path of the containing file to each row, as a string column named `filename`. Relative or absolute paths are returned depending on the path or glob pattern provided to `read_csv`, not just filenames. | `BOOL` | `false` |
 | `force_not_null` | Do not match values in the the specified columns against the `NULL` string. In the default case where the `NULL` string is empty, this means that empty values are read as zero-length strings instead of `NULL`s. | `VARCHAR[]` | `[]` |
 | `header` | First line of each file contains the column names. | `BOOL` | `false` |
 | `hive_partitioning` | Interpret the path as a [Hive partitioned path]({% link docs/data/partitioning/hive_partitioning.md %}). | `BOOL` | `false` |
 | `ignore_errors` | Ignore any parsing errors encountered. | `BOOL` | `false` |
-| `max_line_size` or `maximum_line_size` | Maximum line size, in bytes. | `BIGINT` | 2000000 |
+| `max_line_size` or `maximum_line_size`. Not available in the `COPY` statement. | Maximum line size, in bytes. | `BIGINT` | 2000000 |
 | `names` or `column_names` | Column names, as a list. See [example]({% link docs/data/csv/tips.md %}#provide-names-if-the-file-does-not-contain-a-header). | `VARCHAR[]` | (empty) |
 | `new_line` | New line character(s). Options are `'\r'`,`'\n'`, or `'\r\n'`. The CSV parser only distinguishes between single-character and double-character line delimiters. Therefore, it does not differentiate between `'\r'` and `'\n'`.| `VARCHAR` | (empty) |
 | `normalize_names` | Normalize column names, removing any non-alphanumeric characters from them. | `BOOL` | `false` |

--- a/docs/data/csv/overview.md
+++ b/docs/data/csv/overview.md
@@ -102,7 +102,7 @@ Below are parameters that can be passed to the CSV reader. These parameters are 
 | `encoding` | Encoding used by the CSV file.  | `VARCHAR` | `utf-8` |
 | `filename` | Add path of the containing file to each row, as a string column named `filename`. Relative or absolute paths are returned depending on the path or glob pattern provided to `read_csv`, not just filenames. | `BOOL` | `false` |
 | `force_not_null` | Do not match values in the the specified columns values against the `NULL` string. In the default case where the `NULL` string is empty, this means that empty values are read as zero-length strings instead of `NULL`s. | `VARCHAR[]` | `[]` |
-| `header` | First line is a header with the column names. | `BOOL` | `false` |
+| `header` | First line of each file contains the column names. | `BOOL` | `false` |
 | `hive_partitioning` | Interpret the path as a [Hive partitioned path]({% link docs/data/partitioning/hive_partitioning.md %}). | `BOOL` | `false` |
 | `ignore_errors` | Ignore any parsing errors encountered. | `BOOL` | `false` |
 | `max_line_size` or `maximum_line_size` | Maximum line size, in bytes. | `BIGINT` | 2000000 |

--- a/docs/data/csv/overview.md
+++ b/docs/data/csv/overview.md
@@ -92,7 +92,7 @@ Below are parameters that can be passed to the CSV reader. These parameters are 
 | `auto_type_candidates` | Types that the sniffer uses when detecting column types. The `VARCHAR` type is always included as a fallback option. See [example](#auto_type_candidates-details). | `TYPE[]` | [default types](#auto_type_candidates-details) |
 | `buffer_size` | Size of the buffers used to read files, in bytes. Must be large enough to hold four lines and can significantly impact performance. | `BIGINT` | `16 * max_line_size` |
 | `columns` | Column names and types, as a struct (e.g., `{'col1': 'INTEGER', 'col2': 'VARCHAR'}`). Using this option disables auto detection. | `STRUCT` | (empty) |
-| `comment` | Character used to start comments, either at the beginning of a line or within it. | `VARCHAR` | `` |
+| `comment` | Character used to initiate comments. Lines starting with a comment character are completely ignored; other lines containing a comment character are parsed only up to that point. | `VARCHAR` | `` |
 | `compression` | Method used to compress the CSV file. By default this is detected automatically from the file extension (e.g., `t.csv.gz` will use gzip, `t.csv` will use `none`). Options are `none`, `gzip`, `zstd`. | `VARCHAR` | `auto` |
 | `dateformat` or `date_format` | [Date format]({% link docs/sql/functions/dateformat.md %}) used when parsing and writing dates. | `VARCHAR` | (empty) |
 | `decimal_separator` | Decimal separator for numbers. | `VARCHAR` | `.` |

--- a/docs/data/csv/overview.md
+++ b/docs/data/csv/overview.md
@@ -122,7 +122,7 @@ Below are parameters that can be passed to the CSV reader. These parameters are 
 | `sep` | Delimiter character used to separate columns within each line. Alias for `delim`. | `VARCHAR` | `,` |
 | `skip` | Number of lines to skip at the start of each file. | `BIGINT` | 0 |
 | `store_rejects` | Skip any lines with errors and store them in the rejects table. | `BOOL` | `false` |
-| `timestampformat` or `timestamp_format` | [Date format]({% link docs/sql/functions/dateformat.md %}) used when parsing and writing timestamps. | `VARCHAR` | (empty) |
+| `timestampformat` or `timestamp_format` | [Timestamp format]({% link docs/sql/functions/dateformat.md %}) used when parsing and writing timestamps. | `VARCHAR` | (empty) |
 | `types` or `dtypes` or `column_types` | Column types, as either a list (by position) or a struct (by name). See [example]({% link docs/data/csv/tips.md %}#override-the-types-of-specific-columns). | `VARCHAR[]` or `STRUCT` | (empty) |
 | `union_by_name` | Align columns from different files [by column name]({% link docs/data/multiple_files/combining_schemas.md %}#union-by-name) instead of position. Using this option increases memory consumption. | `BOOL` | `false` |
 

--- a/docs/data/csv/overview.md
+++ b/docs/data/csv/overview.md
@@ -90,7 +90,7 @@ Below are parameters that can be passed to the CSV reader. These parameters are 
 | `allow_quoted_nulls` | Allow the conversion of quoted values to `NULL` values | `BOOL` | `true` |
 | `auto_detect` | [Auto detect CSV parameters]({% link docs/data/csv/auto_detection.md %}). | `BOOL` | `true` |
 | `auto_type_candidates` | Types that the sniffer uses when detecting column types. The `VARCHAR` type is always included as a fallback option. See [example](#auto_type_candidates-details). | `TYPE[]` | [default types](#auto_type_candidates-details) |
-| `buffer_size` | Size of the buffers used to read files. Must be large enough to always accommodate at least four lines and can significantly impact performance. | `BIGINT` | [`16 * max_line_size` |
+| `buffer_size` | Size of the buffers used to read files. Must be large enough to accommodate at least four lines and can significantly impact performance. | `BIGINT` | [`16 * max_line_size` |
 | `columns` | Column names and types, as a struct (e.g., `{'col1': 'INTEGER', 'col2': 'VARCHAR'}`). Using this option implies that auto detection is not used. | `STRUCT` | (empty) |
 | `comment` | Character used to start comments, either at the start or within a line. | `VARCHAR` | `` |
 | `compression` | Method used to compress the CSV file. By default this is detected automatically from the file extension (e.g., `t.csv.gz` will use gzip, `t.csv` will use `none`). Options are `none`, `gzip`, `zstd`. | `VARCHAR` | `auto` |

--- a/docs/data/csv/overview.md
+++ b/docs/data/csv/overview.md
@@ -92,7 +92,7 @@ Below are parameters that can be passed to the CSV reader. These parameters are 
 | `auto_type_candidates` | Types that the sniffer uses when detecting column types. The `VARCHAR` type is always included as a fallback option. See [example](#auto_type_candidates-details). | `TYPE[]` | [default types](#auto_type_candidates-details) |
 | `buffer_size` | Size of the buffers used to read files, in bytes. Must be large enough to hold four lines and can significantly impact performance. | `BIGINT` | `16 * max_line_size` |
 | `columns` | Column names and types, as a struct (e.g., `{'col1': 'INTEGER', 'col2': 'VARCHAR'}`). Using this option disables auto detection. | `STRUCT` | (empty) |
-| `comment` | Character used to initiate comments. Lines starting with a comment character are completely ignored; other lines containing a comment character are parsed only up to that point. | `VARCHAR` | `` |
+| `comment` | Character used to initiate comments. Lines starting with a comment character (optionally preceded by space characters) are completely ignored; other lines containing a comment character are parsed only up to that point. | `VARCHAR` | `` |
 | `compression` | Method used to compress the CSV file. By default this is detected automatically from the file extension (e.g., `t.csv.gz` will use gzip, `t.csv` will use `none`). Options are `none`, `gzip`, `zstd`. | `VARCHAR` | `auto` |
 | `dateformat` or `date_format` | [Date format]({% link docs/sql/functions/dateformat.md %}) used when parsing and writing dates. | `VARCHAR` | (empty) |
 | `decimal_separator` | Decimal separator for numbers. | `VARCHAR` | `.` |

--- a/docs/data/csv/overview.md
+++ b/docs/data/csv/overview.md
@@ -86,42 +86,42 @@ Below are parameters that can be passed to the CSV reader. These parameters are 
 
 | Name | Description | Type | Default |
 |:--|:-----|:-|:-|
-| `all_varchar` | Skip type detection for CSV parsing and assume all columns to be of type `VARCHAR`. This option is only supported by the `read_csv` function. | `BOOL` | `false` |
+| `all_varchar` | Skip type detection and assume all columns to be of type `VARCHAR`. This option is only supported by the `read_csv` function. | `BOOL` | `false` |
 | `allow_quoted_nulls` | Allow the conversion of quoted values to `NULL` values | `BOOL` | `true` |
 | `auto_detect` | [Auto detect CSV parameters]({% link docs/data/csv/auto_detection.md %}). | `BOOL` | `true` |
-| `auto_type_candidates` | Types that the sniffer uses when detecting CSV column types. The `VARCHAR` type is always included in the detected types (as a fallback option). See [example](#auto_type_candidates-details). | `TYPE[]` | [default types](#auto_type_candidates-details) |
-| `buffer_size` | Size of the buffers used to read the file. Must be large enough to always accommodate at least four lines of the CSV file. This option can significantly impact performance. | `BIGINT` | [`16 * max_line_size` |
-| `columns` | Specifies the column names and types contained within the CSV file, as a strcut (e.g., `{'col1': 'INTEGER', 'col2': 'VARCHAR'}`). Using this option implies that auto detection is not used. | `STRUCT` | (empty) |
-| `comment` | Specifies the character used to represent comments in the CSV file. Comment characters can either cause an entire line to be ignored or appear anywhere within a line, causing the parser to ignore the rest of it. | `VARCHAR` | `` |
-| `compression` | Specifies the compression type for the file. By default this is detected automatically from the file extension (e.g., `t.csv.gz` will use gzip, `t.csv` will use `none`). Options are `none`, `gzip`, `zstd`. | `VARCHAR` | `auto` |
-| `dateformat` or `date_format` | Specifies the date format used in the file, which is used when parsing and writing dates. See [Date Format]({% link docs/sql/functions/dateformat.md %}). | `VARCHAR` | (empty) |
+| `auto_type_candidates` | Types that the sniffer uses when detecting column types. The `VARCHAR` type is always included in the detected types (as a fallback option). See [example](#auto_type_candidates-details). | `TYPE[]` | [default types](#auto_type_candidates-details) |
+| `buffer_size` | Size of the buffers used to read files. Must be large enough to always accommodate at least four lines. This option can significantly impact performance. | `BIGINT` | [`16 * max_line_size` |
+| `columns` | Specifies the column names and types, as a struct (e.g., `{'col1': 'INTEGER', 'col2': 'VARCHAR'}`). Using this option implies that auto detection is not used. | `STRUCT` | (empty) |
+| `comment` | Specifies the character used to start comments. Comment characters can either cause an entire line to be ignored or appear anywhere within a line, causing the parser to ignore the rest of it. | `VARCHAR` | `` |
+| `compression` | Specifies the compression type. By default this is detected automatically from the file extension (e.g., `t.csv.gz` will use gzip, `t.csv` will use `none`). Options are `none`, `gzip`, `zstd`. | `VARCHAR` | `auto` |
+| `dateformat` or `date_format` | Specifies the date format that is used when parsing and writing dates. See [Date Format]({% link docs/sql/functions/dateformat.md %}). | `VARCHAR` | (empty) |
 | `decimal_separator` | Specifies the decimal separator for numbers. | `VARCHAR` | `.` |
-| `delimiter` | Specifies the delimiter character that separates columns within each row (line) of the file. Alias for `sep`. This option is only available in the `COPY` statement. | `VARCHAR` | `,` |
-| `delim` | Specifies the delimiter character that separates columns within each row (line) of the file. Alias for `sep`. | `VARCHAR` | `,` |
+| `delimiter` | Specifies the delimiter character that separates columns within each row (line). Alias for `sep`. This option is only available in the `COPY` statement. | `VARCHAR` | `,` |
+| `delim` | Specifies the delimiter character that separates columns within each row (line). Alias for `sep`. | `VARCHAR` | `,` |
 | `escape` | Specifies the string used to escape the `quote` character within quoted values. | `VARCHAR` | `"` |
 | `encoding` | Specifies the encoding used by the CSV file and ensures conversion from the source encoding to `UTF-8`.  | `VARCHAR` | `utf-8` |
-| `filename` | Add path of the containing CSV file to each row, in a string column named `filename`. Relative or absolute paths are returned depending on the path or glob pattern provided to `read_csv`, not just filenames. | `BOOL` | `false` |
+| `filename` | Add path of the containing file to each row, in a string column named `filename`. Relative or absolute paths are returned depending on the path or glob pattern provided to `read_csv`, not just filenames. | `BOOL` | `false` |
 | `force_not_null` | Do not match values in the the specified columns values against the `NULL` string. In the default case where the `NULL` string is empty, this means that empty values are read as zero-length strings instead of `NULL`s. | `VARCHAR[]` | `[]` |
-| `header` | Specifies whether the file contains a header line with the names of each column. | `BOOL` | `false` |
+| `header` | Specifies whether files contain header lines with the column names. | `BOOL` | `false` |
 | `hive_partitioning` | Interpret the path as a [Hive partitioned path]({% link docs/data/partitioning/hive_partitioning.md %}). | `BOOL` | `false` |
 | `ignore_errors` | Ignore any parsing errors encountered. | `BOOL` | `false` |
 | `max_line_size` or `maximum_line_size` | Maximum line size, in bytes. | `BIGINT` | 2000000 |
 | `names` or `column_names` | Specifies the column names, as a list. See [example]({% link docs/data/csv/tips.md %}#provide-names-if-the-file-does-not-contain-a-header). | `VARCHAR[]` | (empty) |
-| `new_line` | Specifies the new line character(s) in the file. Options are `'\r'`,`'\n'`, or `'\r\n'`. The CSV parser only distinguishes between single-character and double-character line delimiters. Therefore, it does not differentiate between `'\r'` and `'\n'`.| `VARCHAR` | (empty) |
+| `new_line` | Specifies the new line character(s). Options are `'\r'`,`'\n'`, or `'\r\n'`. The CSV parser only distinguishes between single-character and double-character line delimiters. Therefore, it does not differentiate between `'\r'` and `'\n'`.| `VARCHAR` | (empty) |
 | `normalize_names` | Normalize column names, removing any non-alphanumeric characters from them. | `BOOL` | `false` |
 | `null_padding` | Pad the remaining columns on the right with `NULL` values when a row lacks columns. | `BOOL` | `false` |
 | `nullstr` or `null` | Specifies a list of strings that represent a `NULL` value. | `VARCHAR` or `VARCHAR[]` | (empty) |
 | `parallel` | Use the parallel CSV reader. | `BOOL` | `true` |
 | `quote` | Specifies the quoting string to be used when a data value is quoted. | `VARCHAR` | `"` |
 | `rejects_scan` | Name of a temporary table where scan information for faulty CSV files is stored.  | `VARCHAR` | `reject_scans` |
-| `rejects_table` | Name of a temporary table where information on faulty lines in a CSV file are stored.  | `VARCHAR` | `reject_errors` |
-| `rejects_limit` | Upper limit on the number of faulty records from a CSV file that will be recorded in the rejects table. 0 is used when no limit should be applied.  | `BIGINT` | `0` |
+| `rejects_table` | Name of a temporary table where information on faulty lines in a file are stored.  | `VARCHAR` | `reject_errors` |
+| `rejects_limit` | Upper limit on the number of faulty records from a CSV file that are recorded in the rejects table. Setting this to `0` means that no limit is applied.  | `BIGINT` | `0` |
 | `rfc_4180` | Adhere to the RFC 4180 standard. Setting this to `false` may allow the parser to read structurally incorrect files. | `BOOL` | `false` |
 | `sample_size` | Number of sample rows for [auto detection of parameters]({% link docs/data/csv/auto_detection.md %}). | `BIGINT` | 20480 |
 | `sep` | Specifies the delimiter character that separates columns within each row (line) of the file. Alias for `delim`. | `VARCHAR` | `,` |
-| `skip` | Number of lines to skip at at the top of the file. | `BIGINT` | 0 |
-| `store_rejects` | Skip any errors in the file and store them in the rejects temporary table. | `BOOL` | `false` |
-| `timestampformat` or `timestamp_format` | Specifies the date format used in the file, which is used when parsing and writing timestamps. See [Date Format]({% link docs/sql/functions/dateformat.md %}). | `VARCHAR` | (empty) |
+| `skip` | Number of lines to skip at at the top of each file. | `BIGINT` | 0 |
+| `store_rejects` | Skip any lines with errors and store them in the rejects temporary table. | `BOOL` | `false` |
+| `timestampformat` or `timestamp_format` | Specifies the date format that is used when parsing and writing timestamps. See [Date Format]({% link docs/sql/functions/dateformat.md %}). | `VARCHAR` | (empty) |
 | `types` or `dtypes` or `column_types` | Specifies the column types, as either a list (by position) or a struct (by name). [Example here]({% link docs/data/csv/tips.md %}#override-the-types-of-specific-columns). | `VARCHAR[]` or `STRUCT` | (empty) |
 | `union_by_name` | Unify columns of multiple schemas [by name]({% link docs/data/multiple_files/combining_schemas.md %}#union-by-name) rather than by position. Using this option increases memory consumption. | `BOOL` | `false` |
 

--- a/docs/data/csv/overview.md
+++ b/docs/data/csv/overview.md
@@ -96,8 +96,8 @@ Below are parameters that can be passed to the CSV reader. These parameters are 
 | `compression` | Method used to compress the CSV file. By default this is detected automatically from the file extension (e.g., `t.csv.gz` will use gzip, `t.csv` will use `none`). Options are `none`, `gzip`, `zstd`. | `VARCHAR` | `auto` |
 | `dateformat` or `date_format` | Date format used when parsing and writing dates. See [Date Format]({% link docs/sql/functions/dateformat.md %}). | `VARCHAR` | (empty) |
 | `decimal_separator` | Decimal separator for numbers. | `VARCHAR` | `.` |
-| `delimiter` | Delimiter character used to separate columns within each row. Alias for `sep`. This option is only available in the `COPY` statement. | `VARCHAR` | `,` |
-| `delim` | Delimiter character used to separate columns within each row. Alias for `sep`. | `VARCHAR` | `,` |
+| `delimiter` | Delimiter character used to separate columns within each line. Alias for `sep`. This option is only available in the `COPY` statement. | `VARCHAR` | `,` |
+| `delim` | Delimiter character used to separate columns within each line. Alias for `sep`. | `VARCHAR` | `,` |
 | `escape` | String used to escape the `quote` character within quoted values. | `VARCHAR` | `"` |
 | `encoding` | Encoding used by the CSV file.  | `VARCHAR` | `utf-8` |
 | `filename` | Add path of the containing file to each row, as a string column named `filename`. Relative or absolute paths are returned depending on the path or glob pattern provided to `read_csv`, not just filenames. | `BOOL` | `false` |
@@ -109,7 +109,7 @@ Below are parameters that can be passed to the CSV reader. These parameters are 
 | `names` or `column_names` | Column names, as a list. See [example]({% link docs/data/csv/tips.md %}#provide-names-if-the-file-does-not-contain-a-header). | `VARCHAR[]` | (empty) |
 | `new_line` | New line character(s). Options are `'\r'`,`'\n'`, or `'\r\n'`. The CSV parser only distinguishes between single-character and double-character line delimiters. Therefore, it does not differentiate between `'\r'` and `'\n'`.| `VARCHAR` | (empty) |
 | `normalize_names` | Normalize column names, removing any non-alphanumeric characters from them. | `BOOL` | `false` |
-| `null_padding` | Pad the remaining columns on the right with `NULL` values when a row lacks columns. | `BOOL` | `false` |
+| `null_padding` | Pad the remaining columns on the right with `NULL` values when a line lacks columns. | `BOOL` | `false` |
 | `nullstr` or `null` | Strings that represent a `NULL` value. | `VARCHAR` or `VARCHAR[]` | (empty) |
 | `parallel` | Use the parallel CSV reader. | `BOOL` | `true` |
 | `quote` | String used to quote values. | `VARCHAR` | `"` |
@@ -117,8 +117,8 @@ Below are parameters that can be passed to the CSV reader. These parameters are 
 | `rejects_table` | Name of a temporary table where information on faulty lines is stored.  | `VARCHAR` | `reject_errors` |
 | `rejects_limit` | Upper limit on the number of faulty lines per file that are recorded in the rejects table. Setting this to `0` means that no limit is applied.  | `BIGINT` | `0` |
 | `rfc_4180` | Adhere to the RFC 4180 standard. Setting this to `false` may allow the parser to read structurally incorrect files. | `BOOL` | `false` |
-| `sample_size` | Number of sample rows for [auto detection of parameters]({% link docs/data/csv/auto_detection.md %}). | `BIGINT` | 20480 |
-| `sep` | Delimiter character used to separate columns within each row. Alias for `delim`. | `VARCHAR` | `,` |
+| `sample_size` | Number of sample lines for [auto detection of parameters]({% link docs/data/csv/auto_detection.md %}). | `BIGINT` | 20480 |
+| `sep` | Delimiter character used to separate columns within each line. Alias for `delim`. | `VARCHAR` | `,` |
 | `skip` | Number of lines to skip at the start of each file. | `BIGINT` | 0 |
 | `store_rejects` | Skip any lines with errors and store them in the rejects table. | `BOOL` | `false` |
 | `timestampformat` or `timestamp_format` | Date format used when parsing and writing timestamps. See [Date Format]({% link docs/sql/functions/dateformat.md %}). | `VARCHAR` | (empty) |
@@ -223,5 +223,5 @@ iconv -f ISO-8859-2 -t UTF-8 input.csv > input-utf-8.csv
 ## Order Preservation
 
 The CSV reader respects the `preserve_insertion_order` [configuration option]({% link docs/configuration/overview.md %}) to [preserve insertion order]({% link docs/sql/dialect/order_preservation.md %}).
-When `true` (the default), the order of the rows in the resultset returned by the CSV reader is the same as the order of the corresponding lines read from the file(s).
+When `true` (the default), the order of the rows in the result set returned by the CSV reader is the same as the order of the corresponding lines read from the file(s).
 When `false`, there is no guarantee that the order is preserved.

--- a/docs/data/csv/overview.md
+++ b/docs/data/csv/overview.md
@@ -91,10 +91,10 @@ Below are parameters that can be passed to the CSV reader. These parameters are 
 | `auto_detect` | [Auto detect CSV parameters]({% link docs/data/csv/auto_detection.md %}). | `BOOL` | `true` |
 | `auto_type_candidates` | Types that the sniffer uses when detecting CSV column types. The `VARCHAR` type is always included in the detected types (as a fallback option). See [example](#auto_type_candidates-details). | `TYPE[]` | [default types](#auto_type_candidates-details) |
 | `buffer_size` | Size of the buffers used to read the file. Must be large enough to always accommodate at least four lines of the CSV file. This option can significantly impact performance. | `BIGINT` | [`16 * max_line_size` |
-| `columns` | Specifies the column names and types contained within the CSV file (e.g., `{'col1': 'INTEGER', 'col2': 'VARCHAR'}`). Using this option implies that auto detection is not used. | `STRUCT` | (empty) |
+| `columns` | Specifies the column names and types contained within the CSV file, as a strcut (e.g., `{'col1': 'INTEGER', 'col2': 'VARCHAR'}`). Using this option implies that auto detection is not used. | `STRUCT` | (empty) |
 | `comment` | Specifies the character used to represent comments in the CSV file. Comment characters can either cause an entire line to be ignored or appear anywhere within a line, causing the parser to ignore the rest of it. | `VARCHAR` | `` |
 | `compression` | Specifies the compression type for the file. By default this is detected automatically from the file extension (e.g., `t.csv.gz` will use gzip, `t.csv` will use `none`). Options are `none`, `gzip`, `zstd`. | `VARCHAR` | `auto` |
-| `dateformat` or `date_format` | Specifies the date format used in the file, which are used when parsing and writing dates. See [Date Format]({% link docs/sql/functions/dateformat.md %}). | `VARCHAR` | (empty) |
+| `dateformat` or `date_format` | Specifies the date format used in the file, which is used when parsing and writing dates. See [Date Format]({% link docs/sql/functions/dateformat.md %}). | `VARCHAR` | (empty) |
 | `decimal_separator` | Specifies the decimal separator for numbers. | `VARCHAR` | `.` |
 | `delimiter` | Specifies the delimiter character that separates columns within each row (line) of the file. Alias for `sep`. This option is only available in the `COPY` statement. | `VARCHAR` | `,` |
 | `delim` | Specifies the delimiter character that separates columns within each row (line) of the file. Alias for `sep`. | `VARCHAR` | `,` |
@@ -121,7 +121,7 @@ Below are parameters that can be passed to the CSV reader. These parameters are 
 | `sep` | Specifies the delimiter character that separates columns within each row (line) of the file. Alias for `delim`. | `VARCHAR` | `,` |
 | `skip` | Number of lines to skip at at the top of the file. | `BIGINT` | 0 |
 | `store_rejects` | Skip any errors in the file and store them in the rejects temporary table. | `BOOL` | `false` |
-| `timestampformat` or `timestamp_format` | Specifies the date format used in the file, which is used when parsing and wring timestamps. See [Date Format]({% link docs/sql/functions/dateformat.md %}). | `VARCHAR` | (empty) |
+| `timestampformat` or `timestamp_format` | Specifies the date format used in the file, which is used when parsing and writing timestamps. See [Date Format]({% link docs/sql/functions/dateformat.md %}). | `VARCHAR` | (empty) |
 | `types` or `dtypes` or `column_types` | Specifies the column types, as either a list (by position) or a struct (by name). [Example here]({% link docs/data/csv/tips.md %}#override-the-types-of-specific-columns). | `VARCHAR[]` or `STRUCT` | (empty) |
 | `union_by_name` | Unify columns of multiple schemas [by name]({% link docs/data/multiple_files/combining_schemas.md %}#union-by-name) rather than by position. Using this option increases memory consumption. | `BOOL` | `false` |
 

--- a/docs/data/csv/overview.md
+++ b/docs/data/csv/overview.md
@@ -127,6 +127,12 @@ Below are parameters that can be passed to the [`read_csv` function](#csv-functi
 | `types` or `dtypes` or `column_types` | Column types, as either a list (by position) or a struct (by name). See [example]({% link docs/data/csv/tips.md %}#override-the-types-of-specific-columns). | `VARCHAR[]` or `STRUCT` | (empty) |
 | `union_by_name` | Align columns from different files [by column name]({% link docs/data/multiple_files/combining_schemas.md %}#union-by-name) instead of position. Using this option increases memory consumption. | `BOOL` | `false` |
 
+
+> Tip We recommend the [`iconv` command-line tool](https://linux.die.net/man/1/iconv) to convert files with encodings not supported by `read_csv` to UTF-8. For example:
+>  ```bash
+> iconv -f ISO-8859-2 -t UTF-8 input.csv > input-utf-8.csv
+> ```
+
 ### `auto_type_candidates` Details
 
 The `auto_type_candidates` option lets you specify the data types that should be considered by the CSV reader for [column data type detection]({% link docs/data/csv/auto_detection.md %}#type-detection).
@@ -213,14 +219,6 @@ SELECT * FROM ontime;
 ## Reading Faulty CSV Files
 
 DuckDB supports reading erroneous CSV files. For details, see the [Reading Faulty CSV Files page]({% link docs/data/csv/reading_faulty_csv_files.md %}).
-
-## Limitations
-
-The CSV reader only supports input files using UTF-8 character encoding. For CSV files using different encodings, use e.g., the [`iconv` command-line tool](https://linux.die.net/man/1/iconv) to convert them to UTF-8. For example:
-
-```bash
-iconv -f ISO-8859-2 -t UTF-8 input.csv > input-utf-8.csv
-```
 
 ## Order Preservation
 

--- a/docs/data/csv/overview.md
+++ b/docs/data/csv/overview.md
@@ -86,43 +86,43 @@ Below are parameters that can be passed to the CSV reader. These parameters are 
 
 | Name | Description | Type | Default |
 |:--|:-----|:-|:-|
-| `all_varchar` | Skip type detection and assume all columns to be of type `VARCHAR`. This option is only supported by the `read_csv` function. | `BOOL` | `false` |
+| `all_varchar` | Skip type detection and assume all columns are of type `VARCHAR`. This option is only supported by the `read_csv` function. | `BOOL` | `false` |
 | `allow_quoted_nulls` | Allow the conversion of quoted values to `NULL` values | `BOOL` | `true` |
 | `auto_detect` | [Auto detect CSV parameters]({% link docs/data/csv/auto_detection.md %}). | `BOOL` | `true` |
-| `auto_type_candidates` | Types that the sniffer uses when detecting column types. The `VARCHAR` type is always included in the detected types (as a fallback option). See [example](#auto_type_candidates-details). | `TYPE[]` | [default types](#auto_type_candidates-details) |
-| `buffer_size` | Size of the buffers used to read files. Must be large enough to always accommodate at least four lines. This option can significantly impact performance. | `BIGINT` | [`16 * max_line_size` |
-| `columns` | Specifies the column names and types, as a struct (e.g., `{'col1': 'INTEGER', 'col2': 'VARCHAR'}`). Using this option implies that auto detection is not used. | `STRUCT` | (empty) |
-| `comment` | Specifies the character used to start comments. Comment characters can either cause an entire line to be ignored or appear anywhere within a line, causing the parser to ignore the rest of it. | `VARCHAR` | `` |
-| `compression` | Specifies the compression type. By default this is detected automatically from the file extension (e.g., `t.csv.gz` will use gzip, `t.csv` will use `none`). Options are `none`, `gzip`, `zstd`. | `VARCHAR` | `auto` |
-| `dateformat` or `date_format` | Specifies the date format that is used when parsing and writing dates. See [Date Format]({% link docs/sql/functions/dateformat.md %}). | `VARCHAR` | (empty) |
-| `decimal_separator` | Specifies the decimal separator for numbers. | `VARCHAR` | `.` |
-| `delimiter` | Specifies the delimiter character that separates columns within each row (line). Alias for `sep`. This option is only available in the `COPY` statement. | `VARCHAR` | `,` |
-| `delim` | Specifies the delimiter character that separates columns within each row (line). Alias for `sep`. | `VARCHAR` | `,` |
-| `escape` | Specifies the string used to escape the `quote` character within quoted values. | `VARCHAR` | `"` |
-| `encoding` | Specifies the encoding used by the CSV file and ensures conversion from the source encoding to `UTF-8`.  | `VARCHAR` | `utf-8` |
+| `auto_type_candidates` | Types that the sniffer uses when detecting column types. The `VARCHAR` type is always included as a fallback option. See [example](#auto_type_candidates-details). | `TYPE[]` | [default types](#auto_type_candidates-details) |
+| `buffer_size` | Size of the buffers used to read files. Must be large enough to always accommodate at least four lines and can significantly impact performance. | `BIGINT` | [`16 * max_line_size` |
+| `columns` | Column names and types, as a struct (e.g., `{'col1': 'INTEGER', 'col2': 'VARCHAR'}`). Using this option implies that auto detection is not used. | `STRUCT` | (empty) |
+| `comment` | Character used to start comments, either at the start or within a line. | `VARCHAR` | `` |
+| `compression` | Method used to compress the CSV file. By default this is detected automatically from the file extension (e.g., `t.csv.gz` will use gzip, `t.csv` will use `none`). Options are `none`, `gzip`, `zstd`. | `VARCHAR` | `auto` |
+| `dateformat` or `date_format` | Date format used when parsing and writing dates. See [Date Format]({% link docs/sql/functions/dateformat.md %}). | `VARCHAR` | (empty) |
+| `decimal_separator` | Decimal separator for numbers. | `VARCHAR` | `.` |
+| `delimiter` | Delimiter character used to separate columns within each row. Alias for `sep`. This option is only available in the `COPY` statement. | `VARCHAR` | `,` |
+| `delim` | Delimiter character used to separate columns within each row. Alias for `sep`. | `VARCHAR` | `,` |
+| `escape` | String used to escape the `quote` character within quoted values. | `VARCHAR` | `"` |
+| `encoding` | Encoding used by the CSV file.  | `VARCHAR` | `utf-8` |
 | `filename` | Add path of the containing file to each row, in a string column named `filename`. Relative or absolute paths are returned depending on the path or glob pattern provided to `read_csv`, not just filenames. | `BOOL` | `false` |
 | `force_not_null` | Do not match values in the the specified columns values against the `NULL` string. In the default case where the `NULL` string is empty, this means that empty values are read as zero-length strings instead of `NULL`s. | `VARCHAR[]` | `[]` |
-| `header` | Specifies whether files contain header lines with the column names. | `BOOL` | `false` |
+| `header` | First line is a header with the column names. | `BOOL` | `false` |
 | `hive_partitioning` | Interpret the path as a [Hive partitioned path]({% link docs/data/partitioning/hive_partitioning.md %}). | `BOOL` | `false` |
 | `ignore_errors` | Ignore any parsing errors encountered. | `BOOL` | `false` |
 | `max_line_size` or `maximum_line_size` | Maximum line size, in bytes. | `BIGINT` | 2000000 |
-| `names` or `column_names` | Specifies the column names, as a list. See [example]({% link docs/data/csv/tips.md %}#provide-names-if-the-file-does-not-contain-a-header). | `VARCHAR[]` | (empty) |
-| `new_line` | Specifies the new line character(s). Options are `'\r'`,`'\n'`, or `'\r\n'`. The CSV parser only distinguishes between single-character and double-character line delimiters. Therefore, it does not differentiate between `'\r'` and `'\n'`.| `VARCHAR` | (empty) |
+| `names` or `column_names` | Column names, as a list. See [example]({% link docs/data/csv/tips.md %}#provide-names-if-the-file-does-not-contain-a-header). | `VARCHAR[]` | (empty) |
+| `new_line` | New line character(s). Options are `'\r'`,`'\n'`, or `'\r\n'`. The CSV parser only distinguishes between single-character and double-character line delimiters. Therefore, it does not differentiate between `'\r'` and `'\n'`.| `VARCHAR` | (empty) |
 | `normalize_names` | Normalize column names, removing any non-alphanumeric characters from them. | `BOOL` | `false` |
 | `null_padding` | Pad the remaining columns on the right with `NULL` values when a row lacks columns. | `BOOL` | `false` |
 | `nullstr` or `null` | Specifies a list of strings that represent a `NULL` value. | `VARCHAR` or `VARCHAR[]` | (empty) |
 | `parallel` | Use the parallel CSV reader. | `BOOL` | `true` |
-| `quote` | Specifies the quoting string to be used when a data value is quoted. | `VARCHAR` | `"` |
+| `quote` | String used to quote values. | `VARCHAR` | `"` |
 | `rejects_scan` | Name of a temporary table where scan information for faulty CSV files is stored.  | `VARCHAR` | `reject_scans` |
-| `rejects_table` | Name of a temporary table where information on faulty lines in a file are stored.  | `VARCHAR` | `reject_errors` |
-| `rejects_limit` | Upper limit on the number of faulty records from a CSV file that are recorded in the rejects table. Setting this to `0` means that no limit is applied.  | `BIGINT` | `0` |
+| `rejects_table` | Name of a temporary table where information on faulty lines is stored.  | `VARCHAR` | `reject_errors` |
+| `rejects_limit` | Upper limit on the number of faulty lines from a CSV file that are recorded in the rejects table. Setting this to `0` means that no limit is applied.  | `BIGINT` | `0` |
 | `rfc_4180` | Adhere to the RFC 4180 standard. Setting this to `false` may allow the parser to read structurally incorrect files. | `BOOL` | `false` |
 | `sample_size` | Number of sample rows for [auto detection of parameters]({% link docs/data/csv/auto_detection.md %}). | `BIGINT` | 20480 |
-| `sep` | Specifies the delimiter character that separates columns within each row (line) of the file. Alias for `delim`. | `VARCHAR` | `,` |
+| `sep` | Delimiter character used to separate columns within each row. Alias for `delim`. | `VARCHAR` | `,` |
 | `skip` | Number of lines to skip at at the top of each file. | `BIGINT` | 0 |
-| `store_rejects` | Skip any lines with errors and store them in the rejects temporary table. | `BOOL` | `false` |
-| `timestampformat` or `timestamp_format` | Specifies the date format that is used when parsing and writing timestamps. See [Date Format]({% link docs/sql/functions/dateformat.md %}). | `VARCHAR` | (empty) |
-| `types` or `dtypes` or `column_types` | Specifies the column types, as either a list (by position) or a struct (by name). [Example here]({% link docs/data/csv/tips.md %}#override-the-types-of-specific-columns). | `VARCHAR[]` or `STRUCT` | (empty) |
+| `store_rejects` | Skip any lines with errors and store them in the rejects table. | `BOOL` | `false` |
+| `timestampformat` or `timestamp_format` | Date format used when parsing and writing timestamps. See [Date Format]({% link docs/sql/functions/dateformat.md %}). | `VARCHAR` | (empty) |
+| `types` or `dtypes` or `column_types` | Column types, as either a list (by position) or a struct (by name). [Example here]({% link docs/data/csv/tips.md %}#override-the-types-of-specific-columns). | `VARCHAR[]` or `STRUCT` | (empty) |
 | `union_by_name` | Unify columns of multiple schemas [by name]({% link docs/data/multiple_files/combining_schemas.md %}#union-by-name) rather than by position. Using this option increases memory consumption. | `BOOL` | `false` |
 
 ### `auto_type_candidates` Details

--- a/docs/data/csv/overview.md
+++ b/docs/data/csv/overview.md
@@ -90,11 +90,11 @@ Below are parameters that can be passed to the CSV reader. These parameters are 
 | `allow_quoted_nulls` | Allow the conversion of quoted values to `NULL` values | `BOOL` | `true` |
 | `auto_detect` | [Auto detect CSV parameters]({% link docs/data/csv/auto_detection.md %}). | `BOOL` | `true` |
 | `auto_type_candidates` | Types that the sniffer uses when detecting column types. The `VARCHAR` type is always included as a fallback option. See [example](#auto_type_candidates-details). | `TYPE[]` | [default types](#auto_type_candidates-details) |
-| `buffer_size` | Size of the buffers used to read files. Must be large enough to accommodate at least four lines and can significantly impact performance. | `BIGINT` | [`16 * max_line_size` |
+| `buffer_size` | Size of the buffers used to read files, in bytes. Must be large enough to hold four lines and can significantly impact performance. | `BIGINT` | `16 * max_line_size` |
 | `columns` | Column names and types, as a struct (e.g., `{'col1': 'INTEGER', 'col2': 'VARCHAR'}`). Using this option disables auto detection. | `STRUCT` | (empty) |
-| `comment` | Character used to start comments, either at the start of or within a line. | `VARCHAR` | `` |
+| `comment` | Character used to start comments, either at the beginning of a line or within it. | `VARCHAR` | `` |
 | `compression` | Method used to compress the CSV file. By default this is detected automatically from the file extension (e.g., `t.csv.gz` will use gzip, `t.csv` will use `none`). Options are `none`, `gzip`, `zstd`. | `VARCHAR` | `auto` |
-| `dateformat` or `date_format` | Date format used when parsing and writing dates. See [Date Format]({% link docs/sql/functions/dateformat.md %}). | `VARCHAR` | (empty) |
+| `dateformat` or `date_format` | [Date Format]({% link docs/sql/functions/dateformat.md %}) used when parsing and writing dates. | `VARCHAR` | (empty) |
 | `decimal_separator` | Decimal separator for numbers. | `VARCHAR` | `.` |
 | `delimiter` | Delimiter character used to separate columns within each line. Alias for `sep`. This option is only available in the `COPY` statement. | `VARCHAR` | `,` |
 | `delim` | Delimiter character used to separate columns within each line. Alias for `sep`. | `VARCHAR` | `,` |
@@ -121,9 +121,9 @@ Below are parameters that can be passed to the CSV reader. These parameters are 
 | `sep` | Delimiter character used to separate columns within each line. Alias for `delim`. | `VARCHAR` | `,` |
 | `skip` | Number of lines to skip at the start of each file. | `BIGINT` | 0 |
 | `store_rejects` | Skip any lines with errors and store them in the rejects table. | `BOOL` | `false` |
-| `timestampformat` or `timestamp_format` | Date format used when parsing and writing timestamps. See [Date Format]({% link docs/sql/functions/dateformat.md %}). | `VARCHAR` | (empty) |
-| `types` or `dtypes` or `column_types` | Column types, as either a list (by position) or a struct (by name). [Example here]({% link docs/data/csv/tips.md %}#override-the-types-of-specific-columns). | `VARCHAR[]` or `STRUCT` | (empty) |
-| `union_by_name` | Unify columns of multiple schemas [by name]({% link docs/data/multiple_files/combining_schemas.md %}#union-by-name) rather than by position. Using this option increases memory consumption. | `BOOL` | `false` |
+| `timestampformat` or `timestamp_format` | [Date format]({% link docs/sql/functions/dateformat.md %}) used when parsing and writing timestamps. | `VARCHAR` | (empty) |
+| `types` or `dtypes` or `column_types` | Column types, as either a list (by position) or a struct (by name). See [example]({% link docs/data/csv/tips.md %}#override-the-types-of-specific-columns). | `VARCHAR[]` or `STRUCT` | (empty) |
+| `union_by_name` | Align columns from different files [by column name]({% link docs/data/multiple_files/combining_schemas.md %}#union-by-name) instead of position. Using this option increases memory consumption. | `BOOL` | `false` |
 
 ### `auto_type_candidates` Details
 

--- a/docs/data/csv/overview.md
+++ b/docs/data/csv/overview.md
@@ -117,7 +117,7 @@ Below are parameters that can be passed to the CSV reader. These parameters are 
 | `rejects_scan` | Name of the [temporary table where information on faulty scans is stored]({% link docs/data/csv/reading_faulty_csv_files.md %}#reject-scans). | `VARCHAR` | `reject_scans` |
 | `rejects_table` | Name of the [temporary table where information on faulty lines is stored]({% link docs/data/csv/reading_faulty_csv_files.md %}#reject-errors). | `VARCHAR` | `reject_errors` |
 | `rejects_limit` | Upper limit on the number of faulty lines per file that are recorded in the rejects table. Setting this to `0` means that no limit is applied. | `BIGINT` | `0` |
-| `rfc_4180` | Adhere to the RFC 4180 standard. Setting this to `false` may allow the parser to read structurally incorrect files. | `BOOL` | `false` |
+| `rfc_4180` | Enforce the RFC 4180 standard. Setting this to `false` may allow the parser to read structurally incorrect files. | `BOOL` | `false` |
 | `sample_size` | Number of sample lines for [auto detection of parameters]({% link docs/data/csv/auto_detection.md %}). | `BIGINT` | 20480 |
 | `sep` | Delimiter character used to separate columns within each line. Alias for `delim`. | `VARCHAR` | `,` |
 | `skip` | Number of lines to skip at the start of each file. | `BIGINT` | 0 |

--- a/docs/data/csv/overview.md
+++ b/docs/data/csv/overview.md
@@ -93,7 +93,7 @@ Below are parameters that can be passed to the CSV reader. These parameters are 
 | `buffer_size` | Size of the buffers used to read files, in bytes. Must be large enough to hold four lines and can significantly impact performance. | `BIGINT` | `16 * max_line_size` |
 | `columns` | Column names and types, as a struct (e.g., `{'col1': 'INTEGER', 'col2': 'VARCHAR'}`). Using this option disables auto detection. | `STRUCT` | (empty) |
 | `comment` | Character used to initiate comments. Lines starting with a comment character (optionally preceded by space characters) are completely ignored; other lines containing a comment character are parsed only up to that point. | `VARCHAR` | `` |
-| `compression` | Method used to compress the CSV file. By default this is detected automatically from the file extension (e.g., `t.csv.gz` will use gzip, `t.csv` will use `none`). Options are `none`, `gzip`, `zstd`. | `VARCHAR` | `auto` |
+| `compression` | Method used to compress CSV files. By default this is detected automatically from the file extension (e.g., `t.csv.gz` will use gzip, `t.csv` will use `none`). Options are `none`, `gzip`, `zstd`. | `VARCHAR` | `auto` |
 | `dateformat` or `date_format` | [Date format]({% link docs/sql/functions/dateformat.md %}) used when parsing and writing dates. | `VARCHAR` | (empty) |
 | `decimal_separator` | Decimal separator for numbers. | `VARCHAR` | `.` |
 | `delimiter` | Delimiter character used to separate columns within each line. Alias for `sep`. This option is only available in the `COPY` statement. | `VARCHAR` | `,` |

--- a/docs/data/csv/overview.md
+++ b/docs/data/csv/overview.md
@@ -114,8 +114,8 @@ Below are parameters that can be passed to the CSV reader. These parameters are 
 | `nullstr` or `null` | Strings that represent a `NULL` value. | `VARCHAR` or `VARCHAR[]` | (empty) |
 | `parallel` | Use the parallel CSV reader. | `BOOL` | `true` |
 | `quote` | String used to quote values. | `VARCHAR` | `"` |
-| `rejects_scan` | Name of a [temporary table where information on faulty scans is stored]({% link docs/data/csv/reading_faulty_csv_files.md %}#reject-scans). | `VARCHAR` | `reject_scans` |
-| `rejects_table` | Name of a [temporary table where information on faulty lines is stored]({% link docs/data/csv/reading_faulty_csv_files.md %}#reject-errors). | `VARCHAR` | `reject_errors` |
+| `rejects_scan` | Name of the [temporary table where information on faulty scans is stored]({% link docs/data/csv/reading_faulty_csv_files.md %}#reject-scans). | `VARCHAR` | `reject_scans` |
+| `rejects_table` | Name of the [temporary table where information on faulty lines is stored]({% link docs/data/csv/reading_faulty_csv_files.md %}#reject-errors). | `VARCHAR` | `reject_errors` |
 | `rejects_limit` | Upper limit on the number of faulty lines per file that are recorded in the rejects table. Setting this to `0` means that no limit is applied. | `BIGINT` | `0` |
 | `rfc_4180` | Adhere to the RFC 4180 standard. Setting this to `false` may allow the parser to read structurally incorrect files. | `BOOL` | `false` |
 | `sample_size` | Number of sample lines for [auto detection of parameters]({% link docs/data/csv/auto_detection.md %}). | `BIGINT` | 20480 |

--- a/docs/data/csv/overview.md
+++ b/docs/data/csv/overview.md
@@ -94,7 +94,7 @@ Below are parameters that can be passed to the CSV reader. These parameters are 
 | `columns` | Column names and types, as a struct (e.g., `{'col1': 'INTEGER', 'col2': 'VARCHAR'}`). Using this option disables auto detection. | `STRUCT` | (empty) |
 | `comment` | Character used to start comments, either at the beginning of a line or within it. | `VARCHAR` | `` |
 | `compression` | Method used to compress the CSV file. By default this is detected automatically from the file extension (e.g., `t.csv.gz` will use gzip, `t.csv` will use `none`). Options are `none`, `gzip`, `zstd`. | `VARCHAR` | `auto` |
-| `dateformat` or `date_format` | [Date Format]({% link docs/sql/functions/dateformat.md %}) used when parsing and writing dates. | `VARCHAR` | (empty) |
+| `dateformat` or `date_format` | [Date format]({% link docs/sql/functions/dateformat.md %}) used when parsing and writing dates. | `VARCHAR` | (empty) |
 | `decimal_separator` | Decimal separator for numbers. | `VARCHAR` | `.` |
 | `delimiter` | Delimiter character used to separate columns within each line. Alias for `sep`. This option is only available in the `COPY` statement. | `VARCHAR` | `,` |
 | `delim` | Delimiter character used to separate columns within each line. Alias for `sep`. | `VARCHAR` | `,` |
@@ -113,9 +113,9 @@ Below are parameters that can be passed to the CSV reader. These parameters are 
 | `nullstr` or `null` | Strings that represent a `NULL` value. | `VARCHAR` or `VARCHAR[]` | (empty) |
 | `parallel` | Use the parallel CSV reader. | `BOOL` | `true` |
 | `quote` | String used to quote values. | `VARCHAR` | `"` |
-| `rejects_scan` | Name of a temporary table where information on faulty scans is stored.  | `VARCHAR` | `reject_scans` |
-| `rejects_table` | Name of a temporary table where information on faulty lines is stored.  | `VARCHAR` | `reject_errors` |
-| `rejects_limit` | Upper limit on the number of faulty lines per file that are recorded in the rejects table. Setting this to `0` means that no limit is applied.  | `BIGINT` | `0` |
+| `rejects_scan` | Name of a [temporary table where information on faulty scans is stored]({% link docs/data/csv/reading_faulty_csv_files.md %}#reject-scans). | `VARCHAR` | `reject_scans` |
+| `rejects_table` | Name of a [temporary table where information on faulty lines is stored]({% link docs/data/csv/reading_faulty_csv_files.md %}#reject-errors). | `VARCHAR` | `reject_errors` |
+| `rejects_limit` | Upper limit on the number of faulty lines per file that are recorded in the rejects table. Setting this to `0` means that no limit is applied. | `BIGINT` | `0` |
 | `rfc_4180` | Adhere to the RFC 4180 standard. Setting this to `false` may allow the parser to read structurally incorrect files. | `BOOL` | `false` |
 | `sample_size` | Number of sample lines for [auto detection of parameters]({% link docs/data/csv/auto_detection.md %}). | `BIGINT` | 20480 |
 | `sep` | Delimiter character used to separate columns within each line. Alias for `delim`. | `VARCHAR` | `,` |

--- a/docs/data/csv/overview.md
+++ b/docs/data/csv/overview.md
@@ -91,7 +91,7 @@ Below are parameters that can be passed to the CSV reader. These parameters are 
 | `auto_detect` | [Auto detect CSV parameters]({% link docs/data/csv/auto_detection.md %}). | `BOOL` | `true` |
 | `auto_type_candidates` | Types that the sniffer uses when detecting column types. The `VARCHAR` type is always included as a fallback option. See [example](#auto_type_candidates-details). | `TYPE[]` | [default types](#auto_type_candidates-details) |
 | `buffer_size` | Size of the buffers used to read files. Must be large enough to accommodate at least four lines and can significantly impact performance. | `BIGINT` | [`16 * max_line_size` |
-| `columns` | Column names and types, as a struct (e.g., `{'col1': 'INTEGER', 'col2': 'VARCHAR'}`). Using this option implies that auto detection is not used. | `STRUCT` | (empty) |
+| `columns` | Column names and types, as a struct (e.g., `{'col1': 'INTEGER', 'col2': 'VARCHAR'}`). Using this option disables auto detection. | `STRUCT` | (empty) |
 | `comment` | Character used to start comments, either at the start of or within a line. | `VARCHAR` | `` |
 | `compression` | Method used to compress the CSV file. By default this is detected automatically from the file extension (e.g., `t.csv.gz` will use gzip, `t.csv` will use `none`). Options are `none`, `gzip`, `zstd`. | `VARCHAR` | `auto` |
 | `dateformat` or `date_format` | Date format used when parsing and writing dates. See [Date Format]({% link docs/sql/functions/dateformat.md %}). | `VARCHAR` | (empty) |
@@ -101,7 +101,7 @@ Below are parameters that can be passed to the CSV reader. These parameters are 
 | `escape` | String used to escape the `quote` character within quoted values. | `VARCHAR` | `"` |
 | `encoding` | Encoding used by the CSV file.  | `VARCHAR` | `utf-8` |
 | `filename` | Add path of the containing file to each row, as a string column named `filename`. Relative or absolute paths are returned depending on the path or glob pattern provided to `read_csv`, not just filenames. | `BOOL` | `false` |
-| `force_not_null` | Do not match values in the the specified columns values against the `NULL` string. In the default case where the `NULL` string is empty, this means that empty values are read as zero-length strings instead of `NULL`s. | `VARCHAR[]` | `[]` |
+| `force_not_null` | Do not match values in the the specified columns against the `NULL` string. In the default case where the `NULL` string is empty, this means that empty values are read as zero-length strings instead of `NULL`s. | `VARCHAR[]` | `[]` |
 | `header` | First line of each file contains the column names. | `BOOL` | `false` |
 | `hive_partitioning` | Interpret the path as a [Hive partitioned path]({% link docs/data/partitioning/hive_partitioning.md %}). | `BOOL` | `false` |
 | `ignore_errors` | Ignore any parsing errors encountered. | `BOOL` | `false` |
@@ -110,16 +110,16 @@ Below are parameters that can be passed to the CSV reader. These parameters are 
 | `new_line` | New line character(s). Options are `'\r'`,`'\n'`, or `'\r\n'`. The CSV parser only distinguishes between single-character and double-character line delimiters. Therefore, it does not differentiate between `'\r'` and `'\n'`.| `VARCHAR` | (empty) |
 | `normalize_names` | Normalize column names, removing any non-alphanumeric characters from them. | `BOOL` | `false` |
 | `null_padding` | Pad the remaining columns on the right with `NULL` values when a row lacks columns. | `BOOL` | `false` |
-| `nullstr` or `null` | Specifies a list of strings that represent a `NULL` value. | `VARCHAR` or `VARCHAR[]` | (empty) |
+| `nullstr` or `null` | Strings that represent a `NULL` value. | `VARCHAR` or `VARCHAR[]` | (empty) |
 | `parallel` | Use the parallel CSV reader. | `BOOL` | `true` |
 | `quote` | String used to quote values. | `VARCHAR` | `"` |
-| `rejects_scan` | Name of a temporary table where scan information for faulty CSV files is stored.  | `VARCHAR` | `reject_scans` |
+| `rejects_scan` | Name of a temporary table where information on faulty scans is stored.  | `VARCHAR` | `reject_scans` |
 | `rejects_table` | Name of a temporary table where information on faulty lines is stored.  | `VARCHAR` | `reject_errors` |
-| `rejects_limit` | Upper limit on the number of faulty lines from a CSV file that are recorded in the rejects table. Setting this to `0` means that no limit is applied.  | `BIGINT` | `0` |
+| `rejects_limit` | Upper limit on the number of faulty lines per file that are recorded in the rejects table. Setting this to `0` means that no limit is applied.  | `BIGINT` | `0` |
 | `rfc_4180` | Adhere to the RFC 4180 standard. Setting this to `false` may allow the parser to read structurally incorrect files. | `BOOL` | `false` |
 | `sample_size` | Number of sample rows for [auto detection of parameters]({% link docs/data/csv/auto_detection.md %}). | `BIGINT` | 20480 |
 | `sep` | Delimiter character used to separate columns within each row. Alias for `delim`. | `VARCHAR` | `,` |
-| `skip` | Number of lines to skip at at the top of each file. | `BIGINT` | 0 |
+| `skip` | Number of lines to skip at the start of each file. | `BIGINT` | 0 |
 | `store_rejects` | Skip any lines with errors and store them in the rejects table. | `BOOL` | `false` |
 | `timestampformat` or `timestamp_format` | Date format used when parsing and writing timestamps. See [Date Format]({% link docs/sql/functions/dateformat.md %}). | `VARCHAR` | (empty) |
 | `types` or `dtypes` or `column_types` | Column types, as either a list (by position) or a struct (by name). [Example here]({% link docs/data/csv/tips.md %}#override-the-types-of-specific-columns). | `VARCHAR[]` or `STRUCT` | (empty) |

--- a/docs/data/csv/overview.md
+++ b/docs/data/csv/overview.md
@@ -86,44 +86,44 @@ Below are parameters that can be passed to the CSV reader. These parameters are 
 
 | Name | Description | Type | Default |
 |:--|:-----|:-|:-|
-| `all_varchar` | Option to skip type detection for CSV parsing and assume all columns to be of type `VARCHAR`. This option is only supported by the `read_csv` function. | `BOOL` | `false` |
-| `allow_quoted_nulls` | Option to allow the conversion of quoted values to `NULL` values | `BOOL` | `true` |
-| `auto_detect` | Enables [auto detection of CSV parameters]({% link docs/data/csv/auto_detection.md %}). | `BOOL` | `true` |
-| `auto_type_candidates` | This option allows you to specify the types that the sniffer will use when detecting CSV column types. The `VARCHAR` type is always included in the detected types (as a fallback option). See [example](#auto_type_candidates-details). | `TYPE[]` | [default types](#auto_type_candidates-details) |
-| `buffer_size` | This option allows you to specify the size of the buffers used to read the file. It is important to note that the buffer must be large enough to always accommodate at least four lines of the CSV file. Altering this option can significantly impact performance. | `BIGINT` | [`16 * max_line_size` |
-| `columns` | A struct that specifies the column names and column types contained within the CSV file (e.g., `{'col1': 'INTEGER', 'col2': 'VARCHAR'}`). Using this option implies that auto detection is not used. | `STRUCT` | (empty) |
-| `comment` | The character used to represent a comment in a CSV file. Comment characters can either cause an entire line to be ignored or appear anywhere within a line, causing the parser to ignore the rest of it. | `VARCHAR` | `` |
-| `compression` | The compression type for the file. By default this will be detected automatically from the file extension (e.g., `t.csv.gz` will use gzip, `t.csv` will use `none`). Options are `none`, `gzip`, `zstd`. | `VARCHAR` | `auto` |
-| `dateformat` or `date_format` | Specifies the date format to use when parsing dates. See [Date Format]({% link docs/sql/functions/dateformat.md %}). | `VARCHAR` | (empty) |
-| `decimal_separator` | The decimal separator of numbers. | `VARCHAR` | `.` |
+| `all_varchar` | Skip type detection for CSV parsing and assume all columns to be of type `VARCHAR`. This option is only supported by the `read_csv` function. | `BOOL` | `false` |
+| `allow_quoted_nulls` | Allow the conversion of quoted values to `NULL` values | `BOOL` | `true` |
+| `auto_detect` | [Auto detect CSV parameters]({% link docs/data/csv/auto_detection.md %}). | `BOOL` | `true` |
+| `auto_type_candidates` | Types that the sniffer uses when detecting CSV column types. The `VARCHAR` type is always included in the detected types (as a fallback option). See [example](#auto_type_candidates-details). | `TYPE[]` | [default types](#auto_type_candidates-details) |
+| `buffer_size` | Size of the buffers used to read the file. Must be large enough to always accommodate at least four lines of the CSV file. This option can significantly impact performance. | `BIGINT` | [`16 * max_line_size` |
+| `columns` | Specifies the column names and types contained within the CSV file (e.g., `{'col1': 'INTEGER', 'col2': 'VARCHAR'}`). Using this option implies that auto detection is not used. | `STRUCT` | (empty) |
+| `comment` | Specifies the character used to represent comments in the CSV file. Comment characters can either cause an entire line to be ignored or appear anywhere within a line, causing the parser to ignore the rest of it. | `VARCHAR` | `` |
+| `compression` | Specifies the compression type for the file. By default this is detected automatically from the file extension (e.g., `t.csv.gz` will use gzip, `t.csv` will use `none`). Options are `none`, `gzip`, `zstd`. | `VARCHAR` | `auto` |
+| `dateformat` or `date_format` | Specifies the date format used in the file, which are used when parsing and writing dates. See [Date Format]({% link docs/sql/functions/dateformat.md %}). | `VARCHAR` | (empty) |
+| `decimal_separator` | Specifies the decimal separator for numbers. | `VARCHAR` | `.` |
 | `delimiter` | Specifies the delimiter character that separates columns within each row (line) of the file. Alias for `sep`. This option is only available in the `COPY` statement. | `VARCHAR` | `,` |
 | `delim` | Specifies the delimiter character that separates columns within each row (line) of the file. Alias for `sep`. | `VARCHAR` | `,` |
-| `escape` | Specifies the string that should appear before a data character sequence that matches the `quote` value. | `VARCHAR` | `"` |
+| `escape` | Specifies the string used to escape the `quote` character within quoted values. | `VARCHAR` | `"` |
 | `encoding` | Specifies the encoding used by the CSV file and ensures conversion from the source encoding to `UTF-8`.  | `VARCHAR` | `utf-8` |
-| `filename` | Whether or not an extra `filename` column should be included in the result. Note that a string with the relative path will be returned, not just the filename. | `BOOL` | `false` |
-| `force_not_null` | Do not match the specified columns' values against the `NULL` string. In the default case where the `NULL` string is empty, this means that empty values will be read as zero-length strings rather than `NULL`s. | `VARCHAR[]` | `[]` |
-| `header` | Specifies that the file contains a header line with the names of each column in the file. | `BOOL` | `false` |
-| `hive_partitioning` | Whether or not to interpret the path as a [Hive partitioned path]({% link docs/data/partitioning/hive_partitioning.md %}). | `BOOL` | `false` |
-| `ignore_errors` | Option to ignore any parsing errors encountered – and instead ignore rows with errors. | `BOOL` | `false` |
-| `max_line_size` or `maximum_line_size` | The maximum line size in bytes. | `BIGINT` | 2000000 |
-| `names` or `column_names` | The column names as a list, see [example]({% link docs/data/csv/tips.md %}#provide-names-if-the-file-does-not-contain-a-header). | `VARCHAR[]` | (empty) |
-| `new_line` | Set the new line character(s) in the file. Options are `'\r'`,`'\n'`, or `'\r\n'`. Note that the CSV parser only distinguishes between single-character and double-character line delimiters. Therefore, it does not differentiate between `'\r'` and `'\n'`.| `VARCHAR` | (empty) |
-| `normalize_names` | Boolean value that specifies whether or not column names should be normalized, removing any non-alphanumeric characters from them. | `BOOL` | `false` |
-| `null_padding` | If this option is enabled, when a row lacks columns, it will pad the remaining columns on the right with `NULL` values. | `BOOL` | `false` |
-| `nullstr` or `null` | Specifies the string that represents a `NULL` value or (since v0.10.2) a list of strings that represent a `NULL` value. | `VARCHAR` or `VARCHAR[]` | (empty) |
-| `parallel` | Whether or not the parallel CSV reader is used. | `BOOL` | `true` |
+| `filename` | Add path of the containing CSV file to each row, in a string column named `filename`. Relative or absolute paths are returned depending on the path or glob pattern provided to `read_csv`, not just filenames. | `BOOL` | `false` |
+| `force_not_null` | Do not match values in the the specified columns values against the `NULL` string. In the default case where the `NULL` string is empty, this means that empty values are read as zero-length strings instead of `NULL`s. | `VARCHAR[]` | `[]` |
+| `header` | Specifies whether the file contains a header line with the names of each column. | `BOOL` | `false` |
+| `hive_partitioning` | Interpret the path as a [Hive partitioned path]({% link docs/data/partitioning/hive_partitioning.md %}). | `BOOL` | `false` |
+| `ignore_errors` | Ignore any parsing errors encountered. | `BOOL` | `false` |
+| `max_line_size` or `maximum_line_size` | Maximum line size, in bytes. | `BIGINT` | 2000000 |
+| `names` or `column_names` | Specifies the column names, as a list. See [example]({% link docs/data/csv/tips.md %}#provide-names-if-the-file-does-not-contain-a-header). | `VARCHAR[]` | (empty) |
+| `new_line` | Specifies the new line character(s) in the file. Options are `'\r'`,`'\n'`, or `'\r\n'`. The CSV parser only distinguishes between single-character and double-character line delimiters. Therefore, it does not differentiate between `'\r'` and `'\n'`.| `VARCHAR` | (empty) |
+| `normalize_names` | Normalize column names, removing any non-alphanumeric characters from them. | `BOOL` | `false` |
+| `null_padding` | Pad the remaining columns on the right with `NULL` values when a row lacks columns. | `BOOL` | `false` |
+| `nullstr` or `null` | Specifies a list of strings that represent a `NULL` value. | `VARCHAR` or `VARCHAR[]` | (empty) |
+| `parallel` | Use the parallel CSV reader. | `BOOL` | `true` |
 | `quote` | Specifies the quoting string to be used when a data value is quoted. | `VARCHAR` | `"` |
-| `rejects_scan` | Name of a temporary table where the information of the scan information of faulty CSV file are stored.  | `VARCHAR` | `reject_scans` |
-| `rejects_table` | Name of a temporary table where the information of the faulty lines of a CSV file are stored  | `VARCHAR` | `reject_errors` |
+| `rejects_scan` | Name of a temporary table where scan information for faulty CSV files is stored.  | `VARCHAR` | `reject_scans` |
+| `rejects_table` | Name of a temporary table where information on faulty lines in a CSV file are stored.  | `VARCHAR` | `reject_errors` |
 | `rejects_limit` | Upper limit on the number of faulty records from a CSV file that will be recorded in the rejects table. 0 is used when no limit should be applied.  | `BIGINT` | `0` |
-| `rfc_4180` | Specifies whether the parser should adhere to the RFC 4180 standard. Setting this to `false may` allow the parser to read structurally incorrect files. | `BOOL` | `false` |
-| `sample_size` | The number of sample rows for [auto detection of parameters]({% link docs/data/csv/auto_detection.md %}). | `BIGINT` | 20480 |
+| `rfc_4180` | Adhere to the RFC 4180 standard. Setting this to `false` may allow the parser to read structurally incorrect files. | `BOOL` | `false` |
+| `sample_size` | Number of sample rows for [auto detection of parameters]({% link docs/data/csv/auto_detection.md %}). | `BIGINT` | 20480 |
 | `sep` | Specifies the delimiter character that separates columns within each row (line) of the file. Alias for `delim`. | `VARCHAR` | `,` |
-| `skip` | The number of lines at the top of the file to skip. | `BIGINT` | 0 |
-| `store_rejects` | If set to true, any errors in the file will be skipped and stored in the default rejects temporary tables. | `BOOL` | `false` |
-| `timestampformat` or `timestamp_format` | Specifies the date format to use when parsing timestamps. See [Date Format]({% link docs/sql/functions/dateformat.md %}). | `VARCHAR` | (empty) |
-| `types` or `dtypes` or `column_types` | The column types as either a list (by position) or a struct (by name). [Example here]({% link docs/data/csv/tips.md %}#override-the-types-of-specific-columns). | `VARCHAR[]` or `STRUCT` | (empty) |
-| `union_by_name` | Whether the columns of multiple schemas should be [unified by name]({% link docs/data/multiple_files/combining_schemas.md %}#union-by-name), rather than by position. Note that using this option increases memory consumption. | `BOOL` | `false` |
+| `skip` | Number of lines to skip at at the top of the file. | `BIGINT` | 0 |
+| `store_rejects` | Skip any errors in the file and store them in the rejects temporary table. | `BOOL` | `false` |
+| `timestampformat` or `timestamp_format` | Specifies the date format used in the file, which is used when parsing and wring timestamps. See [Date Format]({% link docs/sql/functions/dateformat.md %}). | `VARCHAR` | (empty) |
+| `types` or `dtypes` or `column_types` | Specifies the column types, as either a list (by position) or a struct (by name). [Example here]({% link docs/data/csv/tips.md %}#override-the-types-of-specific-columns). | `VARCHAR[]` or `STRUCT` | (empty) |
+| `union_by_name` | Unify columns of multiple schemas [by name]({% link docs/data/multiple_files/combining_schemas.md %}#union-by-name) rather than by position. Using this option increases memory consumption. | `BOOL` | `false` |
 
 ### `auto_type_candidates` Details
 

--- a/docs/data/csv/overview.md
+++ b/docs/data/csv/overview.md
@@ -100,7 +100,7 @@ Below are parameters that can be passed to the [`read_csv` function](#csv-functi
 | `delim` | Delimiter character used to separate columns within each line. Alias for `sep`. | `VARCHAR` | `,` |
 | `delimiter` | Alias for `delim`; only available in the `COPY` statement. | `VARCHAR` | `,` |
 | `escape` | String used to escape the `quote` character within quoted values. | `VARCHAR` | `"` |
-| `encoding` | Encoding used by the CSV file. Not available in the `COPY` statement. | `VARCHAR` | `utf-8` |
+| `encoding` | Encoding used by the CSV file. Options are `utf-8`, `utf-16`, `latin-1`. Not available in the `COPY` statement (which always uses `utf-8`). | `VARCHAR` | `utf-8` |
 | `filename` | Add path of the containing file to each row, as a string column named `filename`. Relative or absolute paths are returned depending on the path or glob pattern provided to `read_csv`, not just filenames. | `BOOL` | `false` |
 | `force_not_null` | Do not match values in the the specified columns against the `NULL` string. In the default case where the `NULL` string is empty, this means that empty values are read as zero-length strings instead of `NULL`s. | `VARCHAR[]` | `[]` |
 | `header` | First line of each file contains the column names. | `BOOL` | `false` |

--- a/docs/data/csv/overview.md
+++ b/docs/data/csv/overview.md
@@ -100,7 +100,7 @@ Below are parameters that can be passed to the CSV reader. These parameters are 
 | `delim` | Delimiter character used to separate columns within each row. Alias for `sep`. | `VARCHAR` | `,` |
 | `escape` | String used to escape the `quote` character within quoted values. | `VARCHAR` | `"` |
 | `encoding` | Encoding used by the CSV file.  | `VARCHAR` | `utf-8` |
-| `filename` | Add path of the containing file to each row, in a string column named `filename`. Relative or absolute paths are returned depending on the path or glob pattern provided to `read_csv`, not just filenames. | `BOOL` | `false` |
+| `filename` | Add path of the containing file to each row, as a string column named `filename`. Relative or absolute paths are returned depending on the path or glob pattern provided to `read_csv`, not just filenames. | `BOOL` | `false` |
 | `force_not_null` | Do not match values in the the specified columns values against the `NULL` string. In the default case where the `NULL` string is empty, this means that empty values are read as zero-length strings instead of `NULL`s. | `VARCHAR[]` | `[]` |
 | `header` | First line is a header with the column names. | `BOOL` | `false` |
 | `hive_partitioning` | Interpret the path as a [Hive partitioned path]({% link docs/data/partitioning/hive_partitioning.md %}). | `BOOL` | `false` |

--- a/docs/data/csv/overview.md
+++ b/docs/data/csv/overview.md
@@ -95,10 +95,10 @@ Below are parameters that can be passed to the CSV reader. These parameters are 
 | `comment` | Character used to initiate comments. Lines starting with a comment character (optionally preceded by space characters) are completely ignored; other lines containing a comment character are parsed only up to that point. | `VARCHAR` | `` |
 | `compression` | Method used to compress CSV files. By default this is detected automatically from the file extension (e.g., `t.csv.gz` will use gzip, `t.csv` will use `none`). Options are `none`, `gzip`, `zstd`. | `VARCHAR` | `auto` |
 | `dateformat` | [Date format]({% link docs/sql/functions/dateformat.md %}) used when parsing and writing dates. | `VARCHAR` | (empty) |
-| `date_format` | [Date format]({% link docs/sql/functions/dateformat.md %}) used when parsing and writing dates. This alias is only available in the `COPY` statement. | `VARCHAR` | (empty) |
+| `date_format` | Alias for `dateformat`; only available in the `COPY` statement. | `VARCHAR` | (empty) |
 | `decimal_separator` | Decimal separator for numbers. | `VARCHAR` | `.` |
-| `delimiter` | Delimiter character used to separate columns within each line. Alias for `sep`. This alias is only available in the `COPY` statement. | `VARCHAR` | `,` |
 | `delim` | Delimiter character used to separate columns within each line. Alias for `sep`. | `VARCHAR` | `,` |
+| `delimiter` | Alias for `delim`; only available in the `COPY` statement. | `VARCHAR` | `,` |
 | `escape` | String used to escape the `quote` character within quoted values. | `VARCHAR` | `"` |
 | `encoding` | Encoding used by the CSV file.  | `VARCHAR` | `utf-8` |
 | `filename` | Add path of the containing file to each row, as a string column named `filename`. Relative or absolute paths are returned depending on the path or glob pattern provided to `read_csv`, not just filenames. | `BOOL` | `false` |
@@ -122,7 +122,8 @@ Below are parameters that can be passed to the CSV reader. These parameters are 
 | `sep` | Delimiter character used to separate columns within each line. Alias for `delim`. | `VARCHAR` | `,` |
 | `skip` | Number of lines to skip at the start of each file. | `BIGINT` | 0 |
 | `store_rejects` | Skip any lines with errors and store them in the rejects table. | `BOOL` | `false` |
-| `timestampformat` or `timestamp_format` | [Timestamp format]({% link docs/sql/functions/dateformat.md %}) used when parsing and writing timestamps. | `VARCHAR` | (empty) |
+| `timestampformat` | [Timestamp format]({% link docs/sql/functions/dateformat.md %}) used when parsing and writing timestamps. | `VARCHAR` | (empty) |
+| `timestamp_format` | Alias for `timestampformat`; only available in the `COPY` statement. | `VARCHAR` | (empty) |
 | `types` or `dtypes` or `column_types` | Column types, as either a list (by position) or a struct (by name). See [example]({% link docs/data/csv/tips.md %}#override-the-types-of-specific-columns). | `VARCHAR[]` or `STRUCT` | (empty) |
 | `union_by_name` | Align columns from different files [by column name]({% link docs/data/multiple_files/combining_schemas.md %}#union-by-name) instead of position. Using this option increases memory consumption. | `BOOL` | `false` |
 

--- a/docs/data/csv/overview.md
+++ b/docs/data/csv/overview.md
@@ -92,7 +92,7 @@ Below are parameters that can be passed to the CSV reader. These parameters are 
 | `auto_type_candidates` | Types that the sniffer uses when detecting column types. The `VARCHAR` type is always included as a fallback option. See [example](#auto_type_candidates-details). | `TYPE[]` | [default types](#auto_type_candidates-details) |
 | `buffer_size` | Size of the buffers used to read files. Must be large enough to accommodate at least four lines and can significantly impact performance. | `BIGINT` | [`16 * max_line_size` |
 | `columns` | Column names and types, as a struct (e.g., `{'col1': 'INTEGER', 'col2': 'VARCHAR'}`). Using this option implies that auto detection is not used. | `STRUCT` | (empty) |
-| `comment` | Character used to start comments, either at the start or within a line. | `VARCHAR` | `` |
+| `comment` | Character used to start comments, either at the start of or within a line. | `VARCHAR` | `` |
 | `compression` | Method used to compress the CSV file. By default this is detected automatically from the file extension (e.g., `t.csv.gz` will use gzip, `t.csv` will use `none`). Options are `none`, `gzip`, `zstd`. | `VARCHAR` | `auto` |
 | `dateformat` or `date_format` | Date format used when parsing and writing dates. See [Date Format]({% link docs/sql/functions/dateformat.md %}). | `VARCHAR` | (empty) |
 | `decimal_separator` | Decimal separator for numbers. | `VARCHAR` | `.` |

--- a/docs/data/csv/overview.md
+++ b/docs/data/csv/overview.md
@@ -82,7 +82,7 @@ The DuckDB CSV reader can automatically infer which configuration flags to use b
 
 ## Parameters
 
-Below are parameters that can be passed to the CSV reader. These parameters are accepted by the [`read_csv` function](#csv-functions). But not all parameters are accepted by the [`COPY` statement]({% link docs/sql/statements/copy.md %}#copy-to).
+Below are parameters that can be passed to the [`read_csv` function](#csv-functions). Where meaningfully applicable, these parameters can also be passed to the [`COPY` statement]({% link docs/sql/statements/copy.md %}#copy-to).
 
 | Name | Description | Type | Default |
 |:--|:-----|:-|:-|

--- a/docs/data/csv/overview.md
+++ b/docs/data/csv/overview.md
@@ -94,9 +94,10 @@ Below are parameters that can be passed to the CSV reader. These parameters are 
 | `columns` | Column names and types, as a struct (e.g., `{'col1': 'INTEGER', 'col2': 'VARCHAR'}`). Using this option disables auto detection. | `STRUCT` | (empty) |
 | `comment` | Character used to initiate comments. Lines starting with a comment character (optionally preceded by space characters) are completely ignored; other lines containing a comment character are parsed only up to that point. | `VARCHAR` | `` |
 | `compression` | Method used to compress CSV files. By default this is detected automatically from the file extension (e.g., `t.csv.gz` will use gzip, `t.csv` will use `none`). Options are `none`, `gzip`, `zstd`. | `VARCHAR` | `auto` |
-| `dateformat` or `date_format` | [Date format]({% link docs/sql/functions/dateformat.md %}) used when parsing and writing dates. | `VARCHAR` | (empty) |
+| `dateformat` | [Date format]({% link docs/sql/functions/dateformat.md %}) used when parsing and writing dates. | `VARCHAR` | (empty) |
+| `date_format` | [Date format]({% link docs/sql/functions/dateformat.md %}) used when parsing and writing dates. This alias is only available in the `COPY` statement. | `VARCHAR` | (empty) |
 | `decimal_separator` | Decimal separator for numbers. | `VARCHAR` | `.` |
-| `delimiter` | Delimiter character used to separate columns within each line. Alias for `sep`. This option is only available in the `COPY` statement. | `VARCHAR` | `,` |
+| `delimiter` | Delimiter character used to separate columns within each line. Alias for `sep`. This alias is only available in the `COPY` statement. | `VARCHAR` | `,` |
 | `delim` | Delimiter character used to separate columns within each line. Alias for `sep`. | `VARCHAR` | `,` |
 | `escape` | String used to escape the `quote` character within quoted values. | `VARCHAR` | `"` |
 | `encoding` | Encoding used by the CSV file.  | `VARCHAR` | `utf-8` |


### PR DESCRIPTION
- Remove bloat words "Option to [...]", "Enables [...]", "This option [...]", "This option allows you to specify the [...]", "Specifies the [...]", "Whether or not to [...]", "Set the [...]", "Boolean value that specifies whether or not [...]", "If this option is enabled, [...]", "If set to true, [...]", "It is important to note that [...]"
- Fix and add links to "rejects_scan" and "rejects_table" descriptions
- Fix `filename` description to say that it returns absolute or relative paths depending on the input
- Consistently use `line` to refer to lines of a CSV file, and `row` to refer to records in a DuckDB table
- Mention that `encoding` is not supported by the `COPY` statement
- More precision in `comment` description
- Separate out some aliases that are supported by writer but not reader.
- Downgrade encoding limitation section to `Tip` box, now that DuckDB does support three encodings