### PR TITLE
docs: `winget install` supports arm64 windows

### DIFF
--- a/data/installation-data-1.1.yml
+++ b/data/installation-data-1.1.yml
@@ -2,7 +2,7 @@
   environment: Command line
   platform: Windows
   download_method: Package manager
-  architecture: x86_64
+  architecture: universal
   has_sha_512_hash: 'no'
   installation_code: winget install DuckDB.cli
   note: >-


### PR DESCRIPTION
I don't have arm64 windows machine, but it seems that winget supports arm64 windows.
https://github.com/microsoft/winget-pkgs/blob/bf1b86f08d099af60d0f5ec6c59425b86b87e894/manifests/d/DuckDB/cli/1.1.3/DuckDB.cli.installer.yaml#L22-L27

(Please update #4567 too.)