### PR TITLE
Add documentation for how to use Fastly's S3 compatible "Object Storage" Product

### DIFF
--- a/_data/menu_docs_dev.json
+++ b/_data/menu_docs_dev.json
@@ -1249,6 +1249,10 @@
                 {
                   "page": "DuckDB over HTTPS / S3",
                   "url": "duckdb_over_https_or_s3"
+                },
+                {
+                  "page": "Fastly Object Storage Import",
+                  "url": "fastly_object_storage_import"
                 }
               ]
             },

--- a/docs/guides/network_cloud_storage/fastly_object_storage_import.md
+++ b/docs/guides/network_cloud_storage/fastly_object_storage_import.md
@@ -1,0 +1,42 @@
+---
+layout: docu
+title: Fastly Object Storage Import
+redirect_from:
+  - /docs/guides/import/fastly_object_storage_import
+---
+
+## Prerequisites
+
+For Fastly Object Storage, the [S3 Compatibility API](https://docs.fastly.com/products/object-storage) allows you to use DuckDB's S3 support to read and write from Fastly buckets.
+
+This requires the [`httpfs` extension]({% link docs/extensions/httpfs/overview.md %}), which can be installed using the `INSTALL` SQL command. This only needs to be run once.
+
+## Credentials and Configuration
+
+You will need to [generate an S3 auth token](https://docs.fastly.com/en/guides/working-with-object-storage#creating-an-object-storage-access-key) and create an `S3` secret in DuckDB:
+
+```sql
+CREATE SECRET my_secret (
+    TYPE S3,
+    KEY_ID 'AKIAIOSFODNN7EXAMPLE',
+    SECRET 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+	URL_STYLE 'path',
+    REGION 'us-east',
+    ENDPOINT 'us-east.object.fastlystorage.app' -- see note below
+);
+```
+
+* `ENDPOINT` needs to point to the [Fastly endpoint for the region](https://docs.fastly.com/en/guides/working-with-object-storage#working-with-the-s3-compatible-api) you want to use (e.g `eu-central.object.fastlystorage.app`).
+* `REGION` must use the same region mentioned in `ENDPOINT`.
+* `URL_STYLE` needs to use `path`.
+
+## Querying
+
+After setting up the Fastly Object Storage credentials, you can query the data there using DuckDB's built-in methods, such as `read_csv` or `read_parquet`:
+
+```sql
+SELECT * FROM 's3://⟨fastly_bucket_name⟩/(file).csv';
+SELECT * FROM read_parquet('s3://⟨fastly_bucket_name⟩/⟨file⟩.parquet');
+```
+
+


### PR DESCRIPTION
This is a fairly simple doc PR. It's possible that it falls under the "guides for third-party tools using DuckDB should not be included in the DuckDB documentation." but since you have Cloudflare R2 I thought it might be worth asking. Absolutely no problems if it doesn't meet the criteria.

If it is eligible but you'd like to test it before merging then let me know and I'll set you up test credentials or a test account on Fastly. 