### PR TITLE
ATTACH support for table macros is available in 1.2

### DIFF
--- a/docs/guides/snippets/sharing_macros.md
+++ b/docs/guides/snippets/sharing_macros.md
@@ -54,5 +54,3 @@ SELECT pretty_print_integer(42_123) AS x;
 │ 42k     │
 └─────────┘
 ```
-
-> Warning Currently, sharing table macros via attaching is not supported.


### PR DESCRIPTION
> duckdb test.duckdb

```sql
CREATE MACRO static_table() AS TABLE
    SELECT 'Hello' AS column1, 'World' AS column2;
```

> duckdb

```
attach 'test.duckdb' as test;
select * from test.static_table();
```

The above works as intended.