### PR TITLE
Fix new functions detection query

### DIFF
--- a/community_extensions/documentation.md
+++ b/community_extensions/documentation.md
@@ -49,7 +49,7 @@ The process is roughly as follows:
 CREATE TABLE functions_pre AS SELECT ... FROM duckdb_functions();
 LOAD extension_name;
 CREATE TABLE functions_post AS SELECT ... FROM duckdb_functions();
-SELECT * FROM functions_pre EXCEPT (FROM functions_post) ORDER BY ...;
+SELECT * FROM functions_post EXCEPT (FROM functions_pre) ORDER BY ...;
 ```
 
 This works well for detecting new functions, functions overload, new settings, and new types.


### PR DESCRIPTION
There is a little problem with this query in the [community extensions documentation](https://duckdb.org/community_extensions/documentation)

```sql
SELECT * FROM functions_pre EXCEPT (FROM functions_post) ORDER BY ...;
```

This query does not return new functions because the table names are misspelled. The correct query is:

```sql
SELECT * FROM functions_post EXCEPT (FROM functions_pre) ORDER BY ...;
```


Check https://github.com/duckdb/community-extensions/issues/290