### PR TITLE
Add tip box: output to clipboard via .once |pbcopy

### DIFF
--- a/docs/clients/cli/dot_commands.md
+++ b/docs/clients/cli/dot_commands.md
@@ -136,7 +136,9 @@ The results then open in the default text file editor of the system, for example
 
 <img src="/images/cli_docs_output_to_text_editor.jpg" alt="cli_docs_output_to_text_editor" title="Output to text editor" style="width:293px;"/>
 
-> Tip macOS users can copy the results to their clipboards by using `.once` to output to `pbcopy` via a pipe: `.once |pbcopy` Combinging this with `.headers off` and `.mode lines` can be particularly effective.
+> Tip macOS users can copy the results to their clipboards using [`pbcopy`](https://ss64.com/mac/pbcopy.html) by using `.once` to output to `pbcopy` via a pipe: `.once |pbcopy`
+>
+> Combining this with the `.headers off` and `.mode lines` options can be particularly effective.
 
 ## Querying the Database Schema
 

--- a/docs/clients/cli/dot_commands.md
+++ b/docs/clients/cli/dot_commands.md
@@ -136,6 +136,8 @@ The results then open in the default text file editor of the system, for example
 
 <img src="/images/cli_docs_output_to_text_editor.jpg" alt="cli_docs_output_to_text_editor" title="Output to text editor" style="width:293px;"/>
 
+> Tip macOS users can copy the results to their clipboards by using `.once` to output to `pbcopy` via a pipe: `.once |pbcopy` Combinging this with `.headers off` and `.mode lines` can be particularly effective.
+
 ## Querying the Database Schema
 
 All DuckDB clients support [querying the database schema with SQL]({% link docs/sql/meta/information_schema.md %}), but the CLI has additional [dot commands]({% link docs/clients/cli/dot_commands.md %}) that can make it easier to understand the contents of a database.


### PR DESCRIPTION
Hi there! 

I stumbled across this mega useful method for quickly getting output rows from duckdb  by calling `.once |pbcopy` - means that I can paste into other tools without having to faff around with the mouse selecting text and so on. While I'm pretty sure there's a similar method for Linux, my knowledge is out of date - same for Windows. 

Thought it's worth highlighting for other people as it's one of those small little things that turns out to be awesome for day-to-day work. My use case is testing GeoJSON + WKT outputs on maps and matching.

Thanks
Tom.