### PR TITLE
Document .large_number_rendering CLI option.

### DIFF
--- a/docs/clients/cli/dot_commands.md
+++ b/docs/clients/cli/dot_commands.md
@@ -16,54 +16,55 @@ Dot commands are available in the DuckDB CLI client. To use one of these command
 
 | Command | Description |
 |---|------|
-| `.bail on|off`           | Stop after hitting an error. Default: `off`                                                                                            |
-| `.binary on|off`         | Turn binary output `on` or `off`. Default: `off`                                                                                       |
-| `.cd DIRECTORY`          | Change the working directory to `DIRECTORY`                                                                                            |
-| `.changes on|off`        | Show number of rows changed by SQL                                                                                                     |
-| `.check GLOB`            | Fail if output since `.testcase` does not match                                                                                        |
-| `.columns`               | Column-wise rendering of query results                                                                                                 |
-| `.constant ?COLOR?`      | Sets the syntax highlighting color used for constant values                                                                            |
-| `.constantcode ?CODE?`   | Sets the syntax highlighting terminal code used for constant values                                                                    |
-| `.databases`             | List names and files of attached databases                                                                                             |
-| `.echo on|off`           | Turn command echo `on` or `off`                                                                                                        |
-| `.excel`                 | Display the output of next command in spreadsheet                                                                                      |
-| `.exit ?CODE?`           | Exit this program with return-code `CODE`                                                                                              |
-| `.explain ?on|off|auto?` | Change the `EXPLAIN` formatting mode. Default: `auto`                                                                                  |
-| `.fullschema ?--indent?` | Show schema and the content of `sqlite_stat` tables                                                                                    |
-| `.headers on|off`        | Turn display of headers `on` or `off`                                                                                                  |
-| `.help ?-all? ?PATTERN?` | Show help text for `PATTERN`                                                                                                           |
-| `.highlight [on|off]`    | Toggle syntax highlighting in the shell `on` / `off`                                                                                   |
-| `.import FILE TABLE`     | Import data from `FILE` into `TABLE`                                                                                                   |
-| `.indexes ?TABLE?`       | Show names of indexes                                                                                                                  |
-| `.keyword ?COLOR?`       | Sets the syntax highlighting color used for keywords                                                                                   |
-| `.keywordcode ?CODE?`    | Sets the syntax highlighting terminal code used for keywords                                                                           |
-| `.lint OPTIONS`          | Report potential schema issues.                                                                                                        |
-| `.log FILE|off`          | Turn logging `on` or `off`. `FILE` can be `stderr` / `stdout`                                                                          |
-| `.maxrows COUNT`         | Sets the maximum number of rows for display. Only for [duckbox mode]({% link docs/clients/cli/output_formats.md %})                        |
-| `.maxwidth COUNT`        | Sets the maximum width in characters. 0 defaults to terminal width. Only for [duckbox mode]({% link docs/clients/cli/output_formats.md %}) |
-| `.mode MODE ?TABLE?`     | Set [output mode]({% link docs/clients/cli/output_formats.md %})                                                                           |
-| `.multiline`             | Set multi-line mode (default)                                                                                                          |
-| `.nullvalue STRING`      | Use `STRING` in place of `NULL` values                                                                                                 |
-| `.once ?OPTIONS? ?FILE?` | Output for the next SQL command only to `FILE`                                                                                         |
-| `.open ?OPTIONS? ?FILE?` | Close existing database and reopen `FILE`                                                                                              |
-| `.output ?FILE?`         | Send output to `FILE` or `stdout` if `FILE` is omitted                                                                                 |
-| `.parameter CMD ...`     | Manage SQL parameter bindings                                                                                                          |
-| `.print STRING...`       | Print literal `STRING`                                                                                                                 |
-| `.prompt MAIN CONTINUE`  | Replace the standard prompts                                                                                                           |
-| `.quit`                  | Exit this program                                                                                                                      |
-| `.read FILE`             | Read input from `FILE`                                                                                                                 |
-| `.rows`                  | Row-wise rendering of query results (default)                                                                                          |
-| `.schema ?PATTERN?`      | Show the `CREATE` statements matching `PATTERN`                                                                                        |
-| `.separator COL ?ROW?`   | Change the column and row separators                                                                                                   |
-| `.sha3sum ...`           | Compute a SHA3 hash of database content                                                                                                |
-| `.shell CMD ARGS...`     | Run `CMD ARGS...` in a system shell                                                                                                    |
-| `.show`                  | Show the current values for various settings                                                                                           |
-| `.singleline`            | Set single-line mode                                                                                                                   |
-| `.system CMD ARGS...`    | Run `CMD ARGS...` in a system shell                                                                                                    |
-| `.tables ?TABLE?`        | List names of tables [matching LIKE pattern]({% link docs/sql/functions/pattern_matching.md %}) `TABLE`                                |
-| `.testcase NAME`         | Begin redirecting output to `NAME`                                                                                                     |
-| `.timer on|off`          | Turn SQL timer `on` or `off`. SQL statements separated by `;` but *not* separated via newline are measured together.                   |
-| `.width NUM1 NUM2 ...`   | Set minimum column widths for columnar output                                                                                          |
+| `.bail on|off`                           | Stop after hitting an error. Default: `off`                                                                                            |
+| `.binary on|off`                         | Turn binary output `on` or `off`. Default: `off`                                                                                       |
+| `.cd DIRECTORY`                          | Change the working directory to `DIRECTORY`                                                                                            |
+| `.changes on|off`                        | Show number of rows changed by SQL                                                                                                     |
+| `.check GLOB`                            | Fail if output since `.testcase` does not match                                                                                        |
+| `.columns`                               | Column-wise rendering of query results                                                                                                 |
+| `.constant ?COLOR?`                      | Sets the syntax highlighting color used for constant values                                                                            |
+| `.constantcode ?CODE?`                   | Sets the syntax highlighting terminal code used for constant values                                                                    |
+| `.databases`                             | List names and files of attached databases                                                                                             |
+| `.echo on|off`                           | Turn command echo `on` or `off`                                                                                                        |
+| `.excel`                                 | Display the output of next command in spreadsheet                                                                                      |
+| `.exit ?CODE?`                           | Exit this program with return-code `CODE`                                                                                              |
+| `.explain ?on|off|auto?`                 | Change the `EXPLAIN` formatting mode. Default: `auto`                                                                                  |
+| `.fullschema ?--indent?`                 | Show schema and the content of `sqlite_stat` tables                                                                                    |
+| `.headers on|off`                        | Turn display of headers `on` or `off`                                                                                                  |
+| `.help ?-all? ?PATTERN?`                 | Show help text for `PATTERN`                                                                                                           |
+| `.highlight [on|off]`                    | Toggle syntax highlighting in the shell `on` / `off`                                                                                   |
+| `.import FILE TABLE`                     | Import data from `FILE` into `TABLE`                                                                                                   |
+| `.indexes ?TABLE?`                       | Show names of indexes                                                                                                                  |
+| `.keyword ?COLOR?`                       | Sets the syntax highlighting color used for keywords                                                                                   |
+| `.keywordcode ?CODE?`                    | Sets the syntax highlighting terminal code used for keywords                                                                           |
+| `.large_number_rendering all|footer|off` | Toggle readable rendering of large numbers (duckbox only)                                                                              |
+| `.lint OPTIONS`                          | Report potential schema issues.                                                                                                        |
+| `.log FILE|off`                          | Turn logging `on` or `off`. `FILE` can be `stderr` / `stdout`                                                                          |
+| `.maxrows COUNT`                         | Sets the maximum number of rows for display. Only for [duckbox mode]({% link docs/clients/cli/output_formats.md %})                        |
+| `.maxwidth COUNT`                        | Sets the maximum width in characters. 0 defaults to terminal width. Only for [duckbox mode]({% link docs/clients/cli/output_formats.md %}) |
+| `.mode MODE ?TABLE?`                     | Set [output mode]({% link docs/clients/cli/output_formats.md %})                                                                           |
+| `.multiline`                             | Set multi-line mode (default)                                                                                                          |
+| `.nullvalue STRING`                      | Use `STRING` in place of `NULL` values                                                                                                 |
+| `.once ?OPTIONS? ?FILE?`                 | Output for the next SQL command only to `FILE`                                                                                         |
+| `.open ?OPTIONS? ?FILE?`                 | Close existing database and reopen `FILE`                                                                                              |
+| `.output ?FILE?`                         | Send output to `FILE` or `stdout` if `FILE` is omitted                                                                                 |
+| `.parameter CMD ...`                     | Manage SQL parameter bindings                                                                                                          |
+| `.print STRING...`                       | Print literal `STRING`                                                                                                                 |
+| `.prompt MAIN CONTINUE`                  | Replace the standard prompts                                                                                                           |
+| `.quit`                                  | Exit this program                                                                                                                      |
+| `.read FILE`                             | Read input from `FILE`                                                                                                                 |
+| `.rows`                                  | Row-wise rendering of query results (default)                                                                                          |
+| `.schema ?PATTERN?`                      | Show the `CREATE` statements matching `PATTERN`                                                                                        |
+| `.separator COL ?ROW?`                   | Change the column and row separators                                                                                                   |
+| `.sha3sum ...`                           | Compute a SHA3 hash of database content                                                                                                |
+| `.shell CMD ARGS...`                     | Run `CMD ARGS...` in a system shell                                                                                                    |
+| `.show`                                  | Show the current values for various settings                                                                                           |
+| `.singleline`                            | Set single-line mode                                                                                                                   |
+| `.system CMD ARGS...`                    | Run `CMD ARGS...` in a system shell                                                                                                    |
+| `.tables ?TABLE?`                        | List names of tables [matching LIKE pattern]({% link docs/sql/functions/pattern_matching.md %}) `TABLE`                                |
+| `.testcase NAME`                         | Begin redirecting output to `NAME`                                                                                                     |
+| `.timer on|off`                          | Turn SQL timer `on` or `off`. SQL statements separated by `;` but *not* separated via newline are measured together.                   |
+| `.width NUM1 NUM2 ...`                   | Set minimum column widths for columnar output                                                                                          |
 
 ## Using the `.help` Command
 


### PR DESCRIPTION
Documents `.larger_number_rendering` CLI option introduced in 1.2 https://github.com/duckdb/duckdb/pull/15031.

I found this option super helpful and thought others might discover it better in the web docs. I took the documentation string as-is from the duckdb repository here: https://github.com/duckdb/duckdb/blob/28c95be6a97f57fedb0746b8a79cfebc5b4fd10a/tools/shell/shell.cpp#L2205. Please let me know if any changes are needed.

NOTE: sorry about the force pushes, I noticed some issues I had in the formatting/spacing of pipes, and the ordering of items.