### PR TITLE
Julia: Link to API docs generated on JuliaHub

### DIFF
--- a/docs/archive/1.0/api/julia.md
+++ b/docs/archive/1.0/api/julia.md
@@ -7,6 +7,8 @@ The DuckDB Julia package provides a high-performance front-end for DuckDB. Much 
 
 The package also supports multi-threaded execution. It uses Julia threads/tasks for this purpose. If you wish to run queries in parallel, you must launch Julia with multi-threading support (by e.g., setting the `JULIA_NUM_THREADS` environment variable).
 
+In addition to the examples below, you can find [the full API documentation for DuckDB.jl as generated from docstrings on JuliaHub](https://docs.juliahub.com/General/DuckDB/stable/).
+
 ## Installation
 
 Install DuckDB as follows:

--- a/docs/archive/1.0/api/julia.md
+++ b/docs/archive/1.0/api/julia.md
@@ -3,7 +3,7 @@ layout: docu
 title: Julia Package
 ---
 
-The DuckDB Julia package provides a high-performance front-end for DuckDB. Much like SQLite, DuckDB runs in-process within the Julia client, and provides a DBInterface front-end.
+The DuckDB Julia package provides a high-performance front-end for DuckDB. Much like SQLite, DuckDB runs in-process within the Julia client, and provides a `DBInterface.jl` front-end.
 
 The package also supports multi-threaded execution. It uses Julia threads/tasks for this purpose. If you wish to run queries in parallel, you must launch Julia with multi-threading support (by e.g., setting the `JULIA_NUM_THREADS` environment variable).
 


### PR DESCRIPTION
Currently the documentation for the Julia connectors is a bit limited, but there are quite good docstrings. These are available from within Julia's help system, but also build into online docs automatically on JuliaHub This PR adds a link.