### PR TITLE
Added file loading chapter on relative paths to import overview

### DIFF
--- a/docs/data/overview.md
+++ b/docs/data/overview.md
@@ -17,6 +17,11 @@ INSERT INTO people VALUES (1, 'Mark');
 
 For a more detailed description, see the [page on the `INSERT statement`]({% link docs/data/insert.md %}).
 
+## File Loading: Relative Paths
+
+Use the configuration option [`file_search_path`]({% link docs/configuration/overview.html %}#local-configuration-options) to configure to which "root directories" relative paths are expanded.   
+If `file_search_path` is not set, the working directory is used as root directory for relative paths. In CLI, use `.shell echo $(pwd)` to double check the working directory location.
+
 ## CSV Loading
 
 Data can be efficiently loaded from CSV files using several methods. The simplest is to use the CSV file's name:

--- a/docs/data/overview.md
+++ b/docs/data/overview.md
@@ -19,7 +19,7 @@ For a more detailed description, see the [page on the `INSERT statement`]({% lin
 
 ## File Loading: Relative Paths
 
-Use the configuration option [`file_search_path`]({% link docs/configuration/overview.html %}#local-configuration-options) to configure to which "root directories" relative paths are expanded.   
+Use the configuration option [`file_search_path`]({% link docs/configuration/overview.md %}#local-configuration-options) to configure to which "root directories" relative paths are expanded.   
 If `file_search_path` is not set, the working directory is used as root directory for relative paths. In CLI, use `.shell echo $(pwd)` to double check the working directory location.
 
 ## CSV Loading


### PR DESCRIPTION
Before this modification, it was hard to find out how relative paths are expanded in duckdb.

The configuration setting `file_search_path` is a "god sent" when globbing files from a directory tree and needing to reference/harmonize the root of this tree over team members and CD/CI. The added chapter should help others to find this valuable setting more easily than me :).