### PR TITLE
`sql_path` in `information_schema.schemata` applies to a feature not available in DuckDB

### DIFF
--- a/docs/0.10/sql/information_schema.md
+++ b/docs/0.10/sql/information_schema.md
@@ -20,7 +20,7 @@ The top level catalog view is `information_schema.schemata`. It lists the catalo
 | `default_character_set_catalog` | Applies to a feature not available in DuckDB. | `VARCHAR` | `NULL` |
 | `default_character_set_schema` | Applies to a feature not available in DuckDB. | `VARCHAR` | `NULL` |
 | `default_character_set_name` | Applies to a feature not available in DuckDB. | `VARCHAR` | `NULL` |
-| `sql_path` | The file system location of the database. Currently unimplemented. | `VARCHAR` | `NULL` |
+| `sql_path` | Applies to a feature not available in DuckDB. | `VARCHAR` | `NULL` |
 
 ### `information_schema.tables`: Tables and Views
 

--- a/docs/0.8/sql/information_schema.md
+++ b/docs/0.8/sql/information_schema.md
@@ -19,7 +19,7 @@ The top level catalog view is `information_schema.schemata`. It lists the catalo
 | `default_character_set_catalog` |Applies to a feature not available in DuckDB. | `VARCHAR` | `NULL` |
 | `default_character_set_schema` |Applies to a feature not available in DuckDB. | `VARCHAR` | `NULL` |
 | `default_character_set_name` |Applies to a feature not available in DuckDB. | `VARCHAR` | `NULL` |
-| `sql_path` |The file system location of the database. Currently unimplemented. | `VARCHAR` | `NULL` |
+| `sql_path` |Applies to a feature not available in DuckDB. | `VARCHAR` | `NULL` |
 
 ## Tables and Views
 The view that describes the catalog information for tables and views is `information_schema.tables`. It lists the tables present in the database and has the following layout:

--- a/docs/0.9/sql/information_schema.md
+++ b/docs/0.9/sql/information_schema.md
@@ -21,7 +21,7 @@ The top level catalog view is `information_schema.schemata`. It lists the catalo
 | `default_character_set_catalog` |Applies to a feature not available in DuckDB. | `VARCHAR` | `NULL` |
 | `default_character_set_schema` |Applies to a feature not available in DuckDB. | `VARCHAR` | `NULL` |
 | `default_character_set_name` |Applies to a feature not available in DuckDB. | `VARCHAR` | `NULL` |
-| `sql_path` |The file system location of the database. Currently unimplemented. | `VARCHAR` | `NULL` |
+| `sql_path` |Applies to a feature not available in DuckDB. | `VARCHAR` | `NULL` |
 
 ## Tables and Views
 

--- a/docs/1.0/sql/meta/information_schema.md
+++ b/docs/1.0/sql/meta/information_schema.md
@@ -83,7 +83,7 @@ The top level catalog view is `information_schema.schemata`. It lists the catalo
 | `default_character_set_catalog` | Applies to a feature not available in DuckDB. | `VARCHAR` | `NULL` |
 | `default_character_set_schema` | Applies to a feature not available in DuckDB. | `VARCHAR` | `NULL` |
 | `default_character_set_name` | Applies to a feature not available in DuckDB. | `VARCHAR` | `NULL` |
-| `sql_path` | The file system location of the database. Currently unimplemented. | `VARCHAR` | `NULL` |
+| `sql_path` | Applies to a feature not available in DuckDB. | `VARCHAR` | `NULL` |
 
 ### `tables`: Tables and Views
 

--- a/docs/1.1/sql/meta/information_schema.md
+++ b/docs/1.1/sql/meta/information_schema.md
@@ -97,7 +97,7 @@ The top level catalog view is `information_schema.schemata`. It lists the catalo
 | `default_character_set_catalog` | Applies to a feature not available in DuckDB. | `VARCHAR` | `NULL` |
 | `default_character_set_schema` | Applies to a feature not available in DuckDB. | `VARCHAR` | `NULL` |
 | `default_character_set_name` | Applies to a feature not available in DuckDB. | `VARCHAR` | `NULL` |
-| `sql_path` | The file system location of the database. Currently unimplemented. | `VARCHAR` | `NULL` |
+| `sql_path` | Applies to a feature not available in DuckDB. | `VARCHAR` | `NULL` |
 
 ### `tables`: Tables and Views
 

--- a/docs/stable/sql/meta/information_schema.md
+++ b/docs/stable/sql/meta/information_schema.md
@@ -99,7 +99,7 @@ The top level catalog view is `information_schema.schemata`. It lists the catalo
 | `default_character_set_catalog` | Applies to a feature not available in DuckDB. | `VARCHAR` | `NULL` |
 | `default_character_set_schema` | Applies to a feature not available in DuckDB. | `VARCHAR` | `NULL` |
 | `default_character_set_name` | Applies to a feature not available in DuckDB. | `VARCHAR` | `NULL` |
-| `sql_path` | The file system location of the database. Currently unimplemented. | `VARCHAR` | `NULL` |
+| `sql_path` | Applies to a feature not available in DuckDB. | `VARCHAR` | `NULL` |
 
 ### `tables`: Tables and Views
 


### PR DESCRIPTION
This came up here - https://github.com/duckdb/duckdb/pull/16419

I'm not entirely sure what this field should contain, but I would say it's not the file system location of the database at least. Postgres says `Applies to a feature not available in PostgreSQL` so safe to mirror that.