### PR TITLE
Add cross-compilation instructions for DuckDB on RISC-V platforms

### DIFF
--- a/docs/stable/dev/building/unofficial_and_unsupported_platforms.md
+++ b/docs/stable/dev/building/unofficial_and_unsupported_platforms.md
@@ -39,3 +39,15 @@ GEN=ninja \
     CORE_EXTENSIONS='fts' \
     make
 ```
+
+For those who do not have a RISC-V chip development environment, you can cross-compile DuckDB using latest [g++-riscv64-linux-gnu](https://github.com/riscv-collab/riscv-gnu-toolchain) :
+
+```bash
+GEN=ninja \
+    CC='riscv64-linux-gnu-gcc -march=rv64gcv_zicsr_zifencei_zihintpause_zvl256b' \
+    CXX='riscv64-linux-gnu-g++ -march=rv64gcv_zicsr_zifencei_zihintpause_zvl256b' \
+    make
+```
+
+For more reference information on DuckDB RISC-V cross-compiling, see the [mocusez/duckdb-riscv-ci](https://github.com/mocusez/duckdb-riscv-ci) and [DuckDB Pull Request #16549](https://github.com/duckdb/duckdb/pull/16549)
+


### PR DESCRIPTION
Hi, 
Based on https://github.com/duckdb/duckdb/pull/16549, it is feasible to cross-compile DuckDB to RISC-V. 
I would like to add something details to the documentation 
that may be helpful for developers who want to run DuckDB in a RISC-V environment. 
Looking forward to your feedback😉