### PR TITLE
Iceberg extension: Remove allow_moved_paths argument from S3 example

### DIFF
--- a/docs/stable/extensions/iceberg/overview.md
+++ b/docs/stable/extensions/iceberg/overview.md
@@ -70,10 +70,7 @@ The `iceberg` works together with the [`httpfs` extension]({% link docs/stable/e
 
 ```sql
 SELECT count(*)
-FROM iceberg_scan(
-    's3://bucketname/lineitem_iceberg/metadata/v1.metadata.json',
-    allow_moved_paths = true
-);
+FROM iceberg_scan('s3://bucketname/lineitem_iceberg/metadata/v1.metadata.json');
 ```
 
 ### Access Iceberg Metadata


### PR DESCRIPTION
Running the example as is results in an `Invalid Input Error: Enabling allow_moved_paths is not enabled for directly scanning metadata files.`

Omitting the argument, as the error suggests, makes the example work.