### PR TITLE
Correct table name in query in "DuckDB Tricks - Part 2".

### DIFF
--- a/_posts/2024-10-11-duckdb-tricks-part-2.md
+++ b/_posts/2024-10-11-duckdb-tricks-part-2.md
@@ -187,7 +187,7 @@ CREATE OR REPLACE TABLE schedule AS
     )
     SELECT timeslot, location, coalesce(event, '<empty>') AS event
     FROM timeslot_location_combinations
-    LEFT JOIN schedule_cleaned
+    LEFT JOIN schedule
         USING (timeslot, location)
     ORDER BY ALL;
 


### PR DESCRIPTION
In section "Repeated Data Transformation Steps" in DuckDB Blog entry "DuckDB Tricks - Part 2", replace table name "schedule_cleaned" with "schedule".