### PR TITLE
`duckdb.default_connection` changed from attribute to function in duckdb 1.2

### DIFF
--- a/docs/stable/clients/python/dbapi.md
+++ b/docs/stable/clients/python/dbapi.md
@@ -51,7 +51,7 @@ duckdb.execute("CREATE TABLE tbl AS SELECT 42 a")
 con = duckdb.connect(":default:")
 con.sql("SELECT * FROM tbl")
 # or
-duckdb.default_connection.sql("SELECT * FROM tbl")
+duckdb.default_connection().sql("SELECT * FROM tbl")
 ```
 
 ```text


### PR DESCRIPTION
`duckdb.default_connection` was changed from attribute to function in duckdb 1.2.