### PR TITLE
Fix avro current situation

### DIFF
--- a/_posts/2024-12-09-duckdb-avro-extension.md
+++ b/_posts/2024-12-09-duckdb-avro-extension.md
@@ -56,7 +56,9 @@ INSTALL avro FROM community;
 LOAD avro;
 ```
 
-in a DuckDB instance near you. There is currently no build for Wasm because of dependencies (sigh).
+in a DuckDB instance near you.
+
+> Since DuckDB v1.2.1, also Wasm is supported.
 
 ### The `read_avro` Function
 
@@ -116,7 +118,7 @@ In the following, we disclose the limitations of the `avro` DuckDB extension alo
 
 * There is currently no support for projection or filter **pushdown**, but this is also planned at a later stage.
 
-* There is currently no support for the Wasm or the Windows-MinGW builds of DuckDB due to issues with the Avro library dependency (sigh again). We plan to fix this eventually.
+* There is currently no support for ~~the Wasm or~~ the Windows-MinGW builds of DuckDB due to issues with the Avro library dependency (sigh again). We plan to fix this eventually.
 
 * As mentioned above, DuckDB cannot express recursive type definitions that Avro has. This is unlikely to ever change.
 

--- a/_posts/2024-12-09-duckdb-avro-extension.md
+++ b/_posts/2024-12-09-duckdb-avro-extension.md
@@ -58,7 +58,7 @@ LOAD avro;
 
 in a DuckDB instance near you.
 
-> Since DuckDB v1.2.1, also Wasm is supported.
+> Since DuckDB v1.2.1, DuckDB's WebAssembly client is also supported.
 
 ### The `read_avro` Function
 

--- a/docs/stable/extensions/avro.md
+++ b/docs/stable/extensions/avro.md
@@ -1,8 +1,6 @@
 ---
 github_repository: https://github.com/duckdb/duckdb-avro
 layout: docu
-redirect_from:
-- /community_extensions/extensions/avro
 title: Avro Extension
 ---
 


### PR DESCRIPTION
Two changes:

1. Mention avro is supported in Wasm

2. Keep avro as a community extension (no redirect)
I think documentation for community extensions should stay there, without the redirect, but with some clear text saying the extensions will be moved (starting v1.2.2) to `core` extension repository AND will be auto-loadable.

Currently extension is available but not autoloadable, I think it make more sense to say:
* `<= 1.2.1`, it's a community extension
* `>= 1.2.2`, it's a core extension AND autoloadable

That trying to explain the current mix.