### PR TITLE
Docs - Add migration guide from deprecated load_aws_credentials

### DIFF
--- a/docs/1.1/extensions/httpfs/s3api.md
+++ b/docs/1.1/extensions/httpfs/s3api.md
@@ -24,6 +24,8 @@ The preferred way to configure and authenticate to S3 endpoints is to use [secre
 
 > Deprecated Prior to version 0.10.0, DuckDB did not have a [Secrets manager]({% link docs/1.1/sql/statements/create_secret.md %}). Hence, the configuration of and authentication to S3 endpoints was handled via variables. See the [legacy authentication scheme for the S3 API]({% link docs/1.1/extensions/httpfs/s3api_legacy_authentication.md %}).
 
+To migrate from previous, use a defined secret with a profile. See the [below CREDENTIAL_CHAIN section](#loading-a-secret-based-on-a-profile)
+
 ### `CONFIG` Provider
 
 The default provider, `CONFIG` (i.e., user-configured), allows access to the S3 bucket by manually providing a key. For example:
@@ -89,6 +91,21 @@ CREATE SECRET secret4 (
 );
 ```
 
+#### Loading a Secret based on a profile
+
+> Equivalent of deprecated `load_aws_credentials('my-profile')`, 
+
+To load credentials based on a profile which is not defined as a default from AWS_PROFILE environment variable or as a default profile based on AWS SDK precedence, run: 
+
+```sql
+CREATE SECRET secret4 (
+    TYPE S3,
+    PROVIDER CREDENTIAL_CHAIN,
+    CHAIN 'config',
+    PROFILE 'my-profile'
+);
+```
+
 ### Overview of S3 Secret Parameters
 
 Below is a complete list of the supported parameters that can be used for both the `CONFIG` and `CREDENTIAL_CHAIN` providers:
@@ -97,6 +114,7 @@ Below is a complete list of the supported parameters that can be used for both t
 |:------------------------------|:--------------------------------------------------------------------------------------|:------------------|:----------|:--------------------------------------------|
 | `KEY_ID`                      | The ID of the key to use                                                              | `S3`, `GCS`, `R2` | `STRING`  | -                                           |
 | `SECRET`                      | The secret of the key to use                                                          | `S3`, `GCS`, `R2` | `STRING`  | -                                           |
+| `PROFILE`                     | The profile for which to authenticate                                                 | `S3`              | `STRING`  | -                                           |
 | `REGION`                      | The region for which to authenticate (should match the region of the bucket to query) | `S3`, `GCS`, `R2` | `STRING`  | `us-east-1`                                 |
 | `SESSION_TOKEN`               | Optionally, a session token can be passed to use temporary credentials                | `S3`, `GCS`, `R2` | `STRING`  | -                                           |
 | `ENDPOINT`                    | Specify a custom S3 endpoint                                                          | `S3`, `GCS`, `R2` | `STRING`  | `s3.amazonaws.com` for `S3`,                |

--- a/docs/1.1/extensions/httpfs/s3api.md
+++ b/docs/1.1/extensions/httpfs/s3api.md
@@ -93,7 +93,7 @@ CREATE SECRET secret4 (
 
 #### Loading a Secret based on a profile
 
-> Equivalent of deprecated `load_aws_credentials('my-profile')`, 
+> Tip Equivalent of deprecated `load_aws_credentials('my-profile')`
 
 To load credentials based on a profile which is not defined as a default from AWS_PROFILE environment variable or as a default profile based on AWS SDK precedence, run: 
 


### PR DESCRIPTION
Hi maintainers 👋

I'm submitting this PR because I encountered difficulties migrating from the `load_aws_credentials` function to the Secrets Manager.

The equivalent of this command:
```plsql
CALL load_aws_credentials('my-profile');
```
was not clearly explained in the S3 Secrets Manager documentation, which caused some confusion.

The main challenge was understanding how to declare a secret when the Config setup is declaring any default profile or using Environment variables `AWS_PROFILE` or `AWS_DEFAULT_PROFILE`, as the `PROFILE` parameter for S3 secrets was not listed in the Markdown table os S3 Secrets parameters.

After extensive reading and reviewing the [CPP HTML documentation](https://sdk.amazonaws.com/cpp/api/LATEST/aws-cpp-sdk-core/html/namespace_aws_1_1_auth.html#a4fd54f71cf97413fc9248f7bed423969), I realized that the following was sufficient:

```plsql
CREATE SECRET secret4 (
    TYPE S3,
    PROVIDER CREDENTIAL_CHAIN,
    CHAIN 'config',
    PROFILE 'my-profile'
);
```

I hope this documentation suggestion will help users with AWS profiles set up for the load_aws_credentials transition to the Secrets Manager more easily. Please feel free to provide feedback on this suggestion.