### PR TITLE
[community-extensions] Avoid overriding extension list

### DIFF
--- a/.github/workflows/community_extension_docs.yml
+++ b/.github/workflows/community_extension_docs.yml
@@ -28,7 +28,7 @@ jobs:
       run: |
             unzip generated_md.zip
             cp build/docs/*.md community_extensions/extensions/.
-            cp build/docs/extensions_list.md.tmp _includes/list_of_community_extensions.md
+            # TODO: re-enable this line cp build/docs/extensions_list.md.tmp _includes/list_of_community_extensions.md
             rm -r generated_md.zip
             rm -rf build
 


### PR DESCRIPTION
See comment here: https://github.com/duckdb/duckdb-web/pull/5206#issuecomment-2788265968

This makes so extension documentations are updated, but list is not (yet)
This is a bit of a hack, and need reverting, but this might work OK for now, allowing new extensions still to have their page.