### PR TITLE
Add llms.txt and llms-full.txt for /docs/stable

### DIFF
--- a/.github/workflows/build-stable-documentation.yml
+++ b/.github/workflows/build-stable-documentation.yml
@@ -16,6 +16,8 @@ jobs:
           ruby-version: '3.3' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
+      - name: Generate llms.txt files
+        run: python scripts/generate_llms_txt.py
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -49,6 +49,8 @@ jobs:
         uses: montudor/action-zip@v1
       - name: Fetch release calendar
         run: python scripts/get_calendar.py
+      - name: Generate llms.txt files
+        run: python scripts/generate_llms_txt.py
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ ripgrepy
 marko # for generating search index
 python-frontmatter
 icalendar
+python-frontmatter # for parsing frontmatter markdown

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,3 @@ ripgrepy
 marko # for generating search index
 python-frontmatter
 icalendar
-python-frontmatter # for parsing frontmatter markdown

--- a/scripts/generate_llms_txt.py
+++ b/scripts/generate_llms_txt.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+
+import os
+import frontmatter
+from pathlib import Path
+
+def generate_docs_llms_files():
+    """Generate llms.txt and llms-full.txt for the docs/stable directory"""
+    # Path to the docs/stable directory
+    docs_dir = Path('docs/stable')
+    
+    # Initialize content for both files
+    llms_content = []
+    llms_full_content = []
+    
+    # GitHub repository information
+    github_repo = "duckdb/duckdb-web"
+    github_branch = "main"
+    
+    # Group files by directory
+    file_groups = {}
+    
+    # Walk through all markdown files in docs/stable
+    for root, _, files in os.walk(docs_dir):
+        for file in files:
+            if not file.endswith('.md'):
+                continue
+                
+            file_path = Path(root) / file
+            relative_path = file_path.relative_to(docs_dir)
+            
+            # Get the directory name for grouping
+            dir_name = str(relative_path.parent)
+            if dir_name == '.':
+                dir_name = 'root'
+            
+            # Read and parse the markdown file
+            with open(file_path, 'r') as f:
+                doc = frontmatter.load(f)
+                
+            # Get the title and content
+            title = doc.get('title', '')
+            content = doc.content.strip()
+            
+            # Create URLs
+            raw_url = f"https://raw.githubusercontent.com/{github_repo}/{github_branch}/docs/stable/{relative_path}"
+            
+            # For website URL, remove the .md extension
+            website_path = str(relative_path)
+            if website_path.endswith('.md'):
+                website_path = website_path[:-3]
+            website_url = f"https://duckdb.org/docs/stable/{website_path}"
+            
+            # Add to file groups
+            if dir_name not in file_groups:
+                file_groups[dir_name] = []
+            
+            file_groups[dir_name].append({
+                'title': title,
+                'raw_url': raw_url,
+                'website_url': website_url,
+                'content': content
+            })
+            
+            # Add to llms-full.txt (titles, links, and content)
+            llms_full_content.append(f"# {title}\n")
+            llms_full_content.append(f"Source: {raw_url}\n")
+            llms_full_content.append(f"Website: {website_url}\n")
+            llms_full_content.append("---\n")
+            llms_full_content.append(content)
+            llms_full_content.append("\n\n")
+    
+    # Generate llms.txt content with grouped structure
+    for dir_name, files in sorted(file_groups.items()):
+        # Format directory name for display
+        if dir_name == 'root':
+            section_title = "Documentation"
+        else:
+            section_title = dir_name.replace('/', ' ').title()
+        
+        llms_content.append(f"## {section_title}\n")
+        
+        for file_info in sorted(files, key=lambda x: x['title']):
+            llms_content.append(f"- {file_info['title']}:")
+            llms_content.append(f"  - [Website]({file_info['website_url']})")
+            llms_content.append(f"  - [Markdown]({file_info['raw_url']})")
+        
+        llms_content.append("")
+    
+    # Write llms.txt
+    with open(docs_dir / 'llms.txt', 'w') as f:
+        f.write("# DuckDB Documentation\n\n")
+        f.write("> Comprehensive documentation for DuckDB, an in-process analytical database management system.\n\n")
+        f.write('\n'.join(llms_content))
+    
+    # Write llms-full.txt
+    with open(docs_dir / 'llms-full.txt', 'w') as f:
+        f.write("# DuckDB Full Documentation\n\n")
+        f.write('\n'.join(llms_full_content))
+
+def main():
+    # Generate the docs-specific llms.txt and llms-full.txt files
+    generate_docs_llms_files()
+    
+    print("Generated docs/stable/llms.txt and docs/stable/llms-full.txt successfully!")
+
+if __name__ == '__main__':
+    main() 

--- a/scripts/generate_llms_txt.py
+++ b/scripts/generate_llms_txt.py
@@ -14,10 +14,6 @@ def generate_docs_llms_files():
     llms_content = []
     llms_full_content = []
 
-    # GitHub repository information
-    github_repo = "duckdb/duckdb-web"
-    github_branch = "main"
-
     # Group files by directory
     file_groups = {}
 
@@ -43,9 +39,6 @@ def generate_docs_llms_files():
             title = doc.get('title', '')
             content = doc.content.strip()
 
-            # Create URLs
-            raw_url = f"https://raw.githubusercontent.com/{github_repo}/{github_branch}/docs/stable/{relative_path}"
-
             # For website URL, remove the .md extension
             website_path = str(relative_path)
             if website_path.endswith('.md'):
@@ -59,7 +52,6 @@ def generate_docs_llms_files():
             file_groups[dir_name].append(
                 {
                     'title': title,
-                    'raw_url': raw_url,
                     'website_url': website_url,
                     'content': content,
                 }
@@ -67,7 +59,6 @@ def generate_docs_llms_files():
 
             # Add to llms-full.txt (titles, links, and content)
             llms_full_content.append(f"# {title}\n")
-            llms_full_content.append(f"Source: {raw_url}\n")
             llms_full_content.append(f"Website: {website_url}\n")
             llms_full_content.append("---\n")
             llms_full_content.append(content)

--- a/scripts/generate_llms_txt.py
+++ b/scripts/generate_llms_txt.py
@@ -4,64 +4,67 @@ import os
 import frontmatter
 from pathlib import Path
 
+
 def generate_docs_llms_files():
     """Generate llms.txt and llms-full.txt for the docs/stable directory"""
     # Path to the docs/stable directory
     docs_dir = Path('docs/stable')
-    
+
     # Initialize content for both files
     llms_content = []
     llms_full_content = []
-    
+
     # GitHub repository information
     github_repo = "duckdb/duckdb-web"
     github_branch = "main"
-    
+
     # Group files by directory
     file_groups = {}
-    
+
     # Walk through all markdown files in docs/stable
     for root, _, files in os.walk(docs_dir):
         for file in files:
             if not file.endswith('.md'):
                 continue
-                
+
             file_path = Path(root) / file
             relative_path = file_path.relative_to(docs_dir)
-            
+
             # Get the directory name for grouping
             dir_name = str(relative_path.parent)
             if dir_name == '.':
                 dir_name = 'root'
-            
+
             # Read and parse the markdown file
             with open(file_path, 'r') as f:
                 doc = frontmatter.load(f)
-                
+
             # Get the title and content
             title = doc.get('title', '')
             content = doc.content.strip()
-            
+
             # Create URLs
             raw_url = f"https://raw.githubusercontent.com/{github_repo}/{github_branch}/docs/stable/{relative_path}"
-            
+
             # For website URL, remove the .md extension
             website_path = str(relative_path)
             if website_path.endswith('.md'):
                 website_path = website_path[:-3]
             website_url = f"https://duckdb.org/docs/stable/{website_path}"
-            
+
             # Add to file groups
             if dir_name not in file_groups:
                 file_groups[dir_name] = []
-            
-            file_groups[dir_name].append({
-                'title': title,
-                'raw_url': raw_url,
-                'website_url': website_url,
-                'content': content
-            })
-            
+
+            file_groups[dir_name].append(
+                {
+                    'title': title,
+                    'raw_url': raw_url,
+                    'website_url': website_url,
+                    'content': content,
+                }
+            )
+
             # Add to llms-full.txt (titles, links, and content)
             llms_full_content.append(f"# {title}\n")
             llms_full_content.append(f"Source: {raw_url}\n")
@@ -69,7 +72,7 @@ def generate_docs_llms_files():
             llms_full_content.append("---\n")
             llms_full_content.append(content)
             llms_full_content.append("\n\n")
-    
+
     # Generate llms.txt content with grouped structure
     for dir_name, files in sorted(file_groups.items()):
         # Format directory name for display
@@ -77,32 +80,36 @@ def generate_docs_llms_files():
             section_title = "Documentation"
         else:
             section_title = dir_name.replace('/', ' ').title()
-        
+
         llms_content.append(f"## {section_title}\n")
-        
+
         for file_info in sorted(files, key=lambda x: x['title']):
             llms_content.append(f"- {file_info['title']}:")
             llms_content.append(f"  - [Website]({file_info['website_url']})")
             llms_content.append(f"  - [Markdown]({file_info['raw_url']})")
-        
+
         llms_content.append("")
-    
+
     # Write llms.txt
     with open(docs_dir / 'llms.txt', 'w') as f:
         f.write("# DuckDB Documentation\n\n")
-        f.write("> Comprehensive documentation for DuckDB, an in-process analytical database management system.\n\n")
+        f.write(
+            "> Comprehensive documentation for DuckDB, an in-process analytical database management system.\n\n"
+        )
         f.write('\n'.join(llms_content))
-    
+
     # Write llms-full.txt
     with open(docs_dir / 'llms-full.txt', 'w') as f:
         f.write("# DuckDB Full Documentation\n\n")
         f.write('\n'.join(llms_full_content))
 
+
 def main():
     # Generate the docs-specific llms.txt and llms-full.txt files
     generate_docs_llms_files()
-    
+
     print("Generated docs/stable/llms.txt and docs/stable/llms-full.txt successfully!")
 
+
 if __name__ == '__main__':
-    main() 
+    main()

--- a/scripts/generate_llms_txt.py
+++ b/scripts/generate_llms_txt.py
@@ -84,9 +84,7 @@ def generate_docs_llms_files():
         llms_content.append(f"## {section_title}\n")
 
         for file_info in sorted(files, key=lambda x: x['title']):
-            llms_content.append(f"- {file_info['title']}:")
-            llms_content.append(f"  - [Website]({file_info['website_url']})")
-            llms_content.append(f"  - [Markdown]({file_info['raw_url']})")
+            llms_content.append(f"- [{file_info['title']}]({file_info['website_url']})")
 
         llms_content.append("")
 


### PR DESCRIPTION
Currently, we only have [`llms.txt`](https://duckdb.org/llms.txt) at the root, which is quite minimal.

This PR adds a Python script pipeline to keep `/docs/stable` always up to date:

- `llms.txt`: list of links
- `llms-full.txt`: full content of the linked pages

**Note:**  
@szarnyasg — I noticed you pointed to the `raw.githubusercontent.com` version of the markdown URL on the root `llms.txt`. I have mixed thoughts on this. While [llmstxt.org](https://llmstxt.org) recommends using markdown-friendly URLs, relying on the raw GitHub link could reduce traffic through duckdb.org and hurt its domain authority.

As a workaround, I’ve included both the duckdb.org link and the raw markdown URL for now. Curious to hear your thoughts, @tdoehmen.