### PR TITLE
Add page for encodings extension

### DIFF
--- a/_data/menu_docs_preview.json
+++ b/_data/menu_docs_preview.json
@@ -1031,6 +1031,10 @@
               "url": "delta"
             },
             {
+              "page": "Encodings",
+              "url": "encodings"
+            },
+            {
               "page": "Excel",
               "url": "excel"
             },

--- a/docs/preview/extensions/encodings.md
+++ b/docs/preview/extensions/encodings.md
@@ -1,0 +1,24 @@
+---
+github_directory: https://github.com/duckdb/duckdb-encodings
+layout: docu
+title: Encodings Extension
+---
+
+> Warning The Encodings extension will be available with the release of DuckDB v1.3.0.
+
+The `encodings` extension adds supports for the [1,000+ character encodings available in the ICU data repository](https://github.com/unicode-org/icu-data/tree/main/charset/data/ucm).
+
+### Installing and Loading
+
+```sql
+INSTALL encodings;
+LOAD encodings;
+```
+
+## Usage
+
+Refer to the encoding while reading from files:
+
+```sql
+FROM read_csv('my_shift_jis.csv', encoding = 'shift_jis');
+```


### PR DESCRIPTION
Fixes #5263

We need to write about which functions are supported (e.g., `read_json`?)

To be merged when the extension becomes available

cc @pdet 