### PR TITLE
Fix repeat words

### DIFF
--- a/docs/preview/data/json/loading_json.md
+++ b/docs/preview/data/json/loading_json.md
@@ -348,7 +348,7 @@ CREATE TABLE numbers AS
 
 | Name | Description | Type | Default |
 |:--|:-----|:-|:-|
-| `auto_detect` | Whether to auto-detect detect the names of the keys and data types of the values automatically | `BOOL` | `false` |
+| `auto_detect` | Whether to auto-detect the names of the keys and data types of the values automatically | `BOOL` | `false` |
 | `columns` | A struct that specifies the key names and value types contained within the JSON file (e.g., `{key1: 'INTEGER', key2: 'VARCHAR'}`). If `auto_detect` is enabled these will be inferred | `STRUCT` | `(empty)` |
 | `compression` | The compression type for the file. By default this will be detected automatically from the file extension (e.g., `t.json.gz` will use gzip, `t.json` will use none). Options are `uncompressed`, `gzip`, `zstd` and `auto_detect`. | `VARCHAR` | `auto_detect` |
 | `convert_strings_to_integers` | Whether strings representing integer values should be converted to a numerical type. | `BOOL` | `false` |

--- a/docs/preview/sql/functions/blob.md
+++ b/docs/preview/sql/functions/blob.md
@@ -21,7 +21,7 @@ This section describes functions and operators for examining and manipulating [`
 | [`from_binary(value)`](#from_binaryvalue) | Converts a `value` from binary representation to a blob. |
 | [`from_hex(value)`](#from_hexvalue) | Converts a `value` from hexadecimal representation to a blob. |
 | [`hex(blob)`](#hexblob) | Converts `blob` to `VARCHAR` using hexadecimal encoding. |
-| [`md5(blob)`](#md5blob) | Returns the MD5 hash of the `blob` as as a `VARCHAR`. |
+| [`md5(blob)`](#md5blob) | Returns the MD5 hash of the `blob` as a `VARCHAR`. |
 | [`md5_number(blob)`](#md5_numberblob) | Returns the MD5 hash of the `blob` as a `HUGEINT`. |
 | [`octet_length(blob)`](#octet_lengthblob) | Number of bytes in `blob`. |
 | [`read_blob(source)`](#read_blobsource) | Returns the content from `source` (a filename, a list of filenames, or a glob pattern) as a `BLOB`. See the [`read_blob` guide]({% link docs/preview/guides/file_formats/read_file.md %}#read_blob) for more details. |
@@ -119,7 +119,7 @@ This section describes functions and operators for examining and manipulating [`
 
 <div class="nostroke_table"></div>
 
-| **Description** | Returns the MD5 hash of the `blob` as as a `VARCHAR`. |
+| **Description** | Returns the MD5 hash of the `blob` as a `VARCHAR`. |
 | **Example** | `md5('\xAA\xBB'::BLOB)` |
 | **Result** | `58cea1f6b2b06520613e09af90dc1c47` |
 


### PR DESCRIPTION
@c-herrewijn in the description of the `md5` function, a repeat word "as" occurs:

```
Returns the MD5 hash of the `blob` as as a `VARCHAR`.
```

I'm not 100% where it is coming from in the DuckDB codebase, would you mind taking a look?