### PR TITLE
Fixed typo in the ST_Read example section

### DIFF
--- a/docs/stable/extensions/spatial/functions.md
+++ b/docs/stable/extensions/spatial/functions.md
@@ -2854,10 +2854,10 @@ The following formats are currently recognized by their file extension:
 
 ```sql
 -- Read a Shapefile
-ELECT * FROM ST_Read('some/file/path/filename.shp');
+SELECT * FROM ST_Read('some/file/path/filename.shp');
 
 - Read a GeoJSON file
-REATE TABLE my_geojson_table AS SELECT * FROM ST_Read('some/file/path/filename.json');
+CREATE TABLE my_geojson_table AS SELECT * FROM ST_Read('some/file/path/filename.json');
 ```
 
 ----


### PR DESCRIPTION
Looks some of the keywords were truncated at some point
ELECT -> SELECT
REATE -> CREATE