### PR TITLE
Added link development roadmap to the FAQ

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -443,7 +443,7 @@ You can find the recent releases in the [release calendar]({% link release_calen
 
 <div class="answer" markdown="1">
 
-Currently, we do not maintain a public development roadmap.
+You can find the development roadmap at [Development Roadmap]({% link roadmap.html %}).
 
 </div>
 

--- a/faq.md
+++ b/faq.md
@@ -443,7 +443,7 @@ You can find the recent releases in the [release calendar]({% link release_calen
 
 <div class="answer" markdown="1">
 
-You can find the development roadmap at [Development Roadmap]({% link roadmap.html %}).
+You can find the development roadmap at [Development Roadmap]({% link roadmap.md %}).
 
 </div>
 


### PR DESCRIPTION
While reading the docs i noticed there's now a development roadmap. This PR adds the link to the FAQ.

Awesome project!