### PR TITLE
Use Python standard case-style for lambda

### DIFF
--- a/_posts/2025-05-21-announcing-duckdb-130.md
+++ b/_posts/2025-05-21-announcing-duckdb-130.md
@@ -35,7 +35,7 @@ SELECT ((JSON '{"field": 42}')->'field') = 42;
 This often caused confusion among users, therefore, the new release deprecates the old arrow lambda syntax and replaces it with Python-style lambda syntax:
 
 ```sql
-SELECT list_transform([1, 2, 3], LAMBDA x: x + 1);
+SELECT list_transform([1, 2, 3], lambda x: x + 1);
 ```
 
 To make the transition smoother, the deprecation will happen in several steps over the next year.

--- a/docs/preview/sql/functions/lambda.md
+++ b/docs/preview/sql/functions/lambda.md
@@ -4,7 +4,7 @@ title: Lambda Functions
 ---
 
 > Deprecated DuckDB 1.3.0 deprecated the old lambda single arrow syntax (`x -> x + 1`)
-> in favor of the Python-style syntax (`LAMBDA x : x + 1`).
+> in favor of the Python-style syntax (`lambda x : x + 1`).
 >
 > DuckDB 1.3.0 also introduces a new setting to configure the lambda syntax.
 >
@@ -27,14 +27,14 @@ title: Lambda Functions
 Lambda functions enable the use of more complex and flexible expressions in queries.
 DuckDB supports several scalar functions that operate on [`LIST`s]({% link docs/preview/sql/data_types/list.md %}) and
 accept lambda functions as parameters
-in the form `LAMBDA (⟨parameter1⟩, ⟨parameter2⟩, ...) : ⟨expression⟩`{:.language-sql .highlight}.
+in the form `lambda (⟨parameter1⟩, ⟨parameter2⟩, ...) : ⟨expression⟩`{:.language-sql .highlight}.
 If the lambda function has only one parameter, then the parentheses can be omitted.
 The parameters can have any names.
 For example, the following are all valid lambda functions:
 
-* `LAMBDA param : param > 1`{:.language-sql .highlight}
-* `LAMBDA s : contains(concat(s, 'DB'), 'duck')`{:.language-sql .highlight}
-* `LAMBDA (acc, x) : acc + x`{:.language-sql .highlight}
+* `lambda param : param > 1`{:.language-sql .highlight}
+* `lambda s : contains(concat(s, 'DB'), 'duck')`{:.language-sql .highlight}
+* `lambda acc, x : acc + x`{:.language-sql .highlight}
 
 ## Scalar Functions That Accept Lambda Functions
 
@@ -49,7 +49,7 @@ For example, the following are all valid lambda functions:
 <div class="nostroke_table"></div>
 
 | **Description** | Returns a list that is the result of applying the lambda function to each element of the input list. The return type is defined by the return type of the lambda function. See [`list_transform` examples](#list_transform-examples). |
-| **Example** | `list_transform([4, 5, 6], LAMBDA x : x + 1)`{:.language-sql .highlight} |
+| **Example** | `list_transform([4, 5, 6], lambda x : x + 1)`{:.language-sql .highlight} |
 | **Result** | `[5, 6, 7]` |
 | **Aliases** | `array_transform`, `apply`, `list_apply`, `array_apply` |
 
@@ -58,7 +58,7 @@ For example, the following are all valid lambda functions:
 <div class="nostroke_table"></div>
 
 | **Description** | Constructs a list from those elements of the input list for which the lambda function returns `true`. DuckDB must be able to cast the lambda function's return type to `BOOL`. The return type of `list_filter` is the same as the input list's. See [`list_filter` examples](#list_filter-examples). |
-| **Example** | `list_filter([4, 5, 6], LAMBDA x : x > 4)`{:.language-sql .highlight} |
+| **Example** | `list_filter([4, 5, 6], lambda x : x > 4)`{:.language-sql .highlight} |
 | **Result** | `[5, 6]` |
 | **Aliases** | `array_filter`, `filter` |
 
@@ -67,7 +67,7 @@ For example, the following are all valid lambda functions:
 <div class="nostroke_table"></div>
 
 | **Description** | Reduces all elements of the input list into a single scalar value by executing the lambda function on a running result and the next list element. The lambda function has an optional `initial_value` argument. See [`list_reduce` examples](#list_reduce-examples) or details. |
-| **Example** | `list_reduce([1, 2, 3], LAMBDA (x, y) : x + y, 100)`{:.language-sql .highlight} |
+| **Example** | `list_reduce([1, 2, 3], lambda (x, y) : x + y, 100)`{:.language-sql .highlight} |
 | **Result** | `106` |
 | **Aliases** | `array_reduce`, `reduce` |
 
@@ -77,8 +77,8 @@ All scalar functions can be arbitrarily nested. For example, nested lambda funct
 
 ```sql
 SELECT list_transform(
-        list_filter([0, 1, 2, 3, 4, 5], LAMBDA x : x % 2 = 0),
-        LAMBDA y : y * y
+        list_filter([0, 1, 2, 3, 4, 5], lambda x: x % 2 = 0),
+        lambda y: y * y
     );
 ```
 
@@ -91,8 +91,8 @@ Nested lambda function to add each element of the first list to the sum of the s
 ```sql
 SELECT list_transform(
         [1, 2, 3],
-        LAMBDA x :
-            list_reduce([4, 5, 6], LAMBDA (a, b) : a + b) + x
+        lambda x :
+            list_reduce([4, 5, 6], lambda a, b: a + b) + x
     );
 ```
 
@@ -114,7 +114,7 @@ CREATE TABLE tbl (x INTEGER);
 INSERT INTO tbl VALUES (10);
 SELECT list_apply(
             [1, 2],
-            LAMBDA x : list_apply([4], LAMBDA x : x + tbl.x)[1] + x
+            lambda x: list_apply([4], lambda x: x + tbl.x)[1] + x
     )
 FROM tbl;
 ```
@@ -131,7 +131,7 @@ This is always the last parameter of the lambda function (e.g., `i` in `(x, i)`)
 Get all elements that are larger than their index:
 
 ```sql
-SELECT list_filter([1, 3, 1, 5], LAMBDA (x, i) : x > i);
+SELECT list_filter([1, 3, 1, 5], lambda x, i: x > i);
 ```
 
 ```text
@@ -145,7 +145,7 @@ SELECT list_filter([1, 3, 1, 5], LAMBDA (x, i) : x > i);
 Incrementing each list element by one:
 
 ```sql
-SELECT list_transform([1, 2, NULL, 3], LAMBDA x : x + 1);
+SELECT list_transform([1, 2, NULL, 3], lambda x: x + 1);
 ```
 
 ```text
@@ -155,7 +155,7 @@ SELECT list_transform([1, 2, NULL, 3], LAMBDA x : x + 1);
 Transforming strings:
 
 ```sql
-SELECT list_transform(['Duck', 'Goose', 'Sparrow'], LAMBDA s : concat(s, 'DB'));
+SELECT list_transform(['Duck', 'Goose', 'Sparrow'], lambda s: concat(s, 'DB'));
 ```
 
 ```text
@@ -165,7 +165,7 @@ SELECT list_transform(['Duck', 'Goose', 'Sparrow'], LAMBDA s : concat(s, 'DB'));
 Combining lambda functions with other functions:
 
 ```sql
-SELECT list_transform([5, NULL, 6], LAMBDA x : coalesce(x, 0) + 1);
+SELECT list_transform([5, NULL, 6], lambda x: coalesce(x, 0) + 1);
 ```
 
 ```text
@@ -177,7 +177,7 @@ SELECT list_transform([5, NULL, 6], LAMBDA x : coalesce(x, 0) + 1);
 Filter out negative values:
 
 ```sql
-SELECT list_filter([5, -6, NULL, 7], LAMBDA x : x > 0);
+SELECT list_filter([5, -6, NULL, 7], lambda x: x > 0);
 ```
 
 ```text
@@ -188,8 +188,8 @@ Divisible by 2 and 5:
 
 ```sql
 SELECT list_filter(
-        list_filter([2, 4, 3, 1, 20, 10, 3, 30], LAMBDA x : x % 2 = 0),
-        LAMBDA y : y % 5 = 0
+        list_filter([2, 4, 3, 1, 20, 10, 3, 30], lambda x: x % 2 = 0),
+        lambda y: y % 5 = 0
     );
 ```
 
@@ -200,7 +200,7 @@ SELECT list_filter(
 In combination with `range(...)` to construct lists:
 
 ```sql
-SELECT list_filter([1, 2, 3, 4], LAMBDA x : x > #1) FROM range(4);
+SELECT list_filter([1, 2, 3, 4], lambda x: x > #1) FROM range(4);
 ```
 
 ```text
@@ -215,7 +215,7 @@ SELECT list_filter([1, 2, 3, 4], LAMBDA x : x > #1) FROM range(4);
 Sum of all list elements:
 
 ```sql
-SELECT list_reduce([1, 2, 3, 4], LAMBDA (acc, x) : acc + x);
+SELECT list_reduce([1, 2, 3, 4], lambda acc, x: acc + x);
 ```
 
 ```text
@@ -226,8 +226,8 @@ Only add up list elements if they are greater than 2:
 
 ```sql
 SELECT list_reduce(
-        list_filter([1, 2, 3, 4], LAMBDA x : x > 2),
-        LAMBDA (acc, x) : acc + x
+        list_filter([1, 2, 3, 4], lambda x: x > 2),
+        lambda acc, x: acc + x
     );
 ```
 
@@ -238,7 +238,7 @@ SELECT list_reduce(
 Concat all list elements:
 
 ```sql
-SELECT list_reduce(['DuckDB', 'is', 'awesome'], LAMBDA (acc, x) : concat(acc, ' ', x));
+SELECT list_reduce(['DuckDB', 'is', 'awesome'], lambda acc, x: concat(acc, ' ', x));
 ```
 
 ```text
@@ -250,7 +250,7 @@ Concatenate elements with the index without an initial value:
 ```sql
 SELECT list_reduce(
         ['a', 'b', 'c', 'd'],
-        LAMBDA (x, y, i) : x || ' - ' || CAST(i AS VARCHAR) || ' - ' || y
+        lambda x, y, i: x || ' - ' || CAST(i AS VARCHAR) || ' - ' || y
     );
 ```
 
@@ -263,7 +263,7 @@ Concatenate elements with the index with an initial value:
 ```sql
 SELECT list_reduce(
         ['a', 'b', 'c', 'd'],
-        LAMBDA (x, y, i) : x || ' - ' || CAST(i AS VARCHAR) || ' - ' || y, 'INITIAL'
+        lambda x, y, i: x || ' - ' || CAST(i AS VARCHAR) || ' - ' || y, 'INITIAL'
     );
 ```
 
@@ -277,7 +277,7 @@ Subqueries in lambda expressions are currently not supported.
 For example:
 
 ```sql
-SELECT list_apply([1, 2, 3], LAMBDA x : (SELECT 42) + x);
+SELECT list_apply([1, 2, 3], lambda x: (SELECT 42) + x);
 ```
 
 ```console

--- a/docs/stable/sql/functions/lambda.md
+++ b/docs/stable/sql/functions/lambda.md
@@ -1,12 +1,10 @@
 ---
 layout: docu
-redirect_from:
-- /docs/sql/functions/lambda
 title: Lambda Functions
 ---
 
 > Deprecated DuckDB 1.3.0 deprecated the old lambda single arrow syntax (`x -> x + 1`)
-> in favor of the Python-style syntax (`LAMBDA x : x + 1`).
+> in favor of the Python-style syntax (`lambda x : x + 1`).
 >
 > DuckDB 1.3.0 also introduces a new setting to configure the lambda syntax.
 >
@@ -27,16 +25,16 @@ title: Lambda Functions
 > so the old behavior will no longer be possible.
 
 Lambda functions enable the use of more complex and flexible expressions in queries.
-DuckDB supports several scalar functions that operate on [`LIST`s]({% link docs/stable/sql/data_types/list.md %}) and
+DuckDB supports several scalar functions that operate on [`LIST`s]({% link docs/preview/sql/data_types/list.md %}) and
 accept lambda functions as parameters
-in the form `LAMBDA (⟨parameter1⟩, ⟨parameter2⟩, ...) : ⟨expression⟩`{:.language-sql .highlight}.
+in the form `lambda (⟨parameter1⟩, ⟨parameter2⟩, ...) : ⟨expression⟩`{:.language-sql .highlight}.
 If the lambda function has only one parameter, then the parentheses can be omitted.
 The parameters can have any names.
 For example, the following are all valid lambda functions:
 
-* `LAMBDA param : param > 1`{:.language-sql .highlight}
-* `LAMBDA s : contains(concat(s, 'DB'), 'duck')`{:.language-sql .highlight}
-* `LAMBDA (acc, x) : acc + x`{:.language-sql .highlight}
+* `lambda param : param > 1`{:.language-sql .highlight}
+* `lambda s : contains(concat(s, 'DB'), 'duck')`{:.language-sql .highlight}
+* `lambda acc, x : acc + x`{:.language-sql .highlight}
 
 ## Scalar Functions That Accept Lambda Functions
 
@@ -51,7 +49,7 @@ For example, the following are all valid lambda functions:
 <div class="nostroke_table"></div>
 
 | **Description** | Returns a list that is the result of applying the lambda function to each element of the input list. The return type is defined by the return type of the lambda function. See [`list_transform` examples](#list_transform-examples). |
-| **Example** | `list_transform([4, 5, 6], LAMBDA x : x + 1)`{:.language-sql .highlight} |
+| **Example** | `list_transform([4, 5, 6], lambda x : x + 1)`{:.language-sql .highlight} |
 | **Result** | `[5, 6, 7]` |
 | **Aliases** | `array_transform`, `apply`, `list_apply`, `array_apply` |
 
@@ -60,7 +58,7 @@ For example, the following are all valid lambda functions:
 <div class="nostroke_table"></div>
 
 | **Description** | Constructs a list from those elements of the input list for which the lambda function returns `true`. DuckDB must be able to cast the lambda function's return type to `BOOL`. The return type of `list_filter` is the same as the input list's. See [`list_filter` examples](#list_filter-examples). |
-| **Example** | `list_filter([4, 5, 6], LAMBDA x : x > 4)`{:.language-sql .highlight} |
+| **Example** | `list_filter([4, 5, 6], lambda x : x > 4)`{:.language-sql .highlight} |
 | **Result** | `[5, 6]` |
 | **Aliases** | `array_filter`, `filter` |
 
@@ -69,7 +67,7 @@ For example, the following are all valid lambda functions:
 <div class="nostroke_table"></div>
 
 | **Description** | Reduces all elements of the input list into a single scalar value by executing the lambda function on a running result and the next list element. The lambda function has an optional `initial_value` argument. See [`list_reduce` examples](#list_reduce-examples) or details. |
-| **Example** | `list_reduce([1, 2, 3], LAMBDA (x, y) : x + y, 100)`{:.language-sql .highlight} |
+| **Example** | `list_reduce([1, 2, 3], lambda (x, y) : x + y, 100)`{:.language-sql .highlight} |
 | **Result** | `106` |
 | **Aliases** | `array_reduce`, `reduce` |
 
@@ -79,8 +77,8 @@ All scalar functions can be arbitrarily nested. For example, nested lambda funct
 
 ```sql
 SELECT list_transform(
-        list_filter([0, 1, 2, 3, 4, 5], LAMBDA x : x % 2 = 0),
-        LAMBDA y : y * y
+        list_filter([0, 1, 2, 3, 4, 5], lambda x: x % 2 = 0),
+        lambda y: y * y
     );
 ```
 
@@ -93,8 +91,8 @@ Nested lambda function to add each element of the first list to the sum of the s
 ```sql
 SELECT list_transform(
         [1, 2, 3],
-        LAMBDA x :
-            list_reduce([4, 5, 6], LAMBDA (a, b) : a + b) + x
+        lambda x :
+            list_reduce([4, 5, 6], lambda a, b: a + b) + x
     );
 ```
 
@@ -116,7 +114,7 @@ CREATE TABLE tbl (x INTEGER);
 INSERT INTO tbl VALUES (10);
 SELECT list_apply(
             [1, 2],
-            LAMBDA x : list_apply([4], LAMBDA x : x + tbl.x)[1] + x
+            lambda x: list_apply([4], lambda x: x + tbl.x)[1] + x
     )
 FROM tbl;
 ```
@@ -133,7 +131,7 @@ This is always the last parameter of the lambda function (e.g., `i` in `(x, i)`)
 Get all elements that are larger than their index:
 
 ```sql
-SELECT list_filter([1, 3, 1, 5], LAMBDA (x, i) : x > i);
+SELECT list_filter([1, 3, 1, 5], lambda x, i: x > i);
 ```
 
 ```text
@@ -147,7 +145,7 @@ SELECT list_filter([1, 3, 1, 5], LAMBDA (x, i) : x > i);
 Incrementing each list element by one:
 
 ```sql
-SELECT list_transform([1, 2, NULL, 3], LAMBDA x : x + 1);
+SELECT list_transform([1, 2, NULL, 3], lambda x: x + 1);
 ```
 
 ```text
@@ -157,7 +155,7 @@ SELECT list_transform([1, 2, NULL, 3], LAMBDA x : x + 1);
 Transforming strings:
 
 ```sql
-SELECT list_transform(['Duck', 'Goose', 'Sparrow'], LAMBDA s : concat(s, 'DB'));
+SELECT list_transform(['Duck', 'Goose', 'Sparrow'], lambda s: concat(s, 'DB'));
 ```
 
 ```text
@@ -167,7 +165,7 @@ SELECT list_transform(['Duck', 'Goose', 'Sparrow'], LAMBDA s : concat(s, 'DB'));
 Combining lambda functions with other functions:
 
 ```sql
-SELECT list_transform([5, NULL, 6], LAMBDA x : coalesce(x, 0) + 1);
+SELECT list_transform([5, NULL, 6], lambda x: coalesce(x, 0) + 1);
 ```
 
 ```text
@@ -179,7 +177,7 @@ SELECT list_transform([5, NULL, 6], LAMBDA x : coalesce(x, 0) + 1);
 Filter out negative values:
 
 ```sql
-SELECT list_filter([5, -6, NULL, 7], LAMBDA x : x > 0);
+SELECT list_filter([5, -6, NULL, 7], lambda x: x > 0);
 ```
 
 ```text
@@ -190,8 +188,8 @@ Divisible by 2 and 5:
 
 ```sql
 SELECT list_filter(
-        list_filter([2, 4, 3, 1, 20, 10, 3, 30], LAMBDA x : x % 2 = 0),
-        LAMBDA y : y % 5 = 0
+        list_filter([2, 4, 3, 1, 20, 10, 3, 30], lambda x: x % 2 = 0),
+        lambda y: y % 5 = 0
     );
 ```
 
@@ -202,7 +200,7 @@ SELECT list_filter(
 In combination with `range(...)` to construct lists:
 
 ```sql
-SELECT list_filter([1, 2, 3, 4], LAMBDA x : x > #1) FROM range(4);
+SELECT list_filter([1, 2, 3, 4], lambda x: x > #1) FROM range(4);
 ```
 
 ```text
@@ -217,7 +215,7 @@ SELECT list_filter([1, 2, 3, 4], LAMBDA x : x > #1) FROM range(4);
 Sum of all list elements:
 
 ```sql
-SELECT list_reduce([1, 2, 3, 4], LAMBDA (acc, x) : acc + x);
+SELECT list_reduce([1, 2, 3, 4], lambda acc, x: acc + x);
 ```
 
 ```text
@@ -228,8 +226,8 @@ Only add up list elements if they are greater than 2:
 
 ```sql
 SELECT list_reduce(
-        list_filter([1, 2, 3, 4], LAMBDA x : x > 2),
-        LAMBDA (acc, x) : acc + x
+        list_filter([1, 2, 3, 4], lambda x: x > 2),
+        lambda acc, x: acc + x
     );
 ```
 
@@ -240,7 +238,7 @@ SELECT list_reduce(
 Concat all list elements:
 
 ```sql
-SELECT list_reduce(['DuckDB', 'is', 'awesome'], LAMBDA (acc, x) : concat(acc, ' ', x));
+SELECT list_reduce(['DuckDB', 'is', 'awesome'], lambda acc, x: concat(acc, ' ', x));
 ```
 
 ```text
@@ -252,7 +250,7 @@ Concatenate elements with the index without an initial value:
 ```sql
 SELECT list_reduce(
         ['a', 'b', 'c', 'd'],
-        LAMBDA (x, y, i) : x || ' - ' || CAST(i AS VARCHAR) || ' - ' || y
+        lambda x, y, i: x || ' - ' || CAST(i AS VARCHAR) || ' - ' || y
     );
 ```
 
@@ -265,7 +263,7 @@ Concatenate elements with the index with an initial value:
 ```sql
 SELECT list_reduce(
         ['a', 'b', 'c', 'd'],
-        LAMBDA (x, y, i) : x || ' - ' || CAST(i AS VARCHAR) || ' - ' || y, 'INITIAL'
+        lambda x, y, i: x || ' - ' || CAST(i AS VARCHAR) || ' - ' || y, 'INITIAL'
     );
 ```
 
@@ -279,7 +277,7 @@ Subqueries in lambda expressions are currently not supported.
 For example:
 
 ```sql
-SELECT list_apply([1, 2, 3], LAMBDA x : (SELECT 42) + x);
+SELECT list_apply([1, 2, 3], lambda x: (SELECT 42) + x);
 ```
 
 ```console


### PR DESCRIPTION
This syntax was inspired by Python, so we should use Python-style syntax in the docs. Python is not case-sensitive, so `LAMBDA` does not work - it has to be `lambda`. 

In addition, the docs appear to be outdated when it comes to multi-parameter lambdas - they no longer require (or work with) parenthesis. This fixes the queries so they are correct again.