### PR TITLE
Update adbc docs to use current arrow-go v18

### DIFF
--- a/docs/preview/clients/adbc.md
+++ b/docs/preview/clients/adbc.md
@@ -185,10 +185,10 @@ import (
 
     "github.com/apache/arrow-adbc/go/adbc"
     "github.com/apache/arrow-adbc/go/adbc/drivermgr"
-    "github.com/apache/arrow/go/v17/arrow"
-    "github.com/apache/arrow/go/v17/arrow/array"
-    "github.com/apache/arrow/go/v17/arrow/ipc"
-    "github.com/apache/arrow/go/v17/arrow/memory"
+    "github.com/apache/arrow-go/v18/arrow"
+    "github.com/apache/arrow-go/v18/arrow/array"
+    "github.com/apache/arrow-go/v18/arrow/ipc"
+    "github.com/apache/arrow-go/v18/arrow/memory"
 )
 
 func _makeSampleArrowRecord() arrow.Record {

--- a/docs/stable/clients/adbc.md
+++ b/docs/stable/clients/adbc.md
@@ -189,10 +189,10 @@ import (
 
     "github.com/apache/arrow-adbc/go/adbc"
     "github.com/apache/arrow-adbc/go/adbc/drivermgr"
-    "github.com/apache/arrow/go/v17/arrow"
-    "github.com/apache/arrow/go/v17/arrow/array"
-    "github.com/apache/arrow/go/v17/arrow/ipc"
-    "github.com/apache/arrow/go/v17/arrow/memory"
+    "github.com/apache/arrow-go/v18/arrow"
+    "github.com/apache/arrow-go/v18/arrow/array"
+    "github.com/apache/arrow-go/v18/arrow/ipc"
+    "github.com/apache/arrow-go/v18/arrow/memory"
 )
 
 func _makeSampleArrowRecord() arrow.Record {


### PR DESCRIPTION
Update to latest published version of arrow-go, now the code example works fine

<img width="493" alt="Screenshot 2025-05-22 at 4 17 02 PM" src="https://github.com/user-attachments/assets/e70f0fc7-9ad7-47e1-a273-c4f8abb7faa3" />
