### PR TITLE
Avoid overriding extension list (for 1.3.0)

### DIFF
--- a/.github/workflows/community_extension_docs.yml
+++ b/.github/workflows/community_extension_docs.yml
@@ -28,7 +28,7 @@ jobs:
       run: |
             unzip generated_md.zip
             cp build/docs/*.md community_extensions/extensions/.
-            cp build/docs/extensions_list.md.tmp _includes/list_of_community_extensions.md
+            # cp build/docs/extensions_list.md.tmp _includes/list_of_community_extensions.md
             rm -r generated_md.zip
             rm -rf build
 


### PR DESCRIPTION
Temporary fix to avoid overriding previous extension list. Waiting for a proper fix.