### PR TITLE
redirect `/docs/extensions/<extension_name>` to `/docs/stable/core_extensions/<extension_name>`

### DIFF
--- a/docs/stable/core_extensions/avro.md
+++ b/docs/stable/core_extensions/avro.md
@@ -5,6 +5,8 @@ title: Avro Extension
 redirect_from:
 - /docs/stable/extensions/avro
 - /docs/stable/extensions/avro/
+- /docs/extensions/avro
+- /docs/extensions/avro/
 ---
 
 The `avro` extension enables DuckDB to read [Apache Avro](https://avro.apache.org) files.

--- a/docs/stable/core_extensions/aws.md
+++ b/docs/stable/core_extensions/aws.md
@@ -5,6 +5,8 @@ title: AWS Extension
 redirect_from:
 - /docs/stable/extensions/aws
 - /docs/stable/extensions/aws/
+- /docs/extensions/aws
+- /docs/extensions/aws/
 ---
 
 The `aws` extension adds functionality (e.g., authentication) on top of the `httpfs` extension's [S3 capabilities]({% link docs/stable/core_extensions/httpfs/overview.md %}#s3-api), using the AWS SDK.

--- a/docs/stable/core_extensions/azure.md
+++ b/docs/stable/core_extensions/azure.md
@@ -5,6 +5,8 @@ title: Azure Extension
 redirect_from:
 - /docs/stable/extensions/azure
 - /docs/stable/extensions/azure/
+- /docs/extensions/azure
+- /docs/extensions/azure/
 ---
 
 The `azure` extension is a loadable extension that adds a filesystem abstraction for the [Azure Blob storage](https://azure.microsoft.com/en-us/products/storage/blobs) to DuckDB.

--- a/docs/stable/core_extensions/delta.md
+++ b/docs/stable/core_extensions/delta.md
@@ -5,6 +5,8 @@ title: Delta Extension
 redirect_from:
 - /docs/stable/extensions/delta
 - /docs/stable/extensions/delta/
+- /docs/extensions/delta
+- /docs/extensions/delta/
 ---
 
 The `delta` extension adds support for the [Delta Lake open-source storage format](https://delta.io/). It is built using the [Delta Kernel](https://github.com/delta-incubator/delta-kernel-rs). The extension offers **read support** for Delta tables, both local and remote.

--- a/docs/stable/core_extensions/ducklake.md
+++ b/docs/stable/core_extensions/ducklake.md
@@ -2,6 +2,9 @@
 github_repository: https://github.com/duckdb/ducklake
 layout: docu
 title: DuckLake
+redirect_from:
+- /docs/extensions/ducklake
+- /docs/extensions/ducklake/
 ---
 
 > DuckLake has been released in May 2025.

--- a/docs/stable/core_extensions/encodings.md
+++ b/docs/stable/core_extensions/encodings.md
@@ -5,6 +5,8 @@ title: Encodings Extension
 redirect_from:
 - /docs/stable/extensions/encodings
 - /docs/stable/extensions/encodings/
+- /docs/extensions/encodings
+- /docs/extensions/encodings/
 ---
 
 The `encodings` extension adds supports for reading CSVs using [more than 1,000 character encodings available in the ICU data repository](https://github.com/unicode-org/icu-data/tree/main/charset/data/ucm).

--- a/docs/stable/core_extensions/excel.md
+++ b/docs/stable/core_extensions/excel.md
@@ -5,6 +5,8 @@ title: Excel Extension
 redirect_from:
 - /docs/stable/extensions/excel
 - /docs/stable/extensions/excel/
+- /docs/extensions/excel
+- /docs/extensions/excel/
 ---
 
 The `excel` extension provides functions to format numbers per Excel's formatting rules by wrapping the [i18npool library](https://www.openoffice.org/l10n/i18n_framework/index.html), but as of DuckDB 1.2 also provides functionality to read and write Excel (`.xlsx`) files. However, `.xls` files are not supported.

--- a/docs/stable/core_extensions/full_text_search.md
+++ b/docs/stable/core_extensions/full_text_search.md
@@ -5,6 +5,8 @@ title: Full-Text Search Extension
 redirect_from:
 - /docs/stable/extensions/full_text_search
 - /docs/stable/extensions/full_text_search/
+- /docs/extensions/full_text_search
+- /docs/extensions/full_text_search/
 ---
 
 Full-Text Search is an extension to DuckDB that allows for search through strings, similar to [SQLite's FTS5 extension](https://www.sqlite.org/fts5.html).

--- a/docs/stable/core_extensions/httpfs/https.md
+++ b/docs/stable/core_extensions/httpfs/https.md
@@ -4,6 +4,8 @@ title: HTTP(S) Support
 redirect_from:
 - /docs/stable/extensions/httpfs/https
 - /docs/stable/extensions/httpfs/https/
+- /docs/extensions/httpfs
+- /docs/extensions/httpfs/
 ---
 
 With the `httpfs` extension, it is possible to directly query files over the HTTP(S) protocol. This works for all files supported by DuckDB or its various extensions, and provides read-only access.

--- a/docs/stable/core_extensions/iceberg/overview.md
+++ b/docs/stable/core_extensions/iceberg/overview.md
@@ -8,6 +8,7 @@ redirect_from:
 - /docs/stable/extensions/iceberg/overview
 - /docs/stable/extensions/iceberg/overview/
 - /docs/extensions/iceberg
+- /docs/extensions/iceberg/
 ---
 
 The `iceberg` extension implements support for the [Apache Iceberg open table format](https://iceberg.apache.org/) and can connect to Iceberg REST Catalogs. For information on how to connect to an Iceberg REST Catalog, please see the [Iceberg REST Catalogs]({% link docs/stable/core_extensions/iceberg/iceberg_rest_catalogs.md %}) page.

--- a/docs/stable/core_extensions/icu.md
+++ b/docs/stable/core_extensions/icu.md
@@ -5,6 +5,8 @@ title: ICU Extension
 redirect_from:
 - /docs/stable/extensions/icu
 - /docs/stable/extensions/icu/
+- /docs/extensions/ice
+- /docs/extensions/ice/
 ---
 
 The `icu` extension contains an easy-to-use version of the collation/timezone part of the [ICU library](https://github.com/unicode-org/icu).

--- a/docs/stable/core_extensions/inet.md
+++ b/docs/stable/core_extensions/inet.md
@@ -5,6 +5,8 @@ title: inet Extension
 redirect_from:
 - /docs/stable/extensions/inet
 - /docs/stable/extensions/inet/
+- /docs/extensions/inet
+- /docs/extensions/inet/
 ---
 
 The `inet` extension defines the `INET` data type for storing [IPv4](https://en.wikipedia.org/wiki/Internet_Protocol_version_4) and [IPv6](https://en.wikipedia.org/wiki/IPv6) Internet addresses. It supports the [CIDR notation](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation) for subnet masks (e.g., `198.51.100.0/22`, `2001:db8:3c4d::/48`).

--- a/docs/stable/core_extensions/jemalloc.md
+++ b/docs/stable/core_extensions/jemalloc.md
@@ -5,6 +5,8 @@ title: jemalloc Extension
 redirect_from:
 - /docs/stable/extensions/jemalloc
 - /docs/stable/extensions/jemalloc/
+- /docs/extensions/jemalloc
+- /docs/extensions/jemalloc/
 ---
 
 The `jemalloc` extension replaces the system's memory allocator with [jemalloc](https://jemalloc.net/).

--- a/docs/stable/core_extensions/mysql.md
+++ b/docs/stable/core_extensions/mysql.md
@@ -6,6 +6,8 @@ redirect_from:
 - /docs/extensions/mysql
 - /docs/stable/extensions/mysql
 - /docs/stable/extensions/mysql/
+- /docs/extensions/mysql
+- /docs/extensions/mysql/
 ---
 
 The `mysql` extension allows DuckDB to directly read and write data from/to a running MySQL instance. The data can be queried directly from the underlying MySQL database. Data can be loaded from MySQL tables into DuckDB tables, or vice versa.

--- a/docs/stable/core_extensions/postgres.md
+++ b/docs/stable/core_extensions/postgres.md
@@ -6,6 +6,8 @@ redirect_from:
 - /docs/extensions/postgres
 - /docs/stable/extensions/postgres
 - /docs/stable/extensions/postgres/
+- /docs/extensions/postgres
+- /docs/extensions/postgres/
 ---
 
 The `postgres` extension allows DuckDB to directly read and write data from a running PostgreSQL database instance. The data can be queried directly from the underlying PostgreSQL database. Data can be loaded from PostgreSQL tables into DuckDB tables, or vice versa. See the [official announcement]({% post_url 2022-09-30-postgres-scanner %}) for implementation details and background.

--- a/docs/stable/core_extensions/spatial/overview.md
+++ b/docs/stable/core_extensions/spatial/overview.md
@@ -7,6 +7,8 @@ redirect_from:
 - /docs/stable/extensions/spatial/
 - /docs/stable/extensions/spatial/overview
 - /docs/stable/extensions/spatial/overview/
+- /docs/extensions/spatial
+- /docs/extensions/spatial/
 ---
 
 The `spatial` extension provides support for geospatial data processing in DuckDB.

--- a/docs/stable/core_extensions/sqlite.md
+++ b/docs/stable/core_extensions/sqlite.md
@@ -6,6 +6,8 @@ redirect_from:
 - /docs/extensions/sqlite
 - /docs/stable/extensions/sqlite
 - /docs/stable/extensions/sqlite/
+- /docs/extensions/sqlite
+- /docs/extensions/sqlite/
 ---
 
 The SQLite extension allows DuckDB to directly read and write data from a SQLite database file. The data can be queried directly from the underlying SQLite tables. Data can be loaded from SQLite tables into DuckDB tables, or vice versa.

--- a/docs/stable/core_extensions/sqlsmith.md
+++ b/docs/stable/core_extensions/sqlsmith.md
@@ -5,6 +5,8 @@ title: SQLSmith Extension
 redirect_from:
 - /docs/stable/extensions/sqlsmith
 - /docs/stable/extensions/sqlsmith/
+- /docs/extensions/sqlsmith
+- /docs/extensions/sqlsmith/
 ---
 
 The `sqlsmith` extension is used for testing.

--- a/docs/stable/core_extensions/tpcds.md
+++ b/docs/stable/core_extensions/tpcds.md
@@ -5,6 +5,8 @@ title: TPC-DS Extension
 redirect_from:
 - /docs/stable/extensions/tpcds
 - /docs/stable/extensions/tpcds/
+- /docs/extensions/tpcds
+- /docs/extensions/tpcds/
 ---
 
 The `tpcds` extension implements the data generator and queries for the [TPC-DS benchmark](https://www.tpc.org/tpcds/).

--- a/docs/stable/core_extensions/tpch.md
+++ b/docs/stable/core_extensions/tpch.md
@@ -5,6 +5,8 @@ title: TPC-H Extension
 redirect_from:
 - /docs/stable/extensions/tpch
 - /docs/stable/extensions/tpch/
+- /docs/extensions/tpch
+- /docs/extensions/tpch/
 ---
 
 The `tpch` extension implements the data generator and queries for the [TPC-H benchmark](https://www.tpc.org/tpch/).

--- a/docs/stable/core_extensions/ui.md
+++ b/docs/stable/core_extensions/ui.md
@@ -5,6 +5,8 @@ title: UI Extension
 redirect_from:
 - /docs/stable/extensions/ui
 - /docs/stable/extensions/ui/
+- /docs/extensions/ui
+- /docs/extensions/ui/
 ---
 
 The `ui` extension adds a user interface for your local DuckDB instance.

--- a/docs/stable/core_extensions/vss.md
+++ b/docs/stable/core_extensions/vss.md
@@ -5,6 +5,8 @@ title: Vector Similarity Search Extension
 redirect_from:
 - /docs/stable/extensions/vss
 - /docs/stable/extensions/vss/
+- /docs/extensions/vss
+- /docs/extensions/vss/
 ---
 
 The `vss` extension is an experimental extension for DuckDB that adds indexing support to accelerate vector similarity search queries using DuckDB's new fixed-size `ARRAY` type.


### PR DESCRIPTION
Has been brought up in the Iceberg extension repo, though I would do it for all extensions

https://github.com/duckdb/duckdb-iceberg/issues/264