### PR TITLE
docs/data/csv: auto_type_candidates

### DIFF
--- a/docs/preview/data/csv/auto_detection.md
+++ b/docs/preview/data/csv/auto_detection.md
@@ -111,32 +111,33 @@ The type detection works by attempting to convert the values in each column to t
 
 |   Types   |
 |-----------|
+| NULL      |
 | BOOLEAN   |
-| BIGINT    |
-| DOUBLE    |
 | TIME      |
 | DATE      |
 | TIMESTAMP |
+| BIGINT    |
+| DOUBLE    |
 | VARCHAR   |
 
-Everything can be cast to `VARCHAR`, therefore, this type has the lowest priority meaning that all columns are converted to `VARCHAR` if they cannot be cast to anything else.
+Everything can be cast to `VARCHAR`, therefore, this type has the lowest priority meaning that all columns are converted to `VARCHAR` as a fallback if they cannot be cast to anything else.
 In [`flights.csv`](/data/flights.csv) the `FlightDate` column will be cast to a `DATE`, while the other columns will be cast to `VARCHAR`.
 
-The set of candidate types that should be considered by the CSV reader can be explicitly specified using the [`auto_type_candidates`]({% link docs/preview/data/csv/overview.md %}#auto_type_candidates-details) option.
+The set of candidate types that should be considered by the CSV reader can be specified explicitly using the [`auto_type_candidates`]({% link docs/preview/data/csv/overview.md %}#auto_type_candidates-details) option. `VARCHAR` as the fallback type will always be considered as a candidate type whether you specify it or not.
 
-In addition to the default set of candidate types, other types that may be specified using the `auto_type_candidates` options are:
+Here are all additional candidate types that may be specified using the `auto_type_candidates` option, in order of priority:
 
 <div class="monospace_table"></div>
 
 |   Types   |
 |-----------|
+| TINYINT   |
+| SMALLINT  |
+| INTEGER   |
 | DECIMAL   |
 | FLOAT     |
-| INTEGER   |
-| SMALLINT  |
-| TINYINT   |
 
-Even though the set of data types that can be automatically detected may appear quite limited, the CSV reader can configured to read arbitrarily complex types by using the `types`-option described in the next section.
+Even though the set of data types that can be automatically detected may appear quite limited, the CSV reader can be configured to read arbitrarily complex types by using the `types`-option described in the next section.
 
 Type detection can be entirely disabled by using the `all_varchar` option. If this is set all columns will remain as `VARCHAR` (as they originally occur in the CSV file).
 

--- a/docs/preview/data/csv/auto_detection.md
+++ b/docs/preview/data/csv/auto_detection.md
@@ -109,16 +109,17 @@ The type detection works by attempting to convert the values in each column to t
 
 <div class="monospace_table"></div>
 
-|   Types   |
-|-----------|
-| NULL      |
-| BOOLEAN   |
-| TIME      |
-| DATE      |
-| TIMESTAMP |
-| BIGINT    |
-| DOUBLE    |
-| VARCHAR   |
+|   Types     |
+|-------------|
+| NULL        |
+| BOOLEAN     |
+| TIME        |
+| DATE        |
+| TIMESTAMP   |
+| TIMESTAMPTZ |
+| BIGINT      |
+| DOUBLE      |
+| VARCHAR     |
 
 Everything can be cast to `VARCHAR`, therefore, this type has the lowest priority meaning that all columns are converted to `VARCHAR` as a fallback if they cannot be cast to anything else.
 In [`flights.csv`](/data/flights.csv) the `FlightDate` column will be cast to a `DATE`, while the other columns will be cast to `VARCHAR`.

--- a/docs/preview/data/csv/overview.md
+++ b/docs/preview/data/csv/overview.md
@@ -130,7 +130,7 @@ Usage example:
 SELECT * FROM read_csv('csv_file.csv', auto_type_candidates = ['BIGINT', 'DATE']);
 ```
 
-The default value for the `auto_type_candidates` option is `['SQLNULL', 'BOOLEAN', 'BIGINT', 'DOUBLE', 'TIME', 'DATE', 'TIMESTAMP', 'VARCHAR']`.
+The default value for the `auto_type_candidates` option is `['NULL', 'BOOLEAN', 'TIME', 'DATE', 'TIMESTAMP', 'BIGINT', 'DOUBLE', 'VARCHAR']`.
 
 ## CSV Functions
 

--- a/docs/preview/data/csv/overview.md
+++ b/docs/preview/data/csv/overview.md
@@ -130,7 +130,7 @@ Usage example:
 SELECT * FROM read_csv('csv_file.csv', auto_type_candidates = ['BIGINT', 'DATE']);
 ```
 
-The default value for the `auto_type_candidates` option is `['NULL', 'BOOLEAN', 'TIME', 'DATE', 'TIMESTAMP', 'BIGINT', 'DOUBLE', 'VARCHAR']`.
+The default value for the `auto_type_candidates` option is `['NULL', 'BOOLEAN', 'TIME', 'DATE', 'TIMESTAMP', 'TIMESTAMPTZ', 'BIGINT', 'DOUBLE', 'VARCHAR']`.
 
 ## CSV Functions
 


### PR DESCRIPTION
I split both changes so 09901dd88b58b334d0edad42f2c9eb08dca29c3a can be applied later to docs folder 1.2

Both commits should be applied to folder stable as well.

I'm planning on correcting the order of https://github.com/duckdb/duckdb/blob/dcf0e1c8936d74be48fd1cc0309638117b43aa47/src/include/duckdb/execution/operator/csv_scanner/csv_reader_options.hpp#L82-L86 so it matches the actual specificity defined here: https://github.com/duckdb/duckdb/blob/dcf0e1c8936d74be48fd1cc0309638117b43aa47/src/execution/operator/csv_scanner/util/csv_reader_options.cpp#L523-L530 .

Disclaimer: This was verified using the Python API and SQL commands.
I could not find the code that maps NULL to SQLNULL. The DuckDB code base uses SQLNULL and TIMESTAMP_TZ instead of NULL and TIMESTAMPTZ like the external SQL API. 