### PR TITLE
[Docs][Iceberg] remove catalog re-attach limitation

### DIFF
--- a/docs/preview/core_extensions/iceberg/troubleshooting.md
+++ b/docs/preview/core_extensions/iceberg/troubleshooting.md
@@ -5,7 +5,6 @@ title: Troubleshooting
 
 ## Limitations
 
-* The catalog is not refreshed automatically. To update the list of table in the catalog, `DETACH` from the catalog and `ATTACH` again.
 * Reading tables with deletes is not yet supported.
 
 ## Curl Request Fails


### PR DESCRIPTION
This was resolved by https://github.com/duckdb/duckdb-iceberg/pull/259 

Also see
- https://github.com/duckdb/duckdb-web/issues/5416
- https://github.com/duckdb/duckdb-iceberg/issues/247