### PR TITLE
Fix bug in with.md

### DIFF
--- a/docs/1.1/sql/query_syntax/with.md
+++ b/docs/1.1/sql/query_syntax/with.md
@@ -36,7 +36,7 @@ SELECT * FROM cte2;
 
 ## CTE Materialization
 
-DuckDB can employ CTE materialization, i.e., inlining CTEs into the main query.
+DuckDB can employ CTE materialization, instead of inlining CTEs into the main query.
 This is performed using heuristics: if the CTE performs a grouped aggregation and is queried more than once, it is materialized.
 Materialization can be explicitly activated by defining the CTE using `AS MATERIALIZED` and disabled by using `AS NOT MATERIALIZED`.
 

--- a/docs/preview/sql/query_syntax/with.md
+++ b/docs/preview/sql/query_syntax/with.md
@@ -43,7 +43,7 @@ FROM cte;
 
 ## CTE Materialization
 
-DuckDB can employ CTE materialization, i.e., inlining CTEs into the main query.
+DuckDB can employ CTE materialization, instead of inlining CTEs into the main query.
 This is performed using heuristics: if the CTE performs a grouped aggregation and is queried more than once, it is materialized.
 Materialization can be explicitly activated by defining the CTE using `AS MATERIALIZED` and disabled by using `AS NOT MATERIALIZED`.
 

--- a/docs/stable/sql/query_syntax/with.md
+++ b/docs/stable/sql/query_syntax/with.md
@@ -45,7 +45,7 @@ FROM cte;
 
 ## CTE Materialization
 
-DuckDB can employ CTE materialization, i.e., inlining CTEs into the main query.
+DuckDB can employ CTE materialization, instead of inlining CTEs into the main query.
 This is performed using heuristics: if the CTE performs a grouped aggregation and is queried more than once, it is materialized.
 Materialization can be explicitly activated by defining the CTE using `AS MATERIALIZED` and disabled by using `AS NOT MATERIALIZED`.
 


### PR DESCRIPTION
CTE materialization is the "opposite" of inlining. I fixed that sentence.