### PR TITLE
Fixed typos in ST_Read examples in functions.md

### DIFF
--- a/docs/stable/core_extensions/spatial/functions.md
+++ b/docs/stable/core_extensions/spatial/functions.md
@@ -2855,10 +2855,10 @@ The following formats are currently recognized by their file extension:
 
 ```sql
 -- Read a Shapefile
-ELECT * FROM ST_Read('some/file/path/filename.shp');
+SELECT * FROM ST_Read('some/file/path/filename.shp');
 
 - Read a GeoJSON file
-REATE TABLE my_geojson_table AS SELECT * FROM ST_Read('some/file/path/filename.json');
+CREATE TABLE my_geojson_table AS SELECT * FROM ST_Read('some/file/path/filename.json');
 ```
 
 ----


### PR DESCRIPTION
The first letter of SELECT and CREATE in this example were omitted. This PR adds those back.