### PR TITLE
Prune alias entries

### DIFF
--- a/docs/preview/sql/functions/array.md
+++ b/docs/preview/sql/functions/array.md
@@ -17,9 +17,9 @@ All [`LIST` functions]({% link docs/preview/sql/functions/list.md %}) work with 
 | [`array_cosine_similarity(array1, array2)`](#array_cosine_similarityarray1-array2) | Computes the cosine similarity between two arrays of the same size. The array elements can not be `NULL`. The arrays can have any size as long as the size is the same for both arguments. |
 | [`array_cross_product(array, array)`](#array_cross_productarray-array) | Computes the cross product of two arrays of size 3. The array elements can not be `NULL`. |
 | [`array_distance(array1, array2)`](#array_distancearray1-array2) | Computes the distance between two arrays of the same size. The array elements can not be `NULL`. The arrays can have any size as long as the size is the same for both arguments. |
-| [`array_dot_product(array1, array2)`](#array_dot_productarray1-array2) | Computes the inner product between two arrays of the same size. The array elements can not be `NULL`. The arrays can have any size as long as the size is the same for both arguments. |
+| [`array_dot_product(array1, array2)`](#array_inner_productarray1-array2) | Alias for `array_inner_product`. |
 | [`array_inner_product(array1, array2)`](#array_inner_productarray1-array2) | Computes the inner product between two arrays of the same size. The array elements can not be `NULL`. The arrays can have any size as long as the size is the same for both arguments. |
-| [`array_negative_dot_product(array1, array2)`](#array_negative_dot_productarray1-array2) | Computes the negative inner product between two arrays of the same size. The array elements can not be `NULL`. The arrays can have any size as long as the size is the same for both arguments. |
+| [`array_negative_dot_product(array1, array2)`](#array_negative_inner_productarray1-array2) | Alias for `array_negative_inner_product`. |
 | [`array_negative_inner_product(array1, array2)`](#array_negative_inner_productarray1-array2) | Computes the negative inner product between two arrays of the same size. The array elements can not be `NULL`. The arrays can have any size as long as the size is the same for both arguments. |
 | [`array_value(arg, ...)`](#array_valuearg-) | Creates an `ARRAY` containing the argument values. |
 
@@ -57,15 +57,6 @@ All [`LIST` functions]({% link docs/preview/sql/functions/list.md %}) work with 
 | **Example** | `array_distance(array_value(1.0::FLOAT, 2.0::FLOAT, 3.0::FLOAT), array_value(2.0::FLOAT, 3.0::FLOAT, 4.0::FLOAT))` |
 | **Result** | `1.7320508` |
 
-#### `array_dot_product(array1, array2)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Computes the inner product between two arrays of the same size. The array elements can not be `NULL`. The arrays can have any size as long as the size is the same for both arguments. |
-| **Example** | `array_dot_product(array_value(1.0::FLOAT, 2.0::FLOAT, 3.0::FLOAT), array_value(2.0::FLOAT, 3.0::FLOAT, 4.0::FLOAT))` |
-| **Result** | `20.0` |
-| **Alias** | `array_inner_product` |
-
 #### `array_inner_product(array1, array2)`
 
 <div class="nostroke_table"></div>
@@ -74,15 +65,6 @@ All [`LIST` functions]({% link docs/preview/sql/functions/list.md %}) work with 
 | **Example** | `array_inner_product(array_value(1.0::FLOAT, 2.0::FLOAT, 3.0::FLOAT), array_value(2.0::FLOAT, 3.0::FLOAT, 4.0::FLOAT))` |
 | **Result** | `20.0` |
 | **Alias** | `array_dot_product` |
-
-#### `array_negative_dot_product(array1, array2)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Computes the negative inner product between two arrays of the same size. The array elements can not be `NULL`. The arrays can have any size as long as the size is the same for both arguments. |
-| **Example** | `array_negative_dot_product(array_value(1.0::FLOAT, 2.0::FLOAT, 3.0::FLOAT), array_value(2.0::FLOAT, 3.0::FLOAT, 4.0::FLOAT))` |
-| **Result** | `-20.0` |
-| **Alias** | `array_negative_inner_product` |
 
 #### `array_negative_inner_product(array1, array2)`
 

--- a/docs/preview/sql/functions/blob.md
+++ b/docs/preview/sql/functions/blob.md
@@ -13,12 +13,12 @@ This section describes functions and operators for examining and manipulating [`
 | Function | Description |
 |:--|:-------|
 | [`arg1 || arg2`](#arg1--arg2) | Concatenates two strings, lists, or blobs. Any `NULL` input results in `NULL`. See also [`concat(arg1, arg2, ...)`]({% link docs/preview/sql/functions/text.md %}#concatvalue-) and [`list_concat(list1, list2, ...)`]({% link docs/preview/sql/functions/list.md %}#list_concatlist_1--list_n). |
-| [`base64(blob)`](#base64blob) | Converts a `blob` to a base64 encoded string. |
+| [`base64(blob)`](#to_base64blob) | Alias for `to_base64`. |
 | [`decode(blob)`](#decodeblob) | Converts `blob` to `VARCHAR`. Fails if `blob` is not valid UTF-8. |
 | [`encode(string)`](#encodestring) | Converts the `string` to `BLOB`. Converts UTF-8 characters into literal encoding. |
 | [`from_base64(string)`](#from_base64string) | Converts a base64 encoded `string` to a character string (`BLOB`). |
-| [`from_binary(value)`](#from_binaryvalue) | Converts a `value` from binary representation to a blob. |
-| [`from_hex(value)`](#from_hexvalue) | Converts a `value` from hexadecimal representation to a blob. |
+| [`from_binary(value)`](#unbinvalue) | Alias for `unbin`. |
+| [`from_hex(value)`](#unhexvalue) | Alias for `unhex`. |
 | [`hex(blob)`](#hexblob) | Converts `blob` to `VARCHAR` using hexadecimal encoding. |
 | [`md5(blob)`](#md5blob) | Returns the MD5 hash of the `blob` as a `VARCHAR`. |
 | [`md5_number(blob)`](#md5_numberblob) | Returns the MD5 hash of the `blob` as a `HUGEINT`. |
@@ -28,7 +28,7 @@ This section describes functions and operators for examining and manipulating [`
 | [`sha1(blob)`](#sha1blob) | Returns a `VARCHAR` with the SHA-1 hash of the `blob`. |
 | [`sha256(blob)`](#sha256blob) | Returns a `VARCHAR` with the SHA-256 hash of the `blob`. |
 | [`to_base64(blob)`](#to_base64blob) | Converts a `blob` to a base64 encoded string. |
-| [`to_hex(blob)`](#to_hexblob) | Converts `blob` to `VARCHAR` using hexadecimal encoding. |
+| [`to_hex(blob)`](#hexblob) | Alias for `hex`. |
 | [`unbin(value)`](#unbinvalue) | Converts a `value` from binary representation to a blob. |
 | [`unhex(value)`](#unhexvalue) | Converts a `value` from hexadecimal representation to a blob. |
 
@@ -45,15 +45,6 @@ This section describes functions and operators for examining and manipulating [`
 | **Result** | `[1, 2, 3, 4, 5, 6]` |
 | **Example 3** | `'\xAA'::BLOB || '\xBB'::BLOB` |
 | **Result** | `\xAA\xBB` |
-
-#### `base64(blob)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Converts a `blob` to a base64 encoded string. |
-| **Example** | `base64('A'::BLOB)` |
-| **Result** | `QQ==` |
-| **Alias** | `to_base64` |
 
 #### `decode(blob)`
 
@@ -78,24 +69,6 @@ This section describes functions and operators for examining and manipulating [`
 | **Description** | Converts a base64 encoded `string` to a character string (`BLOB`). |
 | **Example** | `from_base64('QQ==')` |
 | **Result** | `A` |
-
-#### `from_binary(value)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Converts a `value` from binary representation to a blob. |
-| **Example** | `from_binary('0110')` |
-| **Result** | `\x06` |
-| **Alias** | `unbin` |
-
-#### `from_hex(value)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Converts a `value` from hexadecimal representation to a blob. |
-| **Example** | `from_hex('2A')` |
-| **Result** | `*` |
-| **Alias** | `unhex` |
 
 #### `hex(blob)`
 
@@ -170,15 +143,6 @@ This section describes functions and operators for examining and manipulating [`
 | **Example** | `to_base64('A'::BLOB)` |
 | **Result** | `QQ==` |
 | **Alias** | `base64` |
-
-#### `to_hex(blob)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Converts `blob` to `VARCHAR` using hexadecimal encoding. |
-| **Example** | `to_hex('\xAA\xBB'::BLOB)` |
-| **Result** | `AABB` |
-| **Alias** | `hex` |
 
 #### `unbin(value)`
 

--- a/docs/preview/sql/functions/lambda.md
+++ b/docs/preview/sql/functions/lambda.md
@@ -42,82 +42,19 @@ For example, the following are all valid lambda functions:
 
 | Function | Description |
 |:--|:-------|
-| [`apply(list, lambda(x))`](#applylist-lambdax) | Returns a list that is the result of applying the `lambda` function to each element of the input `list`. The return type is defined by the return type of the `lambda` function. See [`list_transform` examples]({% link docs/preview/sql/functions/lambda.md %}#list_transform-examples). |
-| [`array_apply(list, lambda(x))`](#array_applylist-lambdax) | Returns a list that is the result of applying the `lambda` function to each element of the input `list`. The return type is defined by the return type of the `lambda` function. See [`list_transform` examples]({% link docs/preview/sql/functions/lambda.md %}#list_transform-examples). |
-| [`array_filter(list, lambda(x))`](#array_filterlist-lambdax) | Constructs a list from those elements of the input `list` for which the `lambda` function returns `true`. DuckDB must be able to cast the `lambda` function's return type to `BOOL`. The return type of `list_filter` is the same as the input list's. See [`list_filter` examples]({% link docs/preview/sql/functions/lambda.md %}#list_filter-examples). |
-| [`array_reduce(list, lambda(x,y)[, initial_value])`](#array_reducelist-lambdaxy-initial_value) | Reduces all elements of the input `list` into a single scalar value by executing the `lambda` function on a running result and the next list element. The `lambda` function has an optional `initial_value` argument. See [`list_reduce` examples]({% link docs/preview/sql/functions/lambda.md %}#list_reduce-examples). |
-| [`array_transform(list, lambda(x))`](#array_transformlist-lambdax) | Returns a list that is the result of applying the `lambda` function to each element of the input `list`. The return type is defined by the return type of the `lambda` function. See [`list_transform` examples]({% link docs/preview/sql/functions/lambda.md %}#list_transform-examples). |
-| [`filter(list, lambda(x))`](#filterlist-lambdax) | Constructs a list from those elements of the input `list` for which the `lambda` function returns `true`. DuckDB must be able to cast the `lambda` function's return type to `BOOL`. The return type of `list_filter` is the same as the input list's. See [`list_filter` examples]({% link docs/preview/sql/functions/lambda.md %}#list_filter-examples). |
-| [`list_apply(list, lambda(x))`](#list_applylist-lambdax) | Returns a list that is the result of applying the `lambda` function to each element of the input `list`. The return type is defined by the return type of the `lambda` function. See [`list_transform` examples]({% link docs/preview/sql/functions/lambda.md %}#list_transform-examples). |
+| [`apply(list, lambda(x))`](#list_transformlist-lambdax) | Alias for `list_transform`. |
+| [`array_apply(list, lambda(x))`](#list_transformlist-lambdax) | Alias for `list_transform`. |
+| [`array_filter(list, lambda(x))`](#list_filterlist-lambdax) | Alias for `list_filter`. |
+| [`array_reduce(list, lambda(x,y)[, initial_value])`](#list_reducelist-lambdaxy-initial_value) | Alias for `list_reduce`. |
+| [`array_transform(list, lambda(x))`](#list_transformlist-lambdax) | Alias for `list_transform`. |
+| [`filter(list, lambda(x))`](#list_filterlist-lambdax) | Alias for `list_filter`. |
+| [`list_apply(list, lambda(x))`](#list_transformlist-lambdax) | Alias for `list_transform`. |
 | [`list_filter(list, lambda(x))`](#list_filterlist-lambdax) | Constructs a list from those elements of the input `list` for which the `lambda` function returns `true`. DuckDB must be able to cast the `lambda` function's return type to `BOOL`. The return type of `list_filter` is the same as the input list's. See [`list_filter` examples]({% link docs/preview/sql/functions/lambda.md %}#list_filter-examples). |
 | [`list_reduce(list, lambda(x,y)[, initial_value])`](#list_reducelist-lambdaxy-initial_value) | Reduces all elements of the input `list` into a single scalar value by executing the `lambda` function on a running result and the next list element. The `lambda` function has an optional `initial_value` argument. See [`list_reduce` examples]({% link docs/preview/sql/functions/lambda.md %}#list_reduce-examples). |
 | [`list_transform(list, lambda(x))`](#list_transformlist-lambdax) | Returns a list that is the result of applying the `lambda` function to each element of the input `list`. The return type is defined by the return type of the `lambda` function. See [`list_transform` examples]({% link docs/preview/sql/functions/lambda.md %}#list_transform-examples). |
-| [`reduce(list, lambda(x,y)[, initial_value])`](#reducelist-lambdaxy-initial_value) | Reduces all elements of the input `list` into a single scalar value by executing the `lambda` function on a running result and the next list element. The `lambda` function has an optional `initial_value` argument. See [`list_reduce` examples]({% link docs/preview/sql/functions/lambda.md %}#list_reduce-examples). |
+| [`reduce(list, lambda(x,y)[, initial_value])`](#list_reducelist-lambdaxy-initial_value) | Alias for `list_reduce`. |
 
 <!-- markdownlint-enable MD056 -->
-
-#### `apply(list, lambda(x))`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Returns a list that is the result of applying the `lambda` function to each element of the input `list`. The return type is defined by the return type of the `lambda` function. See [`list_transform` examples]({% link docs/preview/sql/functions/lambda.md %}#list_transform-examples). |
-| **Example** | `apply([1, 2, 3], lambda x : x + 1)` |
-| **Result** | `[2, 3, 4]` |
-| **Aliases** | `array_apply`, `array_transform`, `list_apply`, `list_transform` |
-
-#### `array_apply(list, lambda(x))`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Returns a list that is the result of applying the `lambda` function to each element of the input `list`. The return type is defined by the return type of the `lambda` function. See [`list_transform` examples]({% link docs/preview/sql/functions/lambda.md %}#list_transform-examples). |
-| **Example** | `array_apply([1, 2, 3], lambda x : x + 1)` |
-| **Result** | `[2, 3, 4]` |
-| **Aliases** | `apply`, `array_transform`, `list_apply`, `list_transform` |
-
-#### `array_filter(list, lambda(x))`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Constructs a list from those elements of the input `list` for which the `lambda` function returns `true`. DuckDB must be able to cast the `lambda` function's return type to `BOOL`. The return type of `list_filter` is the same as the input list's. See [`list_filter` examples]({% link docs/preview/sql/functions/lambda.md %}#list_filter-examples). |
-| **Example** | `array_filter([3, 4, 5], lambda x : x > 4)` |
-| **Result** | `[5]` |
-| **Aliases** | `filter`, `list_filter` |
-
-#### `array_reduce(list, lambda(x,y)[, initial_value])`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Reduces all elements of the input `list` into a single scalar value by executing the `lambda` function on a running result and the next list element. The `lambda` function has an optional `initial_value` argument. See [`list_reduce` examples]({% link docs/preview/sql/functions/lambda.md %}#list_reduce-examples). |
-| **Example** | `array_reduce([1, 2, 3], lambda x, y : x + y)` |
-| **Result** | `6` |
-| **Aliases** | `list_reduce`, `reduce` |
-
-#### `array_transform(list, lambda(x))`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Returns a list that is the result of applying the `lambda` function to each element of the input `list`. The return type is defined by the return type of the `lambda` function. See [`list_transform` examples]({% link docs/preview/sql/functions/lambda.md %}#list_transform-examples). |
-| **Example** | `array_transform([1, 2, 3], lambda x : x + 1)` |
-| **Result** | `[2, 3, 4]` |
-| **Aliases** | `apply`, `array_apply`, `list_apply`, `list_transform` |
-
-#### `filter(list, lambda(x))`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Constructs a list from those elements of the input `list` for which the `lambda` function returns `true`. DuckDB must be able to cast the `lambda` function's return type to `BOOL`. The return type of `list_filter` is the same as the input list's. See [`list_filter` examples]({% link docs/preview/sql/functions/lambda.md %}#list_filter-examples). |
-| **Example** | `filter([3, 4, 5], lambda x : x > 4)` |
-| **Result** | `[5]` |
-| **Aliases** | `array_filter`, `list_filter` |
-
-#### `list_apply(list, lambda(x))`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Returns a list that is the result of applying the `lambda` function to each element of the input `list`. The return type is defined by the return type of the `lambda` function. See [`list_transform` examples]({% link docs/preview/sql/functions/lambda.md %}#list_transform-examples). |
-| **Example** | `list_apply([1, 2, 3], lambda x : x + 1)` |
-| **Result** | `[2, 3, 4]` |
-| **Aliases** | `apply`, `array_apply`, `array_transform`, `list_transform` |
 
 #### `list_filter(list, lambda(x))`
 
@@ -145,15 +82,6 @@ For example, the following are all valid lambda functions:
 | **Example** | `list_transform([1, 2, 3], lambda x : x + 1)` |
 | **Result** | `[2, 3, 4]` |
 | **Aliases** | `apply`, `array_apply`, `array_transform`, `list_apply` |
-
-#### `reduce(list, lambda(x,y)[, initial_value])`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Reduces all elements of the input `list` into a single scalar value by executing the `lambda` function on a running result and the next list element. The `lambda` function has an optional `initial_value` argument. See [`list_reduce` examples]({% link docs/preview/sql/functions/lambda.md %}#list_reduce-examples). |
-| **Example** | `reduce([1, 2, 3], lambda x, y : x + y)` |
-| **Result** | `6` |
-| **Aliases** | `array_reduce`, `list_reduce` |
 
 <!-- End of section generated by scripts/generate_sql_function_docs.py -->
 

--- a/docs/preview/sql/functions/list.md
+++ b/docs/preview/sql/functions/list.md
@@ -825,9 +825,9 @@ The following operators are supported for lists:
 | Operator | Description | Example | Result |
 |-|--|---|-|
 | `&&`  | Alias for [`list_has_any`](#list_has_anylist1-list2).                                                                   | `[1, 2, 3, 4, 5] && [2, 5, 5, 6]` | `true`               |
-| `@>`  | Alias for [`list_has_all`](#list_has_alllist-sub-list), where the list on the **right** of the operator is the sublist. | `[1, 2, 3, 4] @> [3, 4, 3]`       | `true`               |
-| `<@`  | Alias for [`list_has_all`](#list_has_alllist-sub-list), where the list on the **left** of the operator is the sublist.  | `[1, 4] <@ [1, 2, 3, 4]`          | `true`               |
-| `||`  | Similar to [`list_concat`](#list_concatlist1--listn), except any `NULL` input results in `NULL`.                        | `[1, 2, 3] || [4, 5, 6]`          | `[1, 2, 3, 4, 5, 6]` |
+| `@>`  | Alias for [`list_has_all`](#list_has_alllist1-list2), where the list on the **right** of the operator is the sublist. | `[1, 2, 3, 4] @> [3, 4, 3]`       | `true`               |
+| `<@`  | Alias for [`list_has_all`](#list_has_alllist1-list2), where the list on the **left** of the operator is the sublist.  | `[1, 4] <@ [1, 2, 3, 4]`          | `true`               |
+| `||`  | Similar to [`list_concat`](#list_concatlist_1--list_n), except any `NULL` input results in `NULL`.                        | `[1, 2, 3] || [4, 5, 6]`          | `[1, 2, 3, 4, 5, 6]` |
 | `<=>` | Alias for [`list_cosine_distance`](#list_cosine_distancelist1-list2).                                                   | `[1, 2, 3] <=> [1, 2, 5]`         | `0.007416606`        |
 | `<->` | Alias for [`list_distance`](#list_distancelist1-list2).                                                                 | `[1, 2, 3] <-> [1, 2, 5]`         | `2.0`                |
 

--- a/docs/preview/sql/functions/list.md
+++ b/docs/preview/sql/functions/list.md
@@ -22,12 +22,10 @@ title: List Functions
 | [`apply(list, lambda(x))`](#list_transformlist-lambdax) | Alias for `list_transform`. |
 | [`array_aggr(list, function_name, ...)`](#list_aggregatelist-function_name-) | Alias for `list_aggregate`. |
 | [`array_aggregate(list, function_name, ...)`](#list_aggregatelist-function_name-) | Alias for `list_aggregate`. |
-| [`array_append(list, element)`](#array_appendlist-element) | Appends `element` to `list`. |
+| [`array_append(list, element)`](#list_appendlist-element) | Alias for `list_append`. |
 | [`array_apply(list, lambda(x))`](#list_transformlist-lambdax) | Alias for `list_transform`. |
-| [`array_cat()`](#array_cat) | Concatenates lists. `NULL` inputs are skipped. See also [operator `||`](#arg1--arg2). |
-| [`array_cat(list_1, ..., list_n)`](#array_catlist_1--list_n) | Concatenates lists. `NULL` inputs are skipped. See also [operator `||`](#arg1--arg2). |
-| [`array_concat()`](#array_concat) | Concatenates lists. `NULL` inputs are skipped. See also [operator `||`](#arg1--arg2). |
-| [`array_concat(list_1, ..., list_n)`](#array_concatlist_1--list_n) | Concatenates lists. `NULL` inputs are skipped. See also [operator `||`](#arg1--arg2). |
+| [`array_cat(list_1, ..., list_n)`](#list_concatlist_1--list_n) | Alias for `list_concat`. |
+| [`array_concat(list_1, ..., list_n)`](#list_concatlist_1--list_n) | Alias for `list_concat`. |
 | [`array_contains(list, element)`](#list_containslist-element) | Alias for `list_contains`. |
 | [`array_distinct(list)`](#list_distinctlist) | Alias for `list_distinct`. |
 | [`array_extract(list, index)`](#array_extractlist-index) | Extracts the `index`th (1-based) value from the `list`. |
@@ -37,18 +35,17 @@ title: List Functions
 | [`array_has_all(list1, list2)`](#list_has_alllist1-list2) | Alias for `list_has_all`. |
 | [`array_has_any(list1, list2)`](#list_has_anylist1-list2) | Alias for `list_has_any`. |
 | [`array_indexof(list, element)`](#list_positionlist-element) | Alias for `list_position`. |
-| [`array_intersect(list1, list2)`](#array_intersectlist1-list2) | Returns a list of all the elements that exist in both `list1` and `list2`, without duplicates. |
-| [`array_length(list)`](#array_lengthlist) | Returns the length of the `list`. |
-| [`array_length(list, dimension)`](#array_lengthlist-dimension) | `array_length` for lists with dimensions other than 1 not implemented |
+| [`array_intersect(list1, list2)`](#list_intersectlist1-list2) | Alias for `list_intersect`. |
+| [`array_length(list)`](#lengthlist) | Alias for `length`. |
 | [`array_pop_back(list)`](#array_pop_backlist) | Returns the `list` without the last element. |
 | [`array_pop_front(list)`](#array_pop_frontlist) | Returns the `list` without the first element. |
 | [`array_position(list, element)`](#list_positionlist-element) | Alias for `list_position`. |
-| [`array_prepend(element, list)`](#array_prependelement-list) | Prepends `element` to `list`. |
-| [`array_push_back(list, element)`](#array_push_backlist-element) | Appends `element` to `list`. |
+| [`array_prepend(element, list)`](#list_prependelement-list) | Alias for `list_prepend`. |
+| [`array_push_back(list, element)`](#list_appendlist-element) | Alias for `list_append`. |
 | [`array_push_front(list, element)`](#array_push_frontlist-element) | Prepends `element` to `list`. |
 | [`array_reduce(list, lambda(x,y)[, initial_value])`](#list_reducelist-lambdaxy-initial_value) | Alias for `list_reduce`. |
 | [`array_resize(list, size[[, value]])`](#list_resizelist-size-value) | Alias for `list_resize`. |
-| [`array_reverse(list)`](#array_reverselist) | Reverses the `list`. |
+| [`array_reverse(list)`](#list_reverselist) | Alias for `list_reverse`. |
 | [`array_reverse_sort(list[, col1])`](#list_reverse_sortlist-col1) | Alias for `list_reverse_sort`. |
 | [`array_select(value_list, index_list)`](#list_selectvalue_list-index_list) | Alias for `list_select`. |
 | [`array_slice(list, begin, end)`](#list_slicelist-begin-end) | Alias for `list_slice`. |
@@ -59,8 +56,7 @@ title: List Functions
 | [`array_transform(list, lambda(x))`](#list_transformlist-lambdax) | Alias for `list_transform`. |
 | [`array_unique(list)`](#list_uniquelist) | Alias for `list_unique`. |
 | [`array_where(value_list, mask_list)`](#list_wherevalue_list-mask_list) | Alias for `list_where`. |
-| [`array_zip(arg, ...)`](#array_ziparg-) | Zips n `LIST`s to a new `LIST` whose length will be that of the longest list. Its elements are structs of n elements from each list `list_1`, …, `list_n`, missing elements are replaced with `NULL`. If `truncate` is set, all lists are truncated to the smallest list length. |
-| [`array_zip(list_1, ..., list_n[, truncate])`](#array_ziplist_1--list_n-truncate) | Zips n `LIST`s to a new `LIST` whose length will be that of the longest list. Its elements are structs of n elements from each list `list_1`, …, `list_n`, missing elements are replaced with `NULL`. If `truncate` is set, all lists are truncated to the smallest list length. |
+| [`array_zip(list_1, ..., list_n[, truncate])`](#list_ziplist_1--list_n-truncate) | Alias for `list_zip`. |
 | [`char_length(list)`](#lengthlist) | Alias for `length`. |
 | [`character_length(list)`](#lengthlist) | Alias for `length`. |
 | [`concat(value, ...)`](#concatvalue-) | Concatenates multiple strings or lists. `NULL` inputs are skipped. See also [operator `||`](#arg1--arg2). |
@@ -83,8 +79,7 @@ title: List Functions
 | [`list_bit_xor(list)`](#list_bit_xorlist) | Applies aggregate function [`bit_xor`]({% link docs/preview/sql/functions/aggregates.md %}#general-aggregate-functions) to the `list`. |
 | [`list_bool_and(list)`](#list_bool_andlist) | Applies aggregate function [`bool_and`]({% link docs/preview/sql/functions/aggregates.md %}#general-aggregate-functions) to the `list`. |
 | [`list_bool_or(list)`](#list_bool_orlist) | Applies aggregate function [`bool_or`]({% link docs/preview/sql/functions/aggregates.md %}#general-aggregate-functions) to the `list`. |
-| [`list_cat()`](#list_cat) | Concatenates lists. `NULL` inputs are skipped. See also [operator `||`](#arg1--arg2). |
-| [`list_cat(list_1, ..., list_n)`](#list_catlist_1--list_n) | Concatenates lists. `NULL` inputs are skipped. See also [operator `||`](#arg1--arg2). |
+| [`list_cat(list_1, ..., list_n)`](#list_concatlist_1--list_n) | Alias for `list_concat`. |
 | [`list_concat(list_1, ..., list_n)`](#list_concatlist_1--list_n) | Concatenates lists. `NULL` inputs are skipped. See also [operator `||`](#arg1--arg2). |
 | [`list_contains(list, element)`](#list_containslist-element) | Returns true if the list contains the element. |
 | [`list_cosine_distance(list1, list2)`](#list_cosine_distancelist1-list2) | Computes the cosine distance between two same-sized lists. |
@@ -179,51 +174,6 @@ title: List Functions
 | **Example 3** | `'\xAA'::BLOB || '\xBB'::BLOB` |
 | **Result** | `\xAA\xBB` |
 
-#### `array_append(list, element)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Appends `element` to `list`. |
-| **Example** | `array_append([2, 3], 4)` |
-| **Result** | `[2, 3, 4]` |
-| **Aliases** | `array_push_back`, `list_append` |
-
-#### `array_cat()`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Concatenates lists. `NULL` inputs are skipped. See also [operator `||`](#arg1--arg2). |
-| **Example** | `array_cat([2, 3], [4, 5, 6], [7])` |
-| **Result** | `[2, 3, 4, 5, 6, 7]` |
-| **Aliases** | `array_concat`, `list_cat`, `list_concat` |
-
-#### `array_cat(list_1, ..., list_n)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Concatenates lists. `NULL` inputs are skipped. See also [operator `||`](#arg1--arg2). |
-| **Example** | `array_cat([2, 3], [4, 5, 6], [7])` |
-| **Result** | `[2, 3, 4, 5, 6, 7]` |
-| **Aliases** | `list_cat`, `array_concat`, `list_concat` |
-
-#### `array_concat()`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Concatenates lists. `NULL` inputs are skipped. See also [operator `||`](#arg1--arg2). |
-| **Example** | `array_concat([2, 3], [4, 5, 6], [7])` |
-| **Result** | `[2, 3, 4, 5, 6, 7]` |
-| **Aliases** | `array_cat`, `list_cat`, `list_concat` |
-
-#### `array_concat(list_1, ..., list_n)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Concatenates lists. `NULL` inputs are skipped. See also [operator `||`](#arg1--arg2). |
-| **Example** | `array_concat([2, 3], [4, 5, 6], [7])` |
-| **Result** | `[2, 3, 4, 5, 6, 7]` |
-| **Aliases** | `list_cat`, `array_cat`, `list_concat` |
-
 #### `array_extract(list, index)`
 
 <div class="nostroke_table"></div>
@@ -231,31 +181,6 @@ title: List Functions
 | **Description** | Extracts the `index`th (1-based) value from the `list`. |
 | **Example** | `array_extract([4, 5, 6], 3)` |
 | **Result** | `6` |
-
-#### `array_intersect(list1, list2)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Returns a list of all the elements that exist in both `list1` and `list2`, without duplicates. |
-| **Example** | `array_intersect([1, 2, 3], [2, 3, 4])` |
-| **Result** | `[3, 2]` |
-| **Alias** | `list_intersect` |
-
-#### `array_length(list)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Returns the length of the `list`. |
-| **Example** | `array_length([1, 2, 3])` |
-| **Result** | `3` |
-
-#### `array_length(list, dimension)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | `array_length` for lists with dimensions other than 1 not implemented |
-| **Example** | `array_length([1, 2, 3])` |
-| **Result** | `3` |
 
 #### `array_pop_back(list)`
 
@@ -273,24 +198,6 @@ title: List Functions
 | **Example** | `array_pop_front([4, 5, 6])` |
 | **Result** | `[5, 6]` |
 
-#### `array_prepend(element, list)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Prepends `element` to `list`. |
-| **Example** | `array_prepend(3, [4, 5, 6])` |
-| **Result** | `[3, 4, 5, 6]` |
-| **Alias** | `list_prepend` |
-
-#### `array_push_back(list, element)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Appends `element` to `list`. |
-| **Example** | `array_push_back([2, 3], 4)` |
-| **Result** | `[2, 3, 4]` |
-| **Aliases** | `array_append`, `list_append` |
-
 #### `array_push_front(list, element)`
 
 <div class="nostroke_table"></div>
@@ -298,15 +205,6 @@ title: List Functions
 | **Description** | Prepends `element` to `list`. |
 | **Example** | `array_push_front([4, 5, 6], 3)` |
 | **Result** | `[3, 4, 5, 6]` |
-
-#### `array_reverse(list)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Reverses the `list`. |
-| **Example** | `array_reverse([3, 6, 1, 2])` |
-| **Result** | `[2, 1, 6, 3]` |
-| **Alias** | `list_reverse` |
 
 #### `array_to_string(list, delimiter)`
 
@@ -325,32 +223,6 @@ title: List Functions
 | **Description** | Concatenates list/array elements with a comma delimiter. |
 | **Example** | `array_to_string_comma_default(['Banana', 'Apple', 'Melon'])` |
 | **Result** | `Banana,Apple,Melon` |
-
-#### `array_zip(arg, ...)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Zips n `LIST`s to a new `LIST` whose length will be that of the longest list. Its elements are structs of n elements from each list `list_1`, …, `list_n`, missing elements are replaced with `NULL`. If `truncate` is set, all lists are truncated to the smallest list length. |
-| **Example 1** | `array_zip([1, 2], [3, 4], [5, 6])` |
-| **Result** | `[(1, 3, 5), (2, 4, 6)]` |
-| **Example 2** | `array_zip([1, 2], [3, 4], [5, 6, 7])` |
-| **Result** | `[(1, 3, 5), (2, 4, 6), (NULL, NULL, 7)]` |
-| **Example 3** | `array_zip([1, 2], [3, 4], [5, 6, 7], true)` |
-| **Result** | `[(1, 3, 5), (2, 4, 6)]` |
-| **Alias** | `list_zip` |
-
-#### `array_zip(list_1, ..., list_n[, truncate])`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Zips n `LIST`s to a new `LIST` whose length will be that of the longest list. Its elements are structs of n elements from each list `list_1`, …, `list_n`, missing elements are replaced with `NULL`. If `truncate` is set, all lists are truncated to the smallest list length. |
-| **Example 1** | `array_zip([1, 2], [3, 4], [5, 6])` |
-| **Result** | `[(1, 3, 5), (2, 4, 6)]` |
-| **Example 2** | `array_zip([1, 2], [3, 4], [5, 6, 7])` |
-| **Result** | `[(1, 3, 5), (2, 4, 6), (NULL, NULL, 7)]` |
-| **Example 3** | `array_zip([1, 2], [3, 4], [5, 6, 7], true)` |
-| **Result** | `[(1, 3, 5), (2, 4, 6)]` |
-| **Alias** | `list_zip` |
 
 #### `concat(value, ...)`
 
@@ -476,24 +348,6 @@ title: List Functions
 | **Description** | Applies aggregate function [`bool_or`]({% link docs/preview/sql/functions/aggregates.md %}#general-aggregate-functions) to the `list`. |
 | **Example** | `list_bool_or([true, false])` |
 | **Result** | `true` |
-
-#### `list_cat()`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Concatenates lists. `NULL` inputs are skipped. See also [operator `||`](#arg1--arg2). |
-| **Example** | `list_cat([2, 3], [4, 5, 6], [7])` |
-| **Result** | `[2, 3, 4, 5, 6, 7]` |
-| **Aliases** | `array_cat`, `array_concat`, `list_concat` |
-
-#### `list_cat(list_1, ..., list_n)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Concatenates lists. `NULL` inputs are skipped. See also [operator `||`](#arg1--arg2). |
-| **Example** | `list_cat([2, 3], [4, 5, 6], [7])` |
-| **Result** | `[2, 3, 4, 5, 6, 7]` |
-| **Aliases** | `array_concat`, `array_cat`, `list_concat` |
 
 #### `list_concat(list_1, ..., list_n)`
 

--- a/docs/preview/sql/functions/list.md
+++ b/docs/preview/sql/functions/list.md
@@ -12,70 +12,70 @@ title: List Functions
 |:--|:-------|
 | [`list[index]`](#listindex) | Extracts a single list element using a (1-based) `index`. |
 | [`list[begin[:end][:step]]`](#listbeginendstep) | Extracts a sublist using [slice conventions]({% link docs/preview/sql/functions/list.md %}#slicing). Negative values are accepted. |
-| [`list1 && list2`](#list1--list2) | Returns true if the lists have any element in common. NULLs are ignored. |
-| [`list1 <-> list2`](#list1---list2) | Calculates the Euclidean distance between two points with coordinates given in two inputs lists of equal length. |
-| [`list1 <=> list2`](#list1--list2) | Computes the cosine distance between two same-sized lists. |
-| [`list1 <@ list2`](#list1--list2) | Returns true if all elements of list2 are in list1. NULLs are ignored. |
-| [`list1 @> list2`](#list1--list2) | Returns true if all elements of list2 are in list1. NULLs are ignored. |
+| [`list1 && list2`](#list_has_anylist1-list2) | Alias for `list_has_any`. |
+| [`list1 <-> list2`](#list_distancelist1-list2) | Alias for `list_distance`. |
+| [`list1 <=> list2`](#list_cosine_distancelist1-list2) | Alias for `list_cosine_distance`. |
+| [`list1 <@ list2`](#list_has_alllist1-list2) | Alias for `list_has_all`. |
+| [`list1 @> list2`](#list_has_alllist1-list2) | Alias for `list_has_all`. |
 | [`arg1 || arg2`](#arg1--arg2) | Concatenates two strings, lists, or blobs. Any `NULL` input results in `NULL`. See also [`concat(arg1, arg2, ...)`]({% link docs/preview/sql/functions/text.md %}#concatvalue-) and [`list_concat(list1, list2, ...)`]({% link docs/preview/sql/functions/list.md %}#list_concatlist_1--list_n). |
-| [`aggregate(list, function_name, ...)`](#aggregatelist-function_name-) | Executes the aggregate function `function_name` on the elements of `list`. See the [List Aggregates](#list-aggregates) section for more details. |
-| [`apply(list, lambda(x))`](#applylist-lambdax) | Returns a list that is the result of applying the `lambda` function to each element of the input `list`. The return type is defined by the return type of the `lambda` function. See [`list_transform` examples]({% link docs/preview/sql/functions/lambda.md %}#list_transform-examples). |
-| [`array_aggr(list, function_name, ...)`](#array_aggrlist-function_name-) | Executes the aggregate function `function_name` on the elements of `list`. See the [List Aggregates](#list-aggregates) section for more details. |
-| [`array_aggregate(list, function_name, ...)`](#array_aggregatelist-function_name-) | Executes the aggregate function `function_name` on the elements of `list`. See the [List Aggregates](#list-aggregates) section for more details. |
+| [`aggregate(list, function_name, ...)`](#list_aggregatelist-function_name-) | Alias for `list_aggregate`. |
+| [`apply(list, lambda(x))`](#list_transformlist-lambdax) | Alias for `list_transform`. |
+| [`array_aggr(list, function_name, ...)`](#list_aggregatelist-function_name-) | Alias for `list_aggregate`. |
+| [`array_aggregate(list, function_name, ...)`](#list_aggregatelist-function_name-) | Alias for `list_aggregate`. |
 | [`array_append(list, element)`](#array_appendlist-element) | Appends `element` to `list`. |
-| [`array_apply(list, lambda(x))`](#array_applylist-lambdax) | Returns a list that is the result of applying the `lambda` function to each element of the input `list`. The return type is defined by the return type of the `lambda` function. See [`list_transform` examples]({% link docs/preview/sql/functions/lambda.md %}#list_transform-examples). |
+| [`array_apply(list, lambda(x))`](#list_transformlist-lambdax) | Alias for `list_transform`. |
 | [`array_cat()`](#array_cat) | Concatenates lists. `NULL` inputs are skipped. See also [operator `||`](#arg1--arg2). |
 | [`array_cat(list_1, ..., list_n)`](#array_catlist_1--list_n) | Concatenates lists. `NULL` inputs are skipped. See also [operator `||`](#arg1--arg2). |
 | [`array_concat()`](#array_concat) | Concatenates lists. `NULL` inputs are skipped. See also [operator `||`](#arg1--arg2). |
 | [`array_concat(list_1, ..., list_n)`](#array_concatlist_1--list_n) | Concatenates lists. `NULL` inputs are skipped. See also [operator `||`](#arg1--arg2). |
-| [`array_contains(list, element)`](#array_containslist-element) | Returns true if the list contains the element. |
-| [`array_distinct(list)`](#array_distinctlist) | Removes all duplicates and `NULL` values from a list. Does not preserve the original order. |
+| [`array_contains(list, element)`](#list_containslist-element) | Alias for `list_contains`. |
+| [`array_distinct(list)`](#list_distinctlist) | Alias for `list_distinct`. |
 | [`array_extract(list, index)`](#array_extractlist-index) | Extracts the `index`th (1-based) value from the `list`. |
-| [`array_filter(list, lambda(x))`](#array_filterlist-lambdax) | Constructs a list from those elements of the input `list` for which the `lambda` function returns `true`. DuckDB must be able to cast the `lambda` function's return type to `BOOL`. The return type of `list_filter` is the same as the input list's. See [`list_filter` examples]({% link docs/preview/sql/functions/lambda.md %}#list_filter-examples). |
-| [`array_grade_up(list[, col1][, col2])`](#array_grade_uplist-col1-col2) | Works like [list_sort](#list_sortlist), but the results are the indexes that correspond to the position in the original list instead of the actual values. |
-| [`array_has(list, element)`](#array_haslist-element) | Returns true if the list contains the element. |
-| [`array_has_all(list1, list2)`](#array_has_alllist1-list2) | Returns true if all elements of list2 are in list1. NULLs are ignored. |
-| [`array_has_any(list1, list2)`](#array_has_anylist1-list2) | Returns true if the lists have any element in common. NULLs are ignored. |
-| [`array_indexof(list, element)`](#array_indexoflist-element) | Returns the index of the `element` if the `list` contains the `element`. If the `element` is not found, it returns `NULL`. |
+| [`array_filter(list, lambda(x))`](#list_filterlist-lambdax) | Alias for `list_filter`. |
+| [`array_grade_up(list[, col1][, col2])`](#list_grade_uplist-col1-col2) | Alias for `list_grade_up`. |
+| [`array_has(list, element)`](#list_containslist-element) | Alias for `list_contains`. |
+| [`array_has_all(list1, list2)`](#list_has_alllist1-list2) | Alias for `list_has_all`. |
+| [`array_has_any(list1, list2)`](#list_has_anylist1-list2) | Alias for `list_has_any`. |
+| [`array_indexof(list, element)`](#list_positionlist-element) | Alias for `list_position`. |
 | [`array_intersect(list1, list2)`](#array_intersectlist1-list2) | Returns a list of all the elements that exist in both `list1` and `list2`, without duplicates. |
 | [`array_length(list)`](#array_lengthlist) | Returns the length of the `list`. |
 | [`array_length(list, dimension)`](#array_lengthlist-dimension) | `array_length` for lists with dimensions other than 1 not implemented |
 | [`array_pop_back(list)`](#array_pop_backlist) | Returns the `list` without the last element. |
 | [`array_pop_front(list)`](#array_pop_frontlist) | Returns the `list` without the first element. |
-| [`array_position(list, element)`](#array_positionlist-element) | Returns the index of the `element` if the `list` contains the `element`. If the `element` is not found, it returns `NULL`. |
+| [`array_position(list, element)`](#list_positionlist-element) | Alias for `list_position`. |
 | [`array_prepend(element, list)`](#array_prependelement-list) | Prepends `element` to `list`. |
 | [`array_push_back(list, element)`](#array_push_backlist-element) | Appends `element` to `list`. |
 | [`array_push_front(list, element)`](#array_push_frontlist-element) | Prepends `element` to `list`. |
-| [`array_reduce(list, lambda(x,y)[, initial_value])`](#array_reducelist-lambdaxy-initial_value) | Reduces all elements of the input `list` into a single scalar value by executing the `lambda` function on a running result and the next list element. The `lambda` function has an optional `initial_value` argument. See [`list_reduce` examples]({% link docs/preview/sql/functions/lambda.md %}#list_reduce-examples). |
-| [`array_resize(list, size[[, value]])`](#array_resizelist-size-value) | Resizes the `list` to contain `size` elements. Initializes new elements with `value` or `NULL` if `value` is not set. |
+| [`array_reduce(list, lambda(x,y)[, initial_value])`](#list_reducelist-lambdaxy-initial_value) | Alias for `list_reduce`. |
+| [`array_resize(list, size[[, value]])`](#list_resizelist-size-value) | Alias for `list_resize`. |
 | [`array_reverse(list)`](#array_reverselist) | Reverses the `list`. |
-| [`array_reverse_sort(list[, col1])`](#array_reverse_sortlist-col1) | Sorts the elements of the list in reverse order. See the [Sorting Lists](#sorting-lists) section for more details about sorting order and `NULL` values. |
-| [`array_select(value_list, index_list)`](#array_selectvalue_list-index_list) | Returns a list based on the elements selected by the `index_list`. |
-| [`array_slice(list, begin, end)`](#array_slicelist-begin-end) | Extracts a sublist or substring using [slice conventions]({% link docs/preview/sql/functions/list.md %}#slicing). Negative values are accepted. |
-| [`array_slice(list, begin, end, step)`](#array_slicelist-begin-end-step) | list_slice with added step feature. |
-| [`array_sort(list[, col1][, col2])`](#array_sortlist-col1-col2) | Sorts the elements of the list. See the [Sorting Lists](#sorting-lists) section for more details about sorting order and `NULL` values. |
+| [`array_reverse_sort(list[, col1])`](#list_reverse_sortlist-col1) | Alias for `list_reverse_sort`. |
+| [`array_select(value_list, index_list)`](#list_selectvalue_list-index_list) | Alias for `list_select`. |
+| [`array_slice(list, begin, end)`](#list_slicelist-begin-end) | Alias for `list_slice`. |
+| [`array_slice(list, begin, end, step)`](#list_slicelist-begin-end-step) | Alias for `list_slice`. |
+| [`array_sort(list[, col1][, col2])`](#list_sortlist-col1-col2) | Alias for `list_sort`. |
 | [`array_to_string(list, delimiter)`](#array_to_stringlist-delimiter) | Concatenates list/array elements using an optional `delimiter`. |
 | [`array_to_string_comma_default(array)`](#array_to_string_comma_defaultarray) | Concatenates list/array elements with a comma delimiter. |
-| [`array_transform(list, lambda(x))`](#array_transformlist-lambdax) | Returns a list that is the result of applying the `lambda` function to each element of the input `list`. The return type is defined by the return type of the `lambda` function. See [`list_transform` examples]({% link docs/preview/sql/functions/lambda.md %}#list_transform-examples). |
-| [`array_unique(list)`](#array_uniquelist) | Counts the unique elements of a `list`. |
-| [`array_where(value_list, mask_list)`](#array_wherevalue_list-mask_list) | Returns a list with the `BOOLEAN`s in `mask_list` applied as a mask to the `value_list`. |
+| [`array_transform(list, lambda(x))`](#list_transformlist-lambdax) | Alias for `list_transform`. |
+| [`array_unique(list)`](#list_uniquelist) | Alias for `list_unique`. |
+| [`array_where(value_list, mask_list)`](#list_wherevalue_list-mask_list) | Alias for `list_where`. |
 | [`array_zip(arg, ...)`](#array_ziparg-) | Zips n `LIST`s to a new `LIST` whose length will be that of the longest list. Its elements are structs of n elements from each list `list_1`, …, `list_n`, missing elements are replaced with `NULL`. If `truncate` is set, all lists are truncated to the smallest list length. |
 | [`array_zip(list_1, ..., list_n[, truncate])`](#array_ziplist_1--list_n-truncate) | Zips n `LIST`s to a new `LIST` whose length will be that of the longest list. Its elements are structs of n elements from each list `list_1`, …, `list_n`, missing elements are replaced with `NULL`. If `truncate` is set, all lists are truncated to the smallest list length. |
-| [`char_length(list)`](#char_lengthlist) | Returns the length of the `list`. |
-| [`character_length(list)`](#character_lengthlist) | Returns the length of the `list`. |
+| [`char_length(list)`](#lengthlist) | Alias for `length`. |
+| [`character_length(list)`](#lengthlist) | Alias for `length`. |
 | [`concat(value, ...)`](#concatvalue-) | Concatenates multiple strings or lists. `NULL` inputs are skipped. See also [operator `||`](#arg1--arg2). |
 | [`contains(list, element)`](#containslist-element) | Returns `true` if the `list` contains the `element`. |
-| [`filter(list, lambda(x))`](#filterlist-lambdax) | Constructs a list from those elements of the input `list` for which the `lambda` function returns `true`. DuckDB must be able to cast the `lambda` function's return type to `BOOL`. The return type of `list_filter` is the same as the input list's. See [`list_filter` examples]({% link docs/preview/sql/functions/lambda.md %}#list_filter-examples). |
+| [`filter(list, lambda(x))`](#list_filterlist-lambdax) | Alias for `list_filter`. |
 | [`flatten(nested_list)`](#flattennested_list) | [Flattens](#flattening) a nested list by one level. |
 | [`generate_series(start[, stop][, step])`](#generate_seriesstart-stop-step) | Creates a list of values between `start` and `stop` - the stop parameter is inclusive. |
-| [`grade_up(list[, col1][, col2])`](#grade_uplist-col1-col2) | Works like [list_sort](#list_sortlist), but the results are the indexes that correspond to the position in the original list instead of the actual values. |
-| [`len(list)`](#lenlist) | Returns the length of the `list`. |
+| [`grade_up(list[, col1][, col2])`](#list_grade_uplist-col1-col2) | Alias for `list_grade_up`. |
+| [`len(list)`](#lengthlist) | Alias for `length`. |
 | [`length(list)`](#lengthlist) | Returns the length of the `list`. |
-| [`list_aggr(list, function_name, ...)`](#list_aggrlist-function_name-) | Executes the aggregate function `function_name` on the elements of `list`. See the [List Aggregates](#list-aggregates) section for more details. |
+| [`list_aggr(list, function_name, ...)`](#list_aggregatelist-function_name-) | Alias for `list_aggregate`. |
 | [`list_aggregate(list, function_name, ...)`](#list_aggregatelist-function_name-) | Executes the aggregate function `function_name` on the elements of `list`. See the [List Aggregates](#list-aggregates) section for more details. |
 | [`list_any_value(list)`](#list_any_valuelist) | Applies aggregate function [`any_value`]({% link docs/preview/sql/functions/aggregates.md %}#general-aggregate-functions) to the `list`. |
 | [`list_append(list, element)`](#list_appendlist-element) | Appends `element` to `list`. |
-| [`list_apply(list, lambda(x))`](#list_applylist-lambdax) | Returns a list that is the result of applying the `lambda` function to each element of the input `list`. The return type is defined by the return type of the `lambda` function. See [`list_transform` examples]({% link docs/preview/sql/functions/lambda.md %}#list_transform-examples). |
+| [`list_apply(list, lambda(x))`](#list_transformlist-lambdax) | Alias for `list_transform`. |
 | [`list_approx_count_distinct(list)`](#list_approx_count_distinctlist) | Applies aggregate function [`approx_count_distinct`]({% link docs/preview/sql/functions/aggregates.md %}#general-aggregate-functions) to the `list`. |
 | [`list_avg(list)`](#list_avglist) | Applies aggregate function [`avg`]({% link docs/preview/sql/functions/aggregates.md %}#general-aggregate-functions) to the `list`. |
 | [`list_bit_and(list)`](#list_bit_andlist) | Applies aggregate function [`bit_and`]({% link docs/preview/sql/functions/aggregates.md %}#general-aggregate-functions) to the `list`. |
@@ -92,18 +92,18 @@ title: List Functions
 | [`list_count(list)`](#list_countlist) | Applies aggregate function [`count`]({% link docs/preview/sql/functions/aggregates.md %}#general-aggregate-functions) to the `list`. |
 | [`list_distance(list1, list2)`](#list_distancelist1-list2) | Calculates the Euclidean distance between two points with coordinates given in two inputs lists of equal length. |
 | [`list_distinct(list)`](#list_distinctlist) | Removes all duplicates and `NULL` values from a list. Does not preserve the original order. |
-| [`list_dot_product(list1, list2)`](#list_dot_productlist1-list2) | Computes the inner product between two same-sized lists. |
-| [`list_element(list, index)`](#list_elementlist-index) | Extract the `index`th (1-based) value from the list. |
+| [`list_dot_product(list1, list2)`](#list_inner_productlist1-list2) | Alias for `list_inner_product`. |
+| [`list_element(list, index)`](#list_extractlist-index) | Alias for `list_extract`. |
 | [`list_entropy(list)`](#list_entropylist) | Applies aggregate function [`entropy`]({% link docs/preview/sql/functions/aggregates.md %}#general-aggregate-functions) to the `list`. |
 | [`list_extract(list, index)`](#list_extractlist-index) | Extract the `index`th (1-based) value from the list. |
 | [`list_filter(list, lambda(x))`](#list_filterlist-lambdax) | Constructs a list from those elements of the input `list` for which the `lambda` function returns `true`. DuckDB must be able to cast the `lambda` function's return type to `BOOL`. The return type of `list_filter` is the same as the input list's. See [`list_filter` examples]({% link docs/preview/sql/functions/lambda.md %}#list_filter-examples). |
 | [`list_first(list)`](#list_firstlist) | Applies aggregate function [`first`]({% link docs/preview/sql/functions/aggregates.md %}#general-aggregate-functions) to the `list`. |
 | [`list_grade_up(list[, col1][, col2])`](#list_grade_uplist-col1-col2) | Works like [list_sort](#list_sortlist), but the results are the indexes that correspond to the position in the original list instead of the actual values. |
-| [`list_has(list, element)`](#list_haslist-element) | Returns true if the list contains the element. |
+| [`list_has(list, element)`](#list_containslist-element) | Alias for `list_contains`. |
 | [`list_has_all(list1, list2)`](#list_has_alllist1-list2) | Returns true if all elements of list2 are in list1. NULLs are ignored. |
 | [`list_has_any(list1, list2)`](#list_has_anylist1-list2) | Returns true if the lists have any element in common. NULLs are ignored. |
 | [`list_histogram(list)`](#list_histogramlist) | Applies aggregate function [`histogram`]({% link docs/preview/sql/functions/aggregates.md %}#general-aggregate-functions) to the `list`. |
-| [`list_indexof(list, element)`](#list_indexoflist-element) | Returns the index of the `element` if the `list` contains the `element`. If the `element` is not found, it returns `NULL`. |
+| [`list_indexof(list, element)`](#list_positionlist-element) | Alias for `list_position`. |
 | [`list_inner_product(list1, list2)`](#list_inner_productlist1-list2) | Computes the inner product between two same-sized lists. |
 | [`list_intersect(list1, list2)`](#list_intersectlist1-list2) | Returns a list of all the elements that exist in both `list1` and `list2`, without duplicates. |
 | [`list_kurtosis(list)`](#list_kurtosislist) | Applies aggregate function [`kurtosis`]({% link docs/preview/sql/functions/aggregates.md %}#general-aggregate-functions) to the `list`. |
@@ -114,9 +114,9 @@ title: List Functions
 | [`list_median(list)`](#list_medianlist) | Applies aggregate function [`median`]({% link docs/preview/sql/functions/aggregates.md %}#general-aggregate-functions) to the `list`. |
 | [`list_min(list)`](#list_minlist) | Applies aggregate function [`min`]({% link docs/preview/sql/functions/aggregates.md %}#general-aggregate-functions) to the `list`. |
 | [`list_mode(list)`](#list_modelist) | Applies aggregate function [`mode`]({% link docs/preview/sql/functions/aggregates.md %}#general-aggregate-functions) to the `list`. |
-| [`list_negative_dot_product(list1, list2)`](#list_negative_dot_productlist1-list2) | Computes the negative inner product between two same-sized lists. |
+| [`list_negative_dot_product(list1, list2)`](#list_negative_inner_productlist1-list2) | Alias for `list_negative_inner_product`. |
 | [`list_negative_inner_product(list1, list2)`](#list_negative_inner_productlist1-list2) | Computes the negative inner product between two same-sized lists. |
-| [`list_pack(arg, ...)`](#list_packarg-) | Creates a LIST containing the argument values. |
+| [`list_pack(arg, ...)`](#list_valuearg-) | Alias for `list_value`. |
 | [`list_position(list, element)`](#list_positionlist-element) | Returns the index of the `element` if the `list` contains the `element`. If the `element` is not found, it returns `NULL`. |
 | [`list_prepend(element, list)`](#list_prependelement-list) | Prepends `element` to `list`. |
 | [`list_product(list)`](#list_productlist) | Applies aggregate function [`product`]({% link docs/preview/sql/functions/aggregates.md %}#general-aggregate-functions) to the `list`. |
@@ -142,7 +142,7 @@ title: List Functions
 | [`list_where(value_list, mask_list)`](#list_wherevalue_list-mask_list) | Returns a list with the `BOOLEAN`s in `mask_list` applied as a mask to the `value_list`. |
 | [`list_zip(list_1, ..., list_n[, truncate])`](#list_ziplist_1--list_n-truncate) | Zips n `LIST`s to a new `LIST` whose length will be that of the longest list. Its elements are structs of n elements from each list `list_1`, …, `list_n`, missing elements are replaced with `NULL`. If `truncate` is set, all lists are truncated to the smallest list length. |
 | [`range(start[, stop][, step])`](#rangestart-stop-step) | Creates a list of values between `start` and `stop` - the stop parameter is exclusive. |
-| [`reduce(list, lambda(x,y)[, initial_value])`](#reducelist-lambdaxy-initial_value) | Reduces all elements of the input `list` into a single scalar value by executing the `lambda` function on a running result and the next list element. The `lambda` function has an optional `initial_value` argument. See [`list_reduce` examples]({% link docs/preview/sql/functions/lambda.md %}#list_reduce-examples). |
+| [`reduce(list, lambda(x,y)[, initial_value])`](#list_reducelist-lambdaxy-initial_value) | Alias for `list_reduce`. |
 | [`repeat(list, count)`](#repeatlist-count) | Repeats the `list` `count` number of times. |
 | [`unnest(list)`](#unnestlist) | Unnests a list by one level. Note that this is a special function that alters the cardinality of the result. See the [unnest page]({% link docs/preview/sql/query_syntax/unnest.md %}) for more details. |
 | [`unpivot_list(arg, ...)`](#unpivot_listarg-) | Identical to list_value, but generated as part of unpivot for better error messages. |
@@ -167,51 +167,6 @@ title: List Functions
 | **Result** | `6` |
 | **Alias** | `list_slice` |
 
-#### `list1 && list2`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Returns true if the lists have any element in common. NULLs are ignored. |
-| **Example** | `list_has_any([1, 2, 3], [2, 3, 4])` |
-| **Result** | `true` |
-| **Aliases** | `array_has_any`, `list_has_any` |
-
-#### `list1 <-> list2`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Calculates the Euclidean distance between two points with coordinates given in two inputs lists of equal length. |
-| **Example** | `list_distance([1, 2, 3], [1, 2, 5])` |
-| **Result** | `2.0` |
-| **Alias** | `list_distance` |
-
-#### `list1 <=> list2`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Computes the cosine distance between two same-sized lists. |
-| **Example** | `list_cosine_distance([1, 2, 3], [1, 2, 3])` |
-| **Result** | `0.0` |
-| **Alias** | `list_cosine_distance` |
-
-#### `list1 <@ list2`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Returns true if all elements of list2 are in list1. NULLs are ignored. |
-| **Example** | `list_has_all([1, 2, 3], [2, 3])` |
-| **Result** | `true` |
-| **Aliases** | `@>`, `array_has_all`, `list_has_all` |
-
-#### `list1 @> list2`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Returns true if all elements of list2 are in list1. NULLs are ignored. |
-| **Example** | `list_has_all([1, 2, 3], [2, 3])` |
-| **Result** | `true` |
-| **Aliases** | `<@`, `array_has_all`, `list_has_all` |
-
 #### `arg1 || arg2`
 
 <div class="nostroke_table"></div>
@@ -224,42 +179,6 @@ title: List Functions
 | **Example 3** | `'\xAA'::BLOB || '\xBB'::BLOB` |
 | **Result** | `\xAA\xBB` |
 
-#### `aggregate(list, function_name, ...)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Executes the aggregate function `function_name` on the elements of `list`. See the [List Aggregates](#list-aggregates) section for more details. |
-| **Example** | `aggregate([1, 2, NULL], 'min')` |
-| **Result** | `1` |
-| **Aliases** | `array_aggr`, `array_aggregate`, `list_aggr`, `list_aggregate` |
-
-#### `apply(list, lambda(x))`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Returns a list that is the result of applying the `lambda` function to each element of the input `list`. The return type is defined by the return type of the `lambda` function. See [`list_transform` examples]({% link docs/preview/sql/functions/lambda.md %}#list_transform-examples). |
-| **Example** | `apply([1, 2, 3], lambda x : x + 1)` |
-| **Result** | `[2, 3, 4]` |
-| **Aliases** | `array_apply`, `array_transform`, `list_apply`, `list_transform` |
-
-#### `array_aggr(list, function_name, ...)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Executes the aggregate function `function_name` on the elements of `list`. See the [List Aggregates](#list-aggregates) section for more details. |
-| **Example** | `array_aggr([1, 2, NULL], 'min')` |
-| **Result** | `1` |
-| **Aliases** | `aggregate`, `array_aggregate`, `list_aggr`, `list_aggregate` |
-
-#### `array_aggregate(list, function_name, ...)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Executes the aggregate function `function_name` on the elements of `list`. See the [List Aggregates](#list-aggregates) section for more details. |
-| **Example** | `array_aggregate([1, 2, NULL], 'min')` |
-| **Result** | `1` |
-| **Aliases** | `aggregate`, `array_aggr`, `list_aggr`, `list_aggregate` |
-
 #### `array_append(list, element)`
 
 <div class="nostroke_table"></div>
@@ -268,15 +187,6 @@ title: List Functions
 | **Example** | `array_append([2, 3], 4)` |
 | **Result** | `[2, 3, 4]` |
 | **Aliases** | `array_push_back`, `list_append` |
-
-#### `array_apply(list, lambda(x))`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Returns a list that is the result of applying the `lambda` function to each element of the input `list`. The return type is defined by the return type of the `lambda` function. See [`list_transform` examples]({% link docs/preview/sql/functions/lambda.md %}#list_transform-examples). |
-| **Example** | `array_apply([1, 2, 3], lambda x : x + 1)` |
-| **Result** | `[2, 3, 4]` |
-| **Aliases** | `apply`, `array_transform`, `list_apply`, `list_transform` |
 
 #### `array_cat()`
 
@@ -314,24 +224,6 @@ title: List Functions
 | **Result** | `[2, 3, 4, 5, 6, 7]` |
 | **Aliases** | `list_cat`, `array_cat`, `list_concat` |
 
-#### `array_contains(list, element)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Returns true if the list contains the element. |
-| **Example** | `array_contains([1, 2, NULL], 1)` |
-| **Result** | `true` |
-| **Aliases** | `array_has`, `list_contains`, `list_has` |
-
-#### `array_distinct(list)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Removes all duplicates and `NULL` values from a list. Does not preserve the original order. |
-| **Example** | `array_distinct([1, 1, NULL, -3, 1, 5])` |
-| **Result** | `[5, -3, 1]` |
-| **Alias** | `list_distinct` |
-
 #### `array_extract(list, index)`
 
 <div class="nostroke_table"></div>
@@ -339,60 +231,6 @@ title: List Functions
 | **Description** | Extracts the `index`th (1-based) value from the `list`. |
 | **Example** | `array_extract([4, 5, 6], 3)` |
 | **Result** | `6` |
-
-#### `array_filter(list, lambda(x))`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Constructs a list from those elements of the input `list` for which the `lambda` function returns `true`. DuckDB must be able to cast the `lambda` function's return type to `BOOL`. The return type of `list_filter` is the same as the input list's. See [`list_filter` examples]({% link docs/preview/sql/functions/lambda.md %}#list_filter-examples). |
-| **Example** | `array_filter([3, 4, 5], lambda x : x > 4)` |
-| **Result** | `[5]` |
-| **Aliases** | `filter`, `list_filter` |
-
-#### `array_grade_up(list[, col1][, col2])`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Works like [list_sort](#list_sortlist), but the results are the indexes that correspond to the position in the original list instead of the actual values. |
-| **Example** | `array_grade_up([3, 6, 1, 2])` |
-| **Result** | `[3, 4, 1, 2]` |
-| **Aliases** | `grade_up`, `list_grade_up` |
-
-#### `array_has(list, element)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Returns true if the list contains the element. |
-| **Example** | `array_has([1, 2, NULL], 1)` |
-| **Result** | `true` |
-| **Aliases** | `array_contains`, `list_contains`, `list_has` |
-
-#### `array_has_all(list1, list2)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Returns true if all elements of list2 are in list1. NULLs are ignored. |
-| **Example** | `array_has_all([1, 2, 3], [2, 3])` |
-| **Result** | `true` |
-| **Aliases** | `<@`, `@>`, `list_has_all` |
-
-#### `array_has_any(list1, list2)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Returns true if the lists have any element in common. NULLs are ignored. |
-| **Example** | `array_has_any([1, 2, 3], [2, 3, 4])` |
-| **Result** | `true` |
-| **Aliases** | `&&`, `list_has_any` |
-
-#### `array_indexof(list, element)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Returns the index of the `element` if the `list` contains the `element`. If the `element` is not found, it returns `NULL`. |
-| **Example** | `array_indexof([1, 2, NULL], 2)` |
-| **Result** | `2` |
-| **Aliases** | `array_position`, `list_indexof`, `list_position` |
 
 #### `array_intersect(list1, list2)`
 
@@ -435,15 +273,6 @@ title: List Functions
 | **Example** | `array_pop_front([4, 5, 6])` |
 | **Result** | `[5, 6]` |
 
-#### `array_position(list, element)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Returns the index of the `element` if the `list` contains the `element`. If the `element` is not found, it returns `NULL`. |
-| **Example** | `array_position([1, 2, NULL], 2)` |
-| **Result** | `2` |
-| **Aliases** | `array_indexof`, `list_indexof`, `list_position` |
-
 #### `array_prepend(element, list)`
 
 <div class="nostroke_table"></div>
@@ -470,24 +299,6 @@ title: List Functions
 | **Example** | `array_push_front([4, 5, 6], 3)` |
 | **Result** | `[3, 4, 5, 6]` |
 
-#### `array_reduce(list, lambda(x,y)[, initial_value])`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Reduces all elements of the input `list` into a single scalar value by executing the `lambda` function on a running result and the next list element. The `lambda` function has an optional `initial_value` argument. See [`list_reduce` examples]({% link docs/preview/sql/functions/lambda.md %}#list_reduce-examples). |
-| **Example** | `array_reduce([1, 2, 3], lambda x, y : x + y)` |
-| **Result** | `6` |
-| **Aliases** | `list_reduce`, `reduce` |
-
-#### `array_resize(list, size[[, value]])`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Resizes the `list` to contain `size` elements. Initializes new elements with `value` or `NULL` if `value` is not set. |
-| **Example** | `array_resize([1, 2, 3], 5, 0)` |
-| **Result** | `[1, 2, 3, 0, 0]` |
-| **Alias** | `list_resize` |
-
 #### `array_reverse(list)`
 
 <div class="nostroke_table"></div>
@@ -496,55 +307,6 @@ title: List Functions
 | **Example** | `array_reverse([3, 6, 1, 2])` |
 | **Result** | `[2, 1, 6, 3]` |
 | **Alias** | `list_reverse` |
-
-#### `array_reverse_sort(list[, col1])`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Sorts the elements of the list in reverse order. See the [Sorting Lists](#sorting-lists) section for more details about sorting order and `NULL` values. |
-| **Example** | `array_reverse_sort([3, 6, 1, 2])` |
-| **Result** | `[6, 3, 2, 1]` |
-| **Alias** | `list_reverse_sort` |
-
-#### `array_select(value_list, index_list)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Returns a list based on the elements selected by the `index_list`. |
-| **Example** | `array_select([10, 20, 30, 40], [1, 4])` |
-| **Result** | `[10, 40]` |
-| **Alias** | `list_select` |
-
-#### `array_slice(list, begin, end)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Extracts a sublist or substring using [slice conventions]({% link docs/preview/sql/functions/list.md %}#slicing). Negative values are accepted. |
-| **Example 1** | `array_slice('DuckDB', 3, 4)` |
-| **Result** | `ck` |
-| **Example 2** | `array_slice('DuckDB', 3, NULL)` |
-| **Result** | `NULL` |
-| **Example 3** | `array_slice('DuckDB', 0, -3)` |
-| **Result** | `Duck` |
-| **Alias** | `list_slice` |
-
-#### `array_slice(list, begin, end, step)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | list_slice with added step feature. |
-| **Example** | `array_slice([4, 5, 6], 1, 3, 2)` |
-| **Result** | `[4, 6]` |
-| **Alias** | `list_slice` |
-
-#### `array_sort(list[, col1][, col2])`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Sorts the elements of the list. See the [Sorting Lists](#sorting-lists) section for more details about sorting order and `NULL` values. |
-| **Example** | `array_sort([3, 6, 1, 2])` |
-| **Result** | `[1, 2, 3, 6]` |
-| **Alias** | `list_sort` |
 
 #### `array_to_string(list, delimiter)`
 
@@ -563,33 +325,6 @@ title: List Functions
 | **Description** | Concatenates list/array elements with a comma delimiter. |
 | **Example** | `array_to_string_comma_default(['Banana', 'Apple', 'Melon'])` |
 | **Result** | `Banana,Apple,Melon` |
-
-#### `array_transform(list, lambda(x))`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Returns a list that is the result of applying the `lambda` function to each element of the input `list`. The return type is defined by the return type of the `lambda` function. See [`list_transform` examples]({% link docs/preview/sql/functions/lambda.md %}#list_transform-examples). |
-| **Example** | `array_transform([1, 2, 3], lambda x : x + 1)` |
-| **Result** | `[2, 3, 4]` |
-| **Aliases** | `apply`, `array_apply`, `list_apply`, `list_transform` |
-
-#### `array_unique(list)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Counts the unique elements of a `list`. |
-| **Example** | `array_unique([1, 1, NULL, -3, 1, 5])` |
-| **Result** | `3` |
-| **Alias** | `list_unique` |
-
-#### `array_where(value_list, mask_list)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Returns a list with the `BOOLEAN`s in `mask_list` applied as a mask to the `value_list`. |
-| **Example** | `array_where([10, 20, 30, 40], [true, false, false, true])` |
-| **Result** | `[10, 40]` |
-| **Alias** | `list_where` |
 
 #### `array_zip(arg, ...)`
 
@@ -617,24 +352,6 @@ title: List Functions
 | **Result** | `[(1, 3, 5), (2, 4, 6)]` |
 | **Alias** | `list_zip` |
 
-#### `char_length(list)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Returns the length of the `list`. |
-| **Example** | `char_length([1,2,3])` |
-| **Result** | `3` |
-| **Aliases** | `character_length`, `len`, `length` |
-
-#### `character_length(list)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Returns the length of the `list`. |
-| **Example** | `character_length([1,2,3])` |
-| **Result** | `3` |
-| **Aliases** | `char_length`, `len`, `length` |
-
 #### `concat(value, ...)`
 
 <div class="nostroke_table"></div>
@@ -653,15 +370,6 @@ title: List Functions
 | **Example** | `contains([1, 2, NULL], 1)` |
 | **Result** | `true` |
 
-#### `filter(list, lambda(x))`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Constructs a list from those elements of the input `list` for which the `lambda` function returns `true`. DuckDB must be able to cast the `lambda` function's return type to `BOOL`. The return type of `list_filter` is the same as the input list's. See [`list_filter` examples]({% link docs/preview/sql/functions/lambda.md %}#list_filter-examples). |
-| **Example** | `filter([3, 4, 5], lambda x : x > 4)` |
-| **Result** | `[5]` |
-| **Aliases** | `array_filter`, `list_filter` |
-
 #### `flatten(nested_list)`
 
 <div class="nostroke_table"></div>
@@ -678,24 +386,6 @@ title: List Functions
 | **Example** | `generate_series(2, 5, 3)` |
 | **Result** | `[2, 5]` |
 
-#### `grade_up(list[, col1][, col2])`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Works like [list_sort](#list_sortlist), but the results are the indexes that correspond to the position in the original list instead of the actual values. |
-| **Example** | `grade_up([3, 6, 1, 2])` |
-| **Result** | `[3, 4, 1, 2]` |
-| **Aliases** | `array_grade_up`, `list_grade_up` |
-
-#### `len(list)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Returns the length of the `list`. |
-| **Example** | `length([1,2,3])` |
-| **Result** | `3` |
-| **Aliases** | `char_length`, `character_length`, `length` |
-
 #### `length(list)`
 
 <div class="nostroke_table"></div>
@@ -704,15 +394,6 @@ title: List Functions
 | **Example** | `length([1,2,3])` |
 | **Result** | `3` |
 | **Aliases** | `char_length`, `character_length`, `len` |
-
-#### `list_aggr(list, function_name, ...)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Executes the aggregate function `function_name` on the elements of `list`. See the [List Aggregates](#list-aggregates) section for more details. |
-| **Example** | `list_aggregate([1, 2, NULL], 'min')` |
-| **Result** | `1` |
-| **Aliases** | `aggregate`, `array_aggr`, `array_aggregate`, `list_aggregate` |
 
 #### `list_aggregate(list, function_name, ...)`
 
@@ -739,15 +420,6 @@ title: List Functions
 | **Example** | `list_append([2, 3], 4)` |
 | **Result** | `[2, 3, 4]` |
 | **Aliases** | `array_append`, `array_push_back` |
-
-#### `list_apply(list, lambda(x))`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Returns a list that is the result of applying the `lambda` function to each element of the input `list`. The return type is defined by the return type of the `lambda` function. See [`list_transform` examples]({% link docs/preview/sql/functions/lambda.md %}#list_transform-examples). |
-| **Example** | `list_apply([1, 2, 3], lambda x : x + 1)` |
-| **Result** | `[2, 3, 4]` |
-| **Aliases** | `apply`, `array_apply`, `array_transform`, `list_transform` |
 
 #### `list_approx_count_distinct(list)`
 
@@ -884,24 +556,6 @@ title: List Functions
 | **Result** | `[5, -3, 1]` |
 | **Alias** | `array_distinct` |
 
-#### `list_dot_product(list1, list2)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Computes the inner product between two same-sized lists. |
-| **Example** | `list_dot_product([1, 2, 3], [1, 2, 3])` |
-| **Result** | `14.0` |
-| **Alias** | `list_inner_product` |
-
-#### `list_element(list, index)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Extract the `index`th (1-based) value from the list. |
-| **Example** | `list_element([4, 5, 6], 3)` |
-| **Result** | `6` |
-| **Alias** | `list_extract` |
-
 #### `list_entropy(list)`
 
 <div class="nostroke_table"></div>
@@ -945,15 +599,6 @@ title: List Functions
 | **Result** | `[3, 4, 1, 2]` |
 | **Aliases** | `array_grade_up`, `grade_up` |
 
-#### `list_has(list, element)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Returns true if the list contains the element. |
-| **Example** | `list_has([1, 2, NULL], 1)` |
-| **Result** | `true` |
-| **Aliases** | `array_contains`, `array_has`, `list_contains` |
-
 #### `list_has_all(list1, list2)`
 
 <div class="nostroke_table"></div>
@@ -979,15 +624,6 @@ title: List Functions
 | **Description** | Applies aggregate function [`histogram`]({% link docs/preview/sql/functions/aggregates.md %}#general-aggregate-functions) to the `list`. |
 | **Example** | `list_histogram([3,3,9])` |
 | **Result** | `{3=2, 9=1}` |
-
-#### `list_indexof(list, element)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Returns the index of the `element` if the `list` contains the `element`. If the `element` is not found, it returns `NULL`. |
-| **Example** | `list_indexof([1, 2, NULL], 2)` |
-| **Result** | `2` |
-| **Aliases** | `array_indexof`, `array_position`, `list_position` |
 
 #### `list_inner_product(list1, list2)`
 
@@ -1071,15 +707,6 @@ title: List Functions
 | **Example** | `list_mode([3,3,9])` |
 | **Result** | `3` |
 
-#### `list_negative_dot_product(list1, list2)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Computes the negative inner product between two same-sized lists. |
-| **Example** | `list_negative_dot_product([1, 2, 3], [1, 2, 3])` |
-| **Result** | `-14.0` |
-| **Alias** | `list_negative_inner_product` |
-
 #### `list_negative_inner_product(list1, list2)`
 
 <div class="nostroke_table"></div>
@@ -1088,15 +715,6 @@ title: List Functions
 | **Example** | `list_negative_inner_product([1, 2, 3], [1, 2, 3])` |
 | **Result** | `-14.0` |
 | **Alias** | `list_negative_dot_product` |
-
-#### `list_pack(arg, ...)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Creates a LIST containing the argument values. |
-| **Example** | `list_pack(4, 5, 6)` |
-| **Result** | `[4, 5, 6]` |
-| **Alias** | `list_value` |
 
 #### `list_position(list, element)`
 
@@ -1316,15 +934,6 @@ title: List Functions
 | **Description** | Creates a list of values between `start` and `stop` - the stop parameter is exclusive. |
 | **Example** | `range(2, 5, 3)` |
 | **Result** | `[2]` |
-
-#### `reduce(list, lambda(x,y)[, initial_value])`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Reduces all elements of the input `list` into a single scalar value by executing the `lambda` function on a running result and the next list element. The `lambda` function has an optional `initial_value` argument. See [`list_reduce` examples]({% link docs/preview/sql/functions/lambda.md %}#list_reduce-examples). |
-| **Example** | `reduce([1, 2, 3], lambda x, y : x + y)` |
-| **Result** | `6` |
-| **Aliases** | `array_reduce`, `list_reduce` |
 
 #### `repeat(list, count)`
 

--- a/docs/preview/sql/functions/text.md
+++ b/docs/preview/sql/functions/text.md
@@ -24,7 +24,6 @@ This section describes functions and operators for examining and manipulating [`
 | [`string ^@ search_string`](#string--search_string) | Returns `true` if `string` begins with `search_string`. |
 | [`arg1 || arg2`](#arg1--arg2) | Concatenates two strings, lists, or blobs. Any `NULL` input results in `NULL`. See also [`concat(arg1, arg2, ...)`]({% link docs/preview/sql/functions/text.md %}#concatvalue-) and [`list_concat(list1, list2, ...)`]({% link docs/preview/sql/functions/list.md %}#list_concatlist_1--list_n). |
 | [`array_extract(string, index)`](#array_extractstring-index) | Extracts a single character from a `string` using a (1-based) `index`. |
-| [`array_slice(list, begin, end)`](#array_slicelist-begin-end) | Extracts a sublist or substring using [slice conventions]({% link docs/preview/sql/functions/list.md %}#slicing). Negative values are accepted. |
 | [`ascii(string)`](#asciistring) | Returns an integer that represents the Unicode code point of the first character of the `string`. |
 | [`bar(x, min, max[, width])`](#barx-min-max-width) | Draws a band whose width is proportional to (`x - min`) and equal to `width` characters when `x` = `max`. `width` defaults to 80. |
 | [`base64(blob)`](#to_base64blob) | Alias for `to_base64`. |
@@ -96,7 +95,6 @@ This section describes functions and operators for examining and manipulating [`
 | [`sha256(value)`](#sha256value) | Returns a `VARCHAR` with the SHA-256 hash of the `value` |
 | [`split(string, separator)`](#string_splitstring-separator) | Alias for `string_split`. |
 | [`split_part(string, separator, index)`](#split_partstring-separator-index) | Splits the `string` along the `separator` and returns the data at the (1-based) `index` of the list. If the `index` is outside the bounds of the list, return an empty string (to match PostgreSQL's behavior). |
-| [`starts_with(string, search_string)`](#string--search_string) | Alias for `^@`. |
 | [`str_split(string, separator)`](#string_splitstring-separator) | Alias for `string_split`. |
 | [`str_split_regex(string, regex[, options])`](#string_split_regexstring-regex-options) | Alias for `string_split_regex`. |
 | [`string_split(string, separator)`](#string_splitstring-separator) | Splits the `string` along the `separator`. |
@@ -104,7 +102,6 @@ This section describes functions and operators for examining and manipulating [`
 | [`string_to_array(string, separator)`](#string_splitstring-separator) | Alias for `string_split`. |
 | [`strip_accents(string)`](#strip_accentsstring) | Strips accents from `string`. |
 | [`strlen(string)`](#strlenstring) | Number of bytes in `string`. |
-| [`strpos(string, search_string)`](#instrstring-search_string) | Alias for `instr`. |
 | [`substr(string, start[, length])`](#substringstring-start-length) | Alias for `substring`. |
 | [`substring(string, start[, length])`](#substringstring-start-length) | Extracts substring starting from character `start` up to the end of the string. If optional argument `length` is set, extracts a substring of `length` characters instead. Note that a `start` value of `1` refers to the first character of the `string`. |
 | [`substring_grapheme(string, start[, length])`](#substring_graphemestring-start-length) | Extracts substring starting from grapheme clusters `start` up to the end of the string. If optional argument `length` is set, extracts a substring of `length` grapheme clusters instead. Note that a `start` value of `1` refers to the `first` character of the `string`. |
@@ -188,19 +185,6 @@ This section describes functions and operators for examining and manipulating [`
 | **Description** | Extracts a single character from a `string` using a (1-based) `index`. |
 | **Example** | `array_extract('DuckDB', 2)` |
 | **Result** | `u` |
-
-#### `array_slice(list, begin, end)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Extracts a sublist or substring using [slice conventions]({% link docs/preview/sql/functions/list.md %}#slicing). Negative values are accepted. |
-| **Example 1** | `array_slice('DuckDB', 3, 4)` |
-| **Result** | `ck` |
-| **Example 2** | `array_slice('DuckDB', 3, NULL)` |
-| **Result** | `NULL` |
-| **Example 3** | `array_slice('DuckDB', 0, -3)` |
-| **Result** | `Duck` |
-| **Alias** | `list_slice` |
 
 #### `ascii(string)`
 

--- a/docs/preview/sql/functions/text.md
+++ b/docs/preview/sql/functions/text.md
@@ -27,33 +27,33 @@ This section describes functions and operators for examining and manipulating [`
 | [`array_slice(list, begin, end)`](#array_slicelist-begin-end) | Extracts a sublist or substring using [slice conventions]({% link docs/preview/sql/functions/list.md %}#slicing). Negative values are accepted. |
 | [`ascii(string)`](#asciistring) | Returns an integer that represents the Unicode code point of the first character of the `string`. |
 | [`bar(x, min, max[, width])`](#barx-min-max-width) | Draws a band whose width is proportional to (`x - min`) and equal to `width` characters when `x` = `max`. `width` defaults to 80. |
-| [`base64(blob)`](#base64blob) | Converts a `blob` to a base64 encoded string. |
+| [`base64(blob)`](#to_base64blob) | Alias for `to_base64`. |
 | [`bin(string)`](#binstring) | Converts the `string` to binary representation. |
 | [`bit_length(string)`](#bit_lengthstring) | Number of bits in a `string`. |
-| [`char_length(string)`](#char_lengthstring) | Number of characters in `string`. |
-| [`character_length(string)`](#character_lengthstring) | Number of characters in `string`. |
+| [`char_length(string)`](#lengthstring) | Alias for `length`. |
+| [`character_length(string)`](#lengthstring) | Alias for `length`. |
 | [`chr(code_point)`](#chrcode_point) | Returns a character which is corresponding the ASCII code value or Unicode code point. |
 | [`concat(value, ...)`](#concatvalue-) | Concatenates multiple strings or lists. `NULL` inputs are skipped. See also [operator `||`](#arg1--arg2). |
 | [`concat_ws(separator, string, ...)`](#concat_wsseparator-string-) | Concatenates many strings, separated by `separator`. `NULL` inputs are skipped. |
 | [`contains(string, search_string)`](#containsstring-search_string) | Returns `true` if `search_string` is found within `string`. |
-| [`ends_with(string, search_string)`](#ends_withstring-search_string) | Returns `true` if `string` ends with `search_string`. |
+| [`ends_with(string, search_string)`](#suffixstring-search_string) | Alias for `suffix`. |
 | [`format(format, ...)`](#formatformat-) | Formats a string using the [fmt syntax](#fmt-syntax). |
 | [`formatReadableDecimalSize(integer)`](#formatreadabledecimalsizeinteger) | Converts `integer` to a human-readable representation using units based on powers of 10 (KB, MB, GB, etc.). |
-| [`formatReadableSize(integer)`](#formatreadablesizeinteger) | Converts `integer` to a human-readable representation using units based on powers of 2 (KiB, MiB, GiB, etc.). |
+| [`formatReadableSize(integer)`](#format_bytesinteger) | Alias for `format_bytes`. |
 | [`format_bytes(integer)`](#format_bytesinteger) | Converts `integer` to a human-readable representation using units based on powers of 2 (KiB, MiB, GiB, etc.). |
 | [`from_base64(string)`](#from_base64string) | Converts a base64 encoded `string` to a character string (`BLOB`). |
-| [`from_binary(value)`](#from_binaryvalue) | Converts a `value` from binary representation to a blob. |
-| [`from_hex(value)`](#from_hexvalue) | Converts a `value` from hexadecimal representation to a blob. |
+| [`from_binary(value)`](#unbinvalue) | Alias for `unbin`. |
+| [`from_hex(value)`](#unhexvalue) | Alias for `unhex`. |
 | [`greatest(arg1, ...)`](#greatestarg1-) | Returns the largest value. For strings lexicographical ordering is used. Note that lowercase characters are considered “larger” than uppercase characters and [collations]({% link docs/preview/sql/expressions/collations.md %}) are not supported. |
 | [`hash(value, ...)`](#hashvalue-) | Returns a `UBIGINT` with the hash of the `value`. Note that this is not a cryptographic hash. |
 | [`hex(string)`](#hexstring) | Converts the `string` to hexadecimal representation. |
 | [`ilike_escape(string, like_specifier, escape_character)`](#ilike_escapestring-like_specifier-escape_character) | Returns `true` if the `string` matches the `like_specifier` (see [Pattern Matching]({% link docs/preview/sql/functions/pattern_matching.md %})) using case-insensitive matching. `escape_character` is used to search for wildcard characters in the `string`. |
 | [`instr(string, search_string)`](#instrstring-search_string) | Returns location of first occurrence of `search_string` in `string`, counting from 1. Returns 0 if no match found. |
-| [`lcase(string)`](#lcasestring) | Converts `string` to lower case. |
+| [`lcase(string)`](#lowerstring) | Alias for `lower`. |
 | [`least(arg1, ...)`](#leastarg1-) | Returns the smallest value. For strings lexicographical ordering is used. Note that uppercase characters are considered “smaller” than lowercase characters, and [collations]({% link docs/preview/sql/expressions/collations.md %}) are not supported. |
 | [`left(string, count)`](#leftstring-count) | Extracts the left-most count characters. |
 | [`left_grapheme(string, count)`](#left_graphemestring-count) | Extracts the left-most count grapheme clusters. |
-| [`len(string)`](#lenstring) | Number of characters in `string`. |
+| [`len(string)`](#lengthstring) | Alias for `length`. |
 | [`length(string)`](#lengthstring) | Number of characters in `string`. |
 | [`length_grapheme(string)`](#length_graphemestring) | Number of grapheme clusters in `string`. |
 | [`like_escape(string, like_specifier, escape_character)`](#like_escapestring-like_specifier-escape_character) | Returns `true` if the `string` matches the `like_specifier` (see [Pattern Matching]({% link docs/preview/sql/functions/pattern_matching.md %})) using case-sensitive matching. `escape_character` is used to search for wildcard characters in the `string`. |
@@ -67,7 +67,7 @@ This section describes functions and operators for examining and manipulating [`
 | [`nfc_normalize(string)`](#nfc_normalizestring) | Converts `string` to Unicode NFC normalized string. Useful for comparisons and ordering if text data is mixed between NFC normalized and not. |
 | [`not_ilike_escape(string, like_specifier, escape_character)`](#not_ilike_escapestring-like_specifier-escape_character) | Returns `false` if the `string` matches the `like_specifier` (see [Pattern Matching]({% link docs/preview/sql/functions/pattern_matching.md %})) using case-insensitive matching. `escape_character` is used to search for wildcard characters in the `string`. |
 | [`not_like_escape(string, like_specifier, escape_character)`](#not_like_escapestring-like_specifier-escape_character) | Returns `false` if the `string` matches the `like_specifier` (see [Pattern Matching]({% link docs/preview/sql/functions/pattern_matching.md %})) using case-sensitive matching. `escape_character` is used to search for wildcard characters in the `string`. |
-| [`ord(string)`](#ordstring) | Returns an `INTEGER` representing the `unicode` codepoint of the first character in the `string`. |
+| [`ord(string)`](#unicodestring) | Alias for `unicode`. |
 | [`parse_dirname(path[, separator])`](#parse_dirnamepath-separator) | Returns the top-level directory name from the given `path`. `separator` options: `system`, `both_slash` (default), `forward_slash`, `backslash`. |
 | [`parse_dirpath(path[, separator])`](#parse_dirpathpath-separator) | Returns the head of the `path` (the pathname until the last slash) similarly to Python's [`os.path.dirname`](https://docs.python.org/3.7/library/os.path.html#os.path.dirname). `separator` options: `system`, `both_slash` (default), `forward_slash`, `backslash`. |
 | [`parse_filename(string[, trim_extension][, separator])`](#parse_filenamestring-trim_extension-separator) | Returns the last component of the `path` similarly to Python's [`os.path.basename`](https://docs.python.org/3.7/library/os.path.html#os.path.basename) function. If `trim_extension` is `true`, the file extension will be removed (defaults to `false`). `separator` options: `system`, `both_slash` (default), `forward_slash`, `backslash`. |
@@ -83,7 +83,7 @@ This section describes functions and operators for examining and manipulating [`
 | [`regexp_full_match(string, regex[, col2])`](#regexp_full_matchstring-regex-col2) | Returns `true` if the entire `string` matches the `regex`. A set of optional [regex `options`]({% link docs/preview/sql/functions/regular_expressions.md %}#options-for-regular-expression-functions) can be set. |
 | [`regexp_matches(string, regex[, options])`](#regexp_matchesstring-regex-options) | Returns `true` if `string` contains the `regex`, `false` otherwise. A set of optional [regex `options`]({% link docs/preview/sql/functions/regular_expressions.md %}#options-for-regular-expression-functions) can be set. |
 | [`regexp_replace(string, regex, replacement[, options])`](#regexp_replacestring-regex-replacement-options) | If `string` contains the `regex`, replaces the matching part with `replacement`. A set of optional [regex `options`]({% link docs/preview/sql/functions/regular_expressions.md %}#options-for-regular-expression-functions) can be set. |
-| [`regexp_split_to_array(string, regex[, options])`](#regexp_split_to_arraystring-regex-options) | Splits the `string` along the `regex`. A set of optional [regex `options`]({% link docs/preview/sql/functions/regular_expressions.md %}#options-for-regular-expression-functions) can be set. |
+| [`regexp_split_to_array(string, regex[, options])`](#string_split_regexstring-regex-options) | Alias for `string_split_regex`. |
 | [`regexp_split_to_table(string, regex)`](#regexp_split_to_tablestring-regex) | Splits the `string` along the `regex` and returns a row for each part. |
 | [`repeat(string, count)`](#repeatstring-count) | Repeats the `string` `count` number of times. |
 | [`replace(string, source, target)`](#replacestring-source-target) | Replaces any occurrences of the `source` with `target` in `string`. |
@@ -94,28 +94,28 @@ This section describes functions and operators for examining and manipulating [`
 | [`rtrim(string[, characters])`](#rtrimstring-characters) | Removes any occurrences of any of the `characters` from the right side of the `string`. `characters` defaults to `space`. |
 | [`sha1(value)`](#sha1value) | Returns a `VARCHAR` with the SHA-1 hash of the `value`. |
 | [`sha256(value)`](#sha256value) | Returns a `VARCHAR` with the SHA-256 hash of the `value` |
-| [`split(string, separator)`](#splitstring-separator) | Splits the `string` along the `separator`. |
+| [`split(string, separator)`](#string_splitstring-separator) | Alias for `string_split`. |
 | [`split_part(string, separator, index)`](#split_partstring-separator-index) | Splits the `string` along the `separator` and returns the data at the (1-based) `index` of the list. If the `index` is outside the bounds of the list, return an empty string (to match PostgreSQL's behavior). |
-| [`starts_with(string, search_string)`](#starts_withstring-search_string) | Returns `true` if `string` begins with `search_string`. |
-| [`str_split(string, separator)`](#str_splitstring-separator) | Splits the `string` along the `separator`. |
-| [`str_split_regex(string, regex[, options])`](#str_split_regexstring-regex-options) | Splits the `string` along the `regex`. A set of optional [regex `options`]({% link docs/preview/sql/functions/regular_expressions.md %}#options-for-regular-expression-functions) can be set. |
+| [`starts_with(string, search_string)`](#string--search_string) | Alias for `^@`. |
+| [`str_split(string, separator)`](#string_splitstring-separator) | Alias for `string_split`. |
+| [`str_split_regex(string, regex[, options])`](#string_split_regexstring-regex-options) | Alias for `string_split_regex`. |
 | [`string_split(string, separator)`](#string_splitstring-separator) | Splits the `string` along the `separator`. |
 | [`string_split_regex(string, regex[, options])`](#string_split_regexstring-regex-options) | Splits the `string` along the `regex`. A set of optional [regex `options`]({% link docs/preview/sql/functions/regular_expressions.md %}#options-for-regular-expression-functions) can be set. |
-| [`string_to_array(string, separator)`](#string_to_arraystring-separator) | Splits the `string` along the `separator`. |
+| [`string_to_array(string, separator)`](#string_splitstring-separator) | Alias for `string_split`. |
 | [`strip_accents(string)`](#strip_accentsstring) | Strips accents from `string`. |
 | [`strlen(string)`](#strlenstring) | Number of bytes in `string`. |
-| [`strpos(string, search_string)`](#strposstring-search_string) | Returns location of first occurrence of `search_string` in `string`, counting from 1. Returns 0 if no match found. |
-| [`substr(string, start[, length])`](#substrstring-start-length) | Extracts substring starting from character `start` up to the end of the string. If optional argument `length` is set, extracts a substring of `length` characters instead. Note that a `start` value of `1` refers to the first character of the `string`. |
+| [`strpos(string, search_string)`](#instrstring-search_string) | Alias for `instr`. |
+| [`substr(string, start[, length])`](#substringstring-start-length) | Alias for `substring`. |
 | [`substring(string, start[, length])`](#substringstring-start-length) | Extracts substring starting from character `start` up to the end of the string. If optional argument `length` is set, extracts a substring of `length` characters instead. Note that a `start` value of `1` refers to the first character of the `string`. |
 | [`substring_grapheme(string, start[, length])`](#substring_graphemestring-start-length) | Extracts substring starting from grapheme clusters `start` up to the end of the string. If optional argument `length` is set, extracts a substring of `length` grapheme clusters instead. Note that a `start` value of `1` refers to the `first` character of the `string`. |
 | [`suffix(string, search_string)`](#suffixstring-search_string) | Returns `true` if `string` ends with `search_string`. |
 | [`to_base(number, radix[, min_length])`](#to_basenumber-radix-min_length) | Converts `number` to a string in the given base `radix`, optionally padding with leading zeros to `min_length`. |
 | [`to_base64(blob)`](#to_base64blob) | Converts a `blob` to a base64 encoded string. |
-| [`to_binary(string)`](#to_binarystring) | Converts the `string` to binary representation. |
-| [`to_hex(string)`](#to_hexstring) | Converts the `string` to hexadecimal representation. |
+| [`to_binary(string)`](#binstring) | Alias for `bin`. |
+| [`to_hex(string)`](#hexstring) | Alias for `hex`. |
 | [`translate(string, from, to)`](#translatestring-from-to) | Replaces each character in `string` that matches a character in the `from` set with the corresponding character in the `to` set. If `from` is longer than `to`, occurrences of the extra characters in `from` are deleted. |
 | [`trim(string[, characters])`](#trimstring-characters) | Removes any occurrences of any of the `characters` from either side of the `string`. `characters` defaults to `space`. |
-| [`ucase(string)`](#ucasestring) | Converts `string` to upper case. |
+| [`ucase(string)`](#upperstring) | Alias for `upper`. |
 | [`unbin(value)`](#unbinvalue) | Converts a `value` from binary representation to a blob. |
 | [`unhex(value)`](#unhexvalue) | Converts a `value` from hexadecimal representation to a blob. |
 | [`unicode(string)`](#unicodestring) | Returns an `INTEGER` representing the `unicode` codepoint of the first character in the `string`. |
@@ -218,15 +218,6 @@ This section describes functions and operators for examining and manipulating [`
 | **Example** | `bar(5, 0, 20, 10)` |
 | **Result** | `██▌       ` |
 
-#### `base64(blob)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Converts a `blob` to a base64 encoded string. |
-| **Example** | `base64('A'::BLOB)` |
-| **Result** | `QQ==` |
-| **Alias** | `to_base64` |
-
 #### `bin(string)`
 
 <div class="nostroke_table"></div>
@@ -243,24 +234,6 @@ This section describes functions and operators for examining and manipulating [`
 | **Description** | Number of bits in a `string`. |
 | **Example** | `bit_length('abc')` |
 | **Result** | `24` |
-
-#### `char_length(string)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Number of characters in `string`. |
-| **Example** | `char_length('Hello🦆')` |
-| **Result** | `6` |
-| **Aliases** | `character_length`, `len`, `length` |
-
-#### `character_length(string)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Number of characters in `string`. |
-| **Example** | `character_length('Hello🦆')` |
-| **Result** | `6` |
-| **Aliases** | `char_length`, `len`, `length` |
 
 #### `chr(code_point)`
 
@@ -296,15 +269,6 @@ This section describes functions and operators for examining and manipulating [`
 | **Example** | `contains('abc', 'a')` |
 | **Result** | `true` |
 
-#### `ends_with(string, search_string)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Returns `true` if `string` ends with `search_string`. |
-| **Example** | `ends_with('abc', 'bc')` |
-| **Result** | `true` |
-| **Alias** | `suffix` |
-
 #### `format(format, ...)`
 
 <div class="nostroke_table"></div>
@@ -320,15 +284,6 @@ This section describes functions and operators for examining and manipulating [`
 | **Description** | Converts `integer` to a human-readable representation using units based on powers of 10 (KB, MB, GB, etc.). |
 | **Example** | `formatReadableDecimalSize(16_000)` |
 | **Result** | `16.0 kB` |
-
-#### `formatReadableSize(integer)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Converts `integer` to a human-readable representation using units based on powers of 2 (KiB, MiB, GiB, etc.). |
-| **Example** | `formatReadableSize(16_000)` |
-| **Result** | `15.6 KiB` |
-| **Alias** | `format_bytes` |
 
 #### `format_bytes(integer)`
 
@@ -346,24 +301,6 @@ This section describes functions and operators for examining and manipulating [`
 | **Description** | Converts a base64 encoded `string` to a character string (`BLOB`). |
 | **Example** | `from_base64('QQ==')` |
 | **Result** | `A` |
-
-#### `from_binary(value)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Converts a `value` from binary representation to a blob. |
-| **Example** | `from_binary('0110')` |
-| **Result** | `\x06` |
-| **Alias** | `unbin` |
-
-#### `from_hex(value)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Converts a `value` from hexadecimal representation to a blob. |
-| **Example** | `from_hex('2A')` |
-| **Result** | `*` |
-| **Alias** | `unhex` |
 
 #### `greatest(arg1, ...)`
 
@@ -409,15 +346,6 @@ This section describes functions and operators for examining and manipulating [`
 | **Result** | `2` |
 | **Aliases** | `position`, `strpos` |
 
-#### `lcase(string)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Converts `string` to lower case. |
-| **Example** | `lcase('Hello')` |
-| **Result** | `hello` |
-| **Alias** | `lower` |
-
 #### `least(arg1, ...)`
 
 <div class="nostroke_table"></div>
@@ -443,15 +371,6 @@ This section describes functions and operators for examining and manipulating [`
 | **Description** | Extracts the left-most count grapheme clusters. |
 | **Example** | `left_grapheme('🤦🏼‍♂️🤦🏽‍♀️', 1)` |
 | **Result** | `🤦🏼‍♂️` |
-
-#### `len(string)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Number of characters in `string`. |
-| **Example** | `length('Hello🦆')` |
-| **Result** | `6` |
-| **Aliases** | `char_length`, `character_length`, `length` |
 
 #### `length(string)`
 
@@ -560,15 +479,6 @@ This section describes functions and operators for examining and manipulating [`
 | **Description** | Returns `false` if the `string` matches the `like_specifier` (see [Pattern Matching]({% link docs/preview/sql/functions/pattern_matching.md %})) using case-sensitive matching. `escape_character` is used to search for wildcard characters in the `string`. |
 | **Example** | `not_like_escape('a%c', 'a$%c', '$')` |
 | **Result** | `false` |
-
-#### `ord(string)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Returns an `INTEGER` representing the `unicode` codepoint of the first character in the `string`. |
-| **Example** | `[unicode('âbcd'), unicode('â'), unicode(''), unicode(NULL)]` |
-| **Result** | `[226, 226, -1, NULL]` |
-| **Alias** | `unicode` |
 
 #### `parse_dirname(path[, separator])`
 
@@ -691,15 +601,6 @@ This section describes functions and operators for examining and manipulating [`
 | **Example** | `regexp_replace('hello', '[lo]', '-')` |
 | **Result** | `he-lo` |
 
-#### `regexp_split_to_array(string, regex[, options])`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Splits the `string` along the `regex`. A set of optional [regex `options`]({% link docs/preview/sql/functions/regular_expressions.md %}#options-for-regular-expression-functions) can be set. |
-| **Example** | `regexp_split_to_array('hello world; 42', ';? ')` |
-| **Result** | `[hello, world, 42]` |
-| **Aliases** | `str_split_regex`, `string_split_regex` |
-
 #### `regexp_split_to_table(string, regex)`
 
 <div class="nostroke_table"></div>
@@ -782,15 +683,6 @@ This section describes functions and operators for examining and manipulating [`
 | **Example** | `sha256('🦆')` |
 | **Result** | `d7a5c5e0d1d94c32218539e7e47d4ba9c3c7b77d61332fb60d633dde89e473fb` |
 
-#### `split(string, separator)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Splits the `string` along the `separator`. |
-| **Example** | `split('hello-world', '-')` |
-| **Result** | `[hello, world]` |
-| **Aliases** | `str_split`, `string_split`, `string_to_array` |
-
 #### `split_part(string, separator, index)`
 
 <div class="nostroke_table"></div>
@@ -798,33 +690,6 @@ This section describes functions and operators for examining and manipulating [`
 | **Description** | Splits the `string` along the `separator` and returns the data at the (1-based) `index` of the list. If the `index` is outside the bounds of the list, return an empty string (to match PostgreSQL's behavior). |
 | **Example** | `split_part('a;b;c', ';', 2)` |
 | **Result** | `b` |
-
-#### `starts_with(string, search_string)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Returns `true` if `string` begins with `search_string`. |
-| **Example** | `starts_with('abc', 'a')` |
-| **Result** | `true` |
-| **Alias** | `^@` |
-
-#### `str_split(string, separator)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Splits the `string` along the `separator`. |
-| **Example** | `str_split('hello-world', '-')` |
-| **Result** | `[hello, world]` |
-| **Aliases** | `split`, `string_split`, `string_to_array` |
-
-#### `str_split_regex(string, regex[, options])`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Splits the `string` along the `regex`. A set of optional [regex `options`]({% link docs/preview/sql/functions/regular_expressions.md %}#options-for-regular-expression-functions) can be set. |
-| **Example** | `str_split_regex('hello world; 42', ';? ')` |
-| **Result** | `[hello, world, 42]` |
-| **Aliases** | `regexp_split_to_array`, `string_split_regex` |
 
 #### `string_split(string, separator)`
 
@@ -844,15 +709,6 @@ This section describes functions and operators for examining and manipulating [`
 | **Result** | `[hello, world, 42]` |
 | **Aliases** | `regexp_split_to_array`, `str_split_regex` |
 
-#### `string_to_array(string, separator)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Splits the `string` along the `separator`. |
-| **Example** | `string_to_array('hello-world', '-')` |
-| **Result** | `[hello, world]` |
-| **Aliases** | `split`, `str_split`, `string_split` |
-
 #### `strip_accents(string)`
 
 <div class="nostroke_table"></div>
@@ -868,26 +724,6 @@ This section describes functions and operators for examining and manipulating [`
 | **Description** | Number of bytes in `string`. |
 | **Example** | `strlen('🦆')` |
 | **Result** | `4` |
-
-#### `strpos(string, search_string)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Returns location of first occurrence of `search_string` in `string`, counting from 1. Returns 0 if no match found. |
-| **Example** | `strpos('test test', 'es')` |
-| **Result** | `2` |
-| **Aliases** | `instr`, `position` |
-
-#### `substr(string, start[, length])`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Extracts substring starting from character `start` up to the end of the string. If optional argument `length` is set, extracts a substring of `length` characters instead. Note that a `start` value of `1` refers to the first character of the `string`. |
-| **Example 1** | `substring('Hello', 2)` |
-| **Result** | `ello` |
-| **Example 2** | `substring('Hello', 2, 2)` |
-| **Result** | `el` |
-| **Alias** | `substring` |
 
 #### `substring(string, start[, length])`
 
@@ -936,24 +772,6 @@ This section describes functions and operators for examining and manipulating [`
 | **Result** | `QQ==` |
 | **Alias** | `base64` |
 
-#### `to_binary(string)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Converts the `string` to binary representation. |
-| **Example** | `to_binary('Aa')` |
-| **Result** | `0100000101100001` |
-| **Alias** | `bin` |
-
-#### `to_hex(string)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Converts the `string` to hexadecimal representation. |
-| **Example** | `to_hex('Hello')` |
-| **Result** | `48656C6C6F` |
-| **Alias** | `hex` |
-
 #### `translate(string, from, to)`
 
 <div class="nostroke_table"></div>
@@ -971,15 +789,6 @@ This section describes functions and operators for examining and manipulating [`
 | **Result** | `test` |
 | **Example 2** | `trim('>>>>test<<', '><')` |
 | **Result** | `test` |
-
-#### `ucase(string)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Converts `string` to upper case. |
-| **Example** | `ucase('Hello')` |
-| **Result** | `HELLO` |
-| **Alias** | `upper` |
 
 #### `unbin(value)`
 
@@ -1045,13 +854,13 @@ These functions are used to measure the similarity of two strings using various 
 | Function | Description |
 |:--|:-------|
 | [`damerau_levenshtein(s1, s2)`](#damerau_levenshteins1-s2) | Extension of Levenshtein distance to also include transposition of adjacent characters as an allowed edit operation. In other words, the minimum number of edit operations (insertions, deletions, substitutions or transpositions) required to change one string to another. Characters of different cases (e.g., `a` and `A`) are considered different. |
-| [`editdist3(s1, s2)`](#editdist3s1-s2) | The minimum number of single-character edits (insertions, deletions or substitutions) required to change one string to the other. Characters of different cases (e.g., `a` and `A`) are considered different. |
+| [`editdist3(s1, s2)`](#levenshteins1-s2) | Alias for `levenshtein`. |
 | [`hamming(s1, s2)`](#hammings1-s2) | The Hamming distance between to strings, i.e., the number of positions with different characters for two strings of equal length. Strings must be of equal length. Characters of different cases (e.g., `a` and `A`) are considered different. |
 | [`jaccard(s1, s2)`](#jaccards1-s2) | The Jaccard similarity between two strings. Characters of different cases (e.g., `a` and `A`) are considered different. Returns a number between 0 and 1. |
 | [`jaro_similarity(s1, s2[, score_cutoff])`](#jaro_similaritys1-s2-score_cutoff) | The Jaro similarity between two strings. Characters of different cases (e.g., `a` and `A`) are considered different. Returns a number between 0 and 1. For similarity < `score_cutoff`, 0 is returned instead. `score_cutoff` defaults to 0. |
 | [`jaro_winkler_similarity(s1, s2[, score_cutoff])`](#jaro_winkler_similaritys1-s2-score_cutoff) | The Jaro-Winkler similarity between two strings. Characters of different cases (e.g., `a` and `A`) are considered different. Returns a number between 0 and 1. For similarity < `score_cutoff`, 0 is returned instead. `score_cutoff` defaults to 0. |
 | [`levenshtein(s1, s2)`](#levenshteins1-s2) | The minimum number of single-character edits (insertions, deletions or substitutions) required to change one string to the other. Characters of different cases (e.g., `a` and `A`) are considered different. |
-| [`mismatches(s1, s2)`](#mismatchess1-s2) | The Hamming distance between to strings, i.e., the number of positions with different characters for two strings of equal length. Strings must be of equal length. Characters of different cases (e.g., `a` and `A`) are considered different. |
+| [`mismatches(s1, s2)`](#hammings1-s2) | Alias for `hamming`. |
 
 <!-- markdownlint-enable MD056 -->
 
@@ -1062,15 +871,6 @@ These functions are used to measure the similarity of two strings using various 
 | **Description** | Extension of Levenshtein distance to also include transposition of adjacent characters as an allowed edit operation. In other words, the minimum number of edit operations (insertions, deletions, substitutions or transpositions) required to change one string to another. Characters of different cases (e.g., `a` and `A`) are considered different. |
 | **Example** | `damerau_levenshtein('duckdb', 'udckbd')` |
 | **Result** | `2` |
-
-#### `editdist3(s1, s2)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | The minimum number of single-character edits (insertions, deletions or substitutions) required to change one string to the other. Characters of different cases (e.g., `a` and `A`) are considered different. |
-| **Example** | `editdist3('duck', 'db')` |
-| **Result** | `3` |
-| **Alias** | `levenshtein` |
 
 #### `hamming(s1, s2)`
 
@@ -1113,15 +913,6 @@ These functions are used to measure the similarity of two strings using various 
 | **Example** | `levenshtein('duck', 'db')` |
 | **Result** | `3` |
 | **Alias** | `editdist3` |
-
-#### `mismatches(s1, s2)`
-
-<div class="nostroke_table"></div>
-
-| **Description** | The Hamming distance between to strings, i.e., the number of positions with different characters for two strings of equal length. Strings must be of equal length. Characters of different cases (e.g., `a` and `A`) are considered different. |
-| **Example** | `mismatches('duck', 'luck')` |
-| **Result** | `1` |
-| **Alias** | `hamming` |
 
 <!-- End of section generated by scripts/generate_sql_function_docs.py -->
 

--- a/scripts/generate_sql_function_docs.py
+++ b/scripts/generate_sql_function_docs.py
@@ -293,6 +293,14 @@ OVERRIDES: list[DocFunction] = [
         nr_optional_arguments=1,
         is_variadic=True,
     ),
+    DocFunction(
+        category='list',
+        name='array_length',  # edge case: contains not implemented overload
+        parameters=['list'],
+        description="",
+        examples=[""],
+        alias_of='length',
+    ),
 ]
 
 # NOTE: All function aliases are added, unless explicitly excluded. Format: (<category>, <function_name>)
@@ -433,7 +441,11 @@ def apply_overrides(function_data: list[DocFunction], categories: list[str]):
         func
         for func in function_data
         if not any(
-            func.category == override.category and func.name == override.name
+            func.category == override.category
+            and (
+                func.name == override.name
+                or (func.name in override.aliases and func.alias_of)
+            )
             for override in OVERRIDES
         )
         and (func.category, func.name) not in EXCLUDES
@@ -470,6 +482,7 @@ def apply_overrides(function_data: list[DocFunction], categories: list[str]):
                         example.replace(override.name, alias.name)
                         for example in alias.examples
                     ]
+                    alias.alias_of = override.name
                     function_data.append(alias)
     return function_data
 


### PR DESCRIPTION
Aliases are pruned in the function docs.

# Current situation
aliases are repeated both in the function list and in the section with details and examples

| Function | Description |
|:--|:-------|
| [`apply(list, lambda(x))`](#applylist-lambdax) | Returns a list that is the result of applying the `lambda` function to each element of the input `list`. The return type is defined by the return type of the `lambda` function. See [`list_transform` examples](https://duckdb.org/docs/preview/sql/functions/lambda.html#list_transform-examples). |
| [`list_transform(list, lambda(x))`](#list_transformlist-lambdax) | Returns a list that is the result of applying the `lambda` function to each element of the input `list`. The return type is defined by the return type of the `lambda` function. See [`list_transform` examples](https://duckdb.org/docs/preview/sql/functions/lambda.html#list_transform-examples). |

#### `apply(list, lambda(x))`
|  |  |
|:--|:-------|
| **Description** | Returns a list that is the result of applying the `lambda` function to each element of the input `list`. The return type is defined by the return type of the `lambda` function. See [`list_transform` examples](https://duckdb.org/docs/preview/sql/functions/lambda.html#list_transform-examples). |
| **Example** | `apply([1, 2, 3], lambda x : x + 1)` |
| **Result** | `[2, 3, 4]` |
| **Aliases** | `array_apply`, `array_transform`, `list_apply`, `list_transform` |

#### `list_transform(list, lambda(x))`
|  |  |
|:--|:-------|
| **Description** | Returns a list that is the result of applying the `lambda` function to each element of the input `list`. The return type is defined by the return type of the `lambda` function. See [`list_transform` examples](https://duckdb.org/docs/preview/sql/functions/lambda.html#list_transform-examples). |
| **Example** | `list_transform([1, 2, 3], lambda x : x + 1)` |
| **Result** | `[2, 3, 4]` |
| **Aliases** | `apply`, `array_apply`, `array_transform`, `list_apply` |


# situation with this PR:
- descriptions are not repeated in function list
- entries for aliases are removed from section with details and examples

| Function | Description |
|:--|:-------|
| [`apply(list, lambda(x))`](#list_transformlist-lambdax) | Alias for `list_transform`. |
| [`list_transform(list, lambda(x))`](#list_transformlist-lambdax) | Returns a list that is the result of applying the `lambda` function to each element of the input `list`. The return type is defined by the return type of the `lambda` function. See [`list_transform` examples](https://duckdb.org/docs/preview/sql/functions/lambda.html#list_transform-examples). |

#### `list_transform(list, lambda(x))`
|  |  |
|:--|:-------|
| **Description** | Returns a list that is the result of applying the `lambda` function to each element of the input `list`. The return type is defined by the return type of the `lambda` function.See [`list_transform` examples](https://duckdb.org/docs/preview/sql/functions/lambda.html#list_transform-examples). |
| **Example** | `list_transform([1, 2, 3], lambda x : x + 1)` |
| **Result** | `[2, 3, 4]` |
| **Aliases** | `apply`, `array_apply`, `array_transform`, `list_apply` |