### PR TITLE
explain that `use` statement uses an implicit 'main' schema if not provided explicitly

### DIFF
--- a/docs/stable/sql/statements/use.md
+++ b/docs/stable/sql/statements/use.md
@@ -12,7 +12,7 @@ The `USE` statement selects a database and optional schema to use as the default
 
 ```sql
 --- Sets the 'memory' database as the default. Will use 'main' schema implicitly or error
-if it does not exist.
+--- if it does not exist.
 USE memory;
 --- Sets the 'duck.main' database and schema as the default
 USE duck.main;

--- a/docs/stable/sql/statements/use.md
+++ b/docs/stable/sql/statements/use.md
@@ -11,7 +11,8 @@ The `USE` statement selects a database and optional schema to use as the default
 ## Examples
 
 ```sql
---- Sets the 'memory' database as the default
+--- Sets the 'memory' database as the default. Will use 'main' schema implicitly or error
+if it does not exist.
 USE memory;
 --- Sets the 'duck.main' database and schema as the default
 USE duck.main;


### PR DESCRIPTION
Related https://github.com/duckdb/duckdb-iceberg/issues/324