### PR TITLE
docs(adbc): remove confusing line and update the link to the arrow adbc docs

### DIFF
--- a/docs/preview/clients/adbc.md
+++ b/docs/preview/clients/adbc.md
@@ -7,9 +7,7 @@ title: ADBC Client
 
 [Arrow Database Connectivity (ADBC)](https://arrow.apache.org/adbc/), similarly to ODBC and JDBC, is a C-style API that enables code portability between different database systems. This allows developers to effortlessly build applications that communicate with database systems without using code specific to that system. The main difference between ADBC and ODBC/JDBC is that ADBC uses [Arrow](https://arrow.apache.org/) to transfer data between the database system and the application. DuckDB has an ADBC driver, which takes advantage of the [zero-copy integration between DuckDB and Arrow]({% post_url 2021-12-03-duck-arrow %}) to efficiently transfer data.
 
-DuckDB's ADBC driver currently supports version 0.7 of ADBC.
-
-Please refer to the [ADBC documentation page](https://arrow.apache.org/adbc/0.7.0/cpp/index.html) for a more extensive discussion on ADBC and a detailed API explanation.
+Please refer to the [ADBC documentation page](https://arrow.apache.org/adbc/current/) for a more extensive discussion on ADBC and a detailed API explanation.
 
 ## Implemented Functionality
 

--- a/docs/stable/clients/adbc.md
+++ b/docs/stable/clients/adbc.md
@@ -11,9 +11,7 @@ title: ADBC Client
 
 [Arrow Database Connectivity (ADBC)](https://arrow.apache.org/adbc/), similarly to ODBC and JDBC, is a C-style API that enables code portability between different database systems. This allows developers to effortlessly build applications that communicate with database systems without using code specific to that system. The main difference between ADBC and ODBC/JDBC is that ADBC uses [Arrow](https://arrow.apache.org/) to transfer data between the database system and the application. DuckDB has an ADBC driver, which takes advantage of the [zero-copy integration between DuckDB and Arrow]({% post_url 2021-12-03-duck-arrow %}) to efficiently transfer data.
 
-DuckDB's ADBC driver currently supports version 0.7 of ADBC.
-
-Please refer to the [ADBC documentation page](https://arrow.apache.org/adbc/0.7.0/cpp/index.html) for a more extensive discussion on ADBC and a detailed API explanation.
+Please refer to the [ADBC documentation page](https://arrow.apache.org/adbc/current/) for a more extensive discussion on ADBC and a detailed API explanation.
 
 ## Implemented Functionality
 


### PR DESCRIPTION
Context: apache/arrow-adbc#2216

DuckDB actually supports ADBC API 1.1.0, but the documentation shows the old library version (different from the API version) as 0.7, which is confusing and needs to be updated.
And, the link will be updated to point to the latest version.