### PR TITLE
Update spatial functions to duckdb-spatial's version

### DIFF
--- a/docs/preview/core_extensions/spatial/functions.md
+++ b/docs/preview/core_extensions/spatial/functions.md
@@ -1,4 +1,7 @@
-# DuckDB Spatial Function Reference
+---
+layout: docu
+title: Spatial Functions
+---
 
 ## Function Index 
 **[Scalar Functions](#scalar-functions)**

--- a/docs/stable/core_extensions/spatial/functions.md
+++ b/docs/stable/core_extensions/spatial/functions.md
@@ -1,4 +1,10 @@
-# DuckDB Spatial Function Reference
+---
+layout: docu
+title: Spatial Functions
+redirect_from:
+- /docs/stable/extensions/spatial/functions
+- /docs/stable/extensions/spatial/functions/
+---
 
 ## Function Index 
 **[Scalar Functions](#scalar-functions)**


### PR DESCRIPTION
Currently, not all the spatial functions are documented on <https://duckdb.org/docs/stable/core_extensions/spatial/functions>. I already fixed some in duckdb-spatial repo (https://github.com/duckdb/duckdb-spatial/pull/592, https://github.com/duckdb/duckdb-spatial/pull/598).

However, it seems the corresponding page in this repository is not updated. I'm not sure if there's any mechanism to reflect the updates to this repo automatically. This pull request is to manually reflect the changes.