### PR TITLE
add secret type 'ducklake'

### DIFF
--- a/docs/preview/configuration/secrets_manager.md
+++ b/docs/preview/configuration/secrets_manager.md
@@ -13,16 +13,17 @@ Secrets are typed, their type identifies which service they are for.
 Most secrets are not included in DuckDB default, instead, they are registered by extensions.
 Currently, the following secret types are available:
 
-| Secret type   | Service / protocol   | Extension                                                                  |
-| ------------- | -------------------- | -------------------------------------------------------------------------- |
-| `azure`       | Azure Blob Storage   | [`azure`]({% link docs/preview/core_extensions/azure.md %})                |
-| `gcs`         | Google Cloud Storage | [`httpfs`]({% link docs/preview/core_extensions/httpfs/s3api.md %})        |
-| `http`        | HTTP and HTTPS       | [`httpfs`]({% link docs/preview/core_extensions/httpfs/https.md %})        |
-| `huggingface` | Hugging Face         | [`httpfs`]({% link docs/preview/core_extensions/httpfs/hugging_face.md %}) |
-| `mysql`       | MySQL                | [`mysql`]({% link docs/preview/core_extensions/mysql.md %})                |
-| `postgres`    | PostgreSQL           | [`postgres`]({% link docs/preview/core_extensions/postgres.md %})          |
-| `r2`          | Cloudflare R2        | [`httpfs`]({% link docs/preview/core_extensions/httpfs/s3api.md %})        |
-| `s3`          | AWS S3               | [`httpfs`]({% link docs/preview/core_extensions/httpfs/s3api.md %})        |
+| Secret type   | Service / protocol   | Extension                                                                         |
+| ------------- | -------------------- | --------------------------------------------------------------------------------- |
+| `azure`       | Azure Blob Storage   | [`azure`]({% link docs/preview/core_extensions/azure.md %})                       |
+| `ducklake`    | DuckLake             | [`ducklake`](https://ducklake.select/docs/stable/duckdb/usage/connecting#secrets) |
+| `gcs`         | Google Cloud Storage | [`httpfs`]({% link docs/preview/core_extensions/httpfs/s3api.md %})               |
+| `http`        | HTTP and HTTPS       | [`httpfs`]({% link docs/preview/core_extensions/httpfs/https.md %})               |
+| `huggingface` | Hugging Face         | [`httpfs`]({% link docs/preview/core_extensions/httpfs/hugging_face.md %})        |
+| `mysql`       | MySQL                | [`mysql`]({% link docs/preview/core_extensions/mysql.md %})                       |
+| `postgres`    | PostgreSQL           | [`postgres`]({% link docs/preview/core_extensions/postgres.md %})                 |
+| `r2`          | Cloudflare R2        | [`httpfs`]({% link docs/preview/core_extensions/httpfs/s3api.md %})               |
+| `s3`          | AWS S3               | [`httpfs`]({% link docs/preview/core_extensions/httpfs/s3api.md %})               |
 
 For each type, there are one or more “secret providers” that specify how the secret is created. Secrets can also have an optional scope, which is a file path prefix that the secret applies to. When fetching a secret for a path, the secret scopes are compared to the path, returning the matching secret for the path. In the case of multiple matching secrets, the longest prefix is chosen.
 


### PR DESCRIPTION
Added Secret Type `ducklake`. 
Note that I used an external link to https://ducklake.select/docs/stable/duckdb/usage/connecting#secrets.
The [ducklake extension page](https://duckdb.org/docs/stable/core_extensions/ducklake), is not as detailed at the moment, and doesn't cover DuckLake secrets, atm