### PR TITLE
Document USE schema.

### DIFF
--- a/docs/preview/sql/statements/use.md
+++ b/docs/preview/sql/statements/use.md
@@ -4,7 +4,7 @@ railroad: statements/use.js
 title: USE Statement
 ---
 
-The `USE` statement selects a database and optional schema to use as the default.
+The `USE` statement selects a database and optional schema, or just a schema to use as the default.
 
 ## Examples
 
@@ -14,12 +14,14 @@ The `USE` statement selects a database and optional schema to use as the default
 USE memory;
 --- Sets the 'duck.main' database and schema as the default
 USE duck.main;
+-- Sets the `main` schema of the currently selected database as the default, in this case 'duck.main'
+USE main;
 ```
 
 ## Syntax
 
 <div id="rrdiagram1"></div>
 
-The `USE` statement sets a default database or database/schema combination to use for
+The `USE` statement sets a default database, schema or database/schema combination to use for
 future operations. For instance, tables created without providing a fully qualified
 table name will be created in the default database.

--- a/docs/stable/sql/statements/use.md
+++ b/docs/stable/sql/statements/use.md
@@ -6,7 +6,7 @@ redirect_from:
 title: USE Statement
 ---
 
-The `USE` statement selects a database and optional schema to use as the default.
+The `USE` statement selects a database and optional schema, or just a schema to use as the default.
 
 ## Examples
 
@@ -16,12 +16,14 @@ The `USE` statement selects a database and optional schema to use as the default
 USE memory;
 --- Sets the 'duck.main' database and schema as the default
 USE duck.main;
+-- Sets the `main` schema of the currently selected database as the default, in this case 'duck.main'
+USE main;
 ```
 
 ## Syntax
 
 <div id="rrdiagram1"></div>
 
-The `USE` statement sets a default database or database/schema combination to use for
+The `USE` statement sets a default database, schema or database/schema combination to use for
 future operations. For instance, tables created without providing a fully qualified
 table name will be created in the default database.

--- a/js/preview/statements/use.js
+++ b/js/preview/statements/use.js
@@ -2,8 +2,13 @@ function GenerateUse(options = {}) {
     return Diagram([
         AutomaticStack([
             Keyword("USE"),
-            Expression("database-name"),
-            Optional(Sequence([Keyword("."), Expression("schema-name")]), "skip")
+            Choice(0, [
+                Sequence([
+                    Expression("database-name"),
+                    Optional(Sequence([Keyword("."), Expression("schema-name")]), "skip")
+                ]),
+                Expression("schema-name")
+            ])
         ])
     ])
 }

--- a/js/stable/statements/use.js
+++ b/js/stable/statements/use.js
@@ -2,8 +2,13 @@ function GenerateUse(options = {}) {
     return Diagram([
         AutomaticStack([
             Keyword("USE"),
-            Expression("database-name"),
-            Optional(Sequence([Keyword("."), Expression("schema-name")]), "skip")
+            Choice(0, [
+                Sequence([
+                    Expression("database-name"),
+                    Optional(Sequence([Keyword("."), Expression("schema-name")]), "skip")
+                ]),
+                Expression("schema-name")
+            ])
         ])
     ])
 }


### PR DESCRIPTION
The `USE` command actually permits just a `schema` to be passed in as well. This seems to be [expected behavior](https://github.com/duckdb/duckdb/pull/18179#issuecomment-3054060500).