### PR TITLE
Fix Typo in Known Python Issues

### DIFF
--- a/docs/preview/clients/python/known_issues.md
+++ b/docs/preview/clients/python/known_issues.md
@@ -44,7 +44,7 @@ Out[2]:
 
 Please also check out the [Jupyter guide]({% link docs/preview/guides/python/jupyter.md %}) for tips on using Jupyter with JupySQL.
 
-### Crashes and Errors on Windos
+### Crashes and Errors on Windows
 
 When importing DuckDB on Windows, the Python runtime may crash or return an error upon import or first use:
 

--- a/docs/stable/clients/python/known_issues.md
+++ b/docs/stable/clients/python/known_issues.md
@@ -48,7 +48,7 @@ Out[2]:
 
 Please also check out the [Jupyter guide]({% link docs/stable/guides/python/jupyter.md %}) for tips on using Jupyter with JupySQL.
 
-### Crashes and Errors on Windos
+### Crashes and Errors on Windows
 
 When importing DuckDB on Windows, the Python runtime may crash or return an error upon import or first use:
 


### PR DESCRIPTION
https://duckdb.org/docs/stable/clients/python/known_issues.html#crashes-and-errors-on-windos

Windows was mistyped as Windos.