### PR TITLE
add force option

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -140,7 +140,7 @@ bundle install
 If you are on Windows, run these two commands to ensure Jekyll works:
 
 ```bash
-gem uninstall eventmachine
+gem uninstall eventmachine --force
 gem install eventmachine --platform ruby
 ```
 


### PR DESCRIPTION
Hi DuckDB!

Recently went through the on-boarding process to clone docs repo on windows, I ran into an error when running the command documented [on the BUILDING.md](https://github.com/duckdb/duckdb-web/blob/main/BUILDING.md#jekyll-doesnt-work-on-windows).  Ideally the `--force` option would be used, to save people a bit of time due to the possible dependency error message detailed here:

```
$ gem uninstall eventmachine
ERROR:  While executing gem ... (Gem::DependencyRemovalException)
    Uninstallation aborted due to dependent gem(s)
        C:/Ruby33-x64/lib/ruby/site_ruby/3.3.0/rubygems/uninstaller.rb:152:in `uninstall_gem'
        C:/Ruby33-x64/lib/ruby/site_ruby/3.3.0/rubygems/uninstaller.rb:138:in `uninstall'
        C:/Ruby33-x64/lib/ruby/site_ruby/3.3.0/rubygems/commands/uninstall_command.rb:202:in `uninstall'
        C:/Ruby33-x64/lib/ruby/site_ruby/3.3.0/rubygems/commands/uninstall_command.rb:188:in `uninstall_gem'
        C:/Ruby33-x64/lib/ruby/site_ruby/3.3.0/rubygems/commands/uninstall_command.rb:183:in `block in uninstall_specific'
        C:/Ruby33-x64/lib/ruby/site_ruby/3.3.0/rubygems/commands/uninstall_command.rb:175:in `each'
        C:/Ruby33-x64/lib/ruby/site_ruby/3.3.0/rubygems/commands/uninstall_command.rb:175:in `uninstall_specific'
        C:/Ruby33-x64/lib/ruby/site_ruby/3.3.0/rubygems/commands/uninstall_command.rb:136:in `execute'
        C:/Ruby33-x64/lib/ruby/site_ruby/3.3.0/rubygems/command.rb:326:in `invoke_with_build_args'
        C:/Ruby33-x64/lib/ruby/site_ruby/3.3.0/rubygems/command_manager.rb:253:in `invoke_command'
        C:/Ruby33-x64/lib/ruby/site_ruby/3.3.0/rubygems/command_manager.rb:194:in `process_args'
        C:/Ruby33-x64/lib/ruby/site_ruby/3.3.0/rubygems/command_manager.rb:152:in `run'
        C:/Ruby33-x64/lib/ruby/site_ruby/3.3.0/rubygems/gem_runner.rb:57:in `run'
        C:/Ruby33-x64/bin/gem:12:in `<main>'
        ```