### PR TITLE
CLI WSL Memory Note

### DIFF
--- a/_data/menu_docs_preview.json
+++ b/_data/menu_docs_preview.json
@@ -277,6 +277,10 @@
                 {
                   "page": "Syntax Highlighting",
                   "url": "syntax_highlighting"
+                },
+                {
+                  "page": "Known Issues",
+                  "url": "known_issues"
                 }
               ]
             },

--- a/_data/menu_docs_stable.json
+++ b/_data/menu_docs_stable.json
@@ -277,6 +277,10 @@
                 {
                   "page": "Syntax Highlighting",
                   "url": "syntax_highlighting"
+                },
+                {
+                  "page": "Known Issues",
+                  "url": "known_issues"
                 }
               ]
             },

--- a/docs/preview/clients/cli/known_issues.md
+++ b/docs/preview/clients/cli/known_issues.md
@@ -1,0 +1,26 @@
+---
+layout: docu
+title: Known Issues
+---
+
+## Incorrect Memory Values on WSL 2
+
+On Windows Subsystem for Linux 2 (WSL2), when querying the `max_memory` or `memory_limit` from the `duckdb_settings`, the values may be inaccurate on certain Ubuntu versions (e.g., 20.04 and 24.04):
+
+Example:
+
+```sql
+FROM duckdb_settings() WHERE name LIKE '%mem%';
+```
+
+The output contains values larger than 1000 PiB:
+
+```text
+┌──────────────┬────────────┬─────────────────────────────────────────────┬────────────┬─────────┐
+│     name     │   value    │                 description                 │ input_type │  scope  │
+│   varchar    │  varchar   │                   varchar                   │  varchar   │ varchar │
+├──────────────┼────────────┼─────────────────────────────────────────────┼────────────┼─────────┤
+│ max_memory   │ 1638.3 PiB │ The maximum memory of the system (e.g. 1GB) │ VARCHAR    │ GLOBAL  │
+│ memory_limit │ 1638.3 PiB │ The maximum memory of the system (e.g. 1GB) │ VARCHAR    │ GLOBAL  │
+└──────────────┴────────────┴─────────────────────────────────────────────┴────────────┴─────────┘
+```

--- a/docs/stable/clients/cli/known_issues.md
+++ b/docs/stable/clients/cli/known_issues.md
@@ -1,0 +1,26 @@
+---
+layout: docu
+title: Known Issues
+---
+
+## Incorrect Memory Values on WSL 2
+
+On Windows Subsystem for Linux 2 (WSL2), when querying the `max_memory` or `memory_limit` from the `duckdb_settings`, the values may be inaccurate on certain Ubuntu versions (e.g., 20.04 and 24.04):
+
+Example:
+
+```sql
+FROM duckdb_settings() WHERE name LIKE '%mem%';
+```
+
+The output contains values larger than 1000 PiB:
+
+```text
+┌──────────────┬────────────┬─────────────────────────────────────────────┬────────────┬─────────┐
+│     name     │   value    │                 description                 │ input_type │  scope  │
+│   varchar    │  varchar   │                   varchar                   │  varchar   │ varchar │
+├──────────────┼────────────┼─────────────────────────────────────────────┼────────────┼─────────┤
+│ max_memory   │ 1638.3 PiB │ The maximum memory of the system (e.g. 1GB) │ VARCHAR    │ GLOBAL  │
+│ memory_limit │ 1638.3 PiB │ The maximum memory of the system (e.g. 1GB) │ VARCHAR    │ GLOBAL  │
+└──────────────┴────────────┴─────────────────────────────────────────────┴────────────┴─────────┘
+```

--- a/docs/stable/clients/cli/overview.md
+++ b/docs/stable/clients/cli/overview.md
@@ -326,12 +326,14 @@ To create and execute a prepared statement in the CLI client, use the `PREPARE` 
 
 ## Known Issues
 
-When querying the `max_memory` or `memory_limit` from the `duckdb_settings` using the CLI on Windows Subsystem for Linux (WSL) prior to version `2.5.7`, the returned values are incorrect. 
+When querying the `max_memory` or `memory_limit` from the `duckdb_settings` using the on the following versions of Ubuntu, the results are inaccurate:
+- Ubuntu 24.04.2
+- Canonical-Ubuntu-20.04-2025.07.23-0
 
 Example:
 
 ```bash
-from duckdb_settings() where name like '%mem%';
+echo "from duckdb_settings() where name like '%mem%';" | duckdb mydb.duckdb
 ```
 
 A workaround for this is to [download the latest WSL release](https://github.com/microsoft/WSL/releases).

--- a/docs/stable/clients/cli/overview.md
+++ b/docs/stable/clients/cli/overview.md
@@ -326,11 +326,12 @@ To create and execute a prepared statement in the CLI client, use the `PREPARE` 
 
 ## Known Issues
 
-When querying the `max_memory` or `memory_limit` from the `duckdb_settings` using Windows Subsystem for Linux (WSL) prior to version `2.5.7`,
-the returned values are incorrect. 
+When querying the `max_memory` or `memory_limit` from the `duckdb_settings` using the CLI on Windows Subsystem for Linux (WSL) prior to version `2.5.7`, the returned values are incorrect. 
 
 Example:
 
 ```bash
 from duckdb_settings() where name like '%mem%';
 ```
+
+A workaround for this is to [download the latest WSL release](https://github.com/microsoft/WSL/releases).

--- a/docs/stable/clients/cli/overview.md
+++ b/docs/stable/clients/cli/overview.md
@@ -323,3 +323,14 @@ It is only available in the CLI client and is not supported in other DuckDB clie
 
 The DuckDB CLI supports executing [prepared statements]({% link docs/stable/sql/query_syntax/prepared_statements.md %}) in addition to regular `SELECT` statements.
 To create and execute a prepared statement in the CLI client, use the `PREPARE` clause and the `EXECUTE` statement.
+
+## Known Issues
+
+When querying the `max_memory` or `memory_limit` from the `duckdb_settings` using Windows Subsystem for Linux (WSL) prior to version `2.5.7`,
+the returned values are incorrect. 
+
+Example:
+
+```bash
+from duckdb_settings() where name like '%mem%';
+```

--- a/docs/stable/clients/cli/overview.md
+++ b/docs/stable/clients/cli/overview.md
@@ -323,27 +323,3 @@ It is only available in the CLI client and is not supported in other DuckDB clie
 
 The DuckDB CLI supports executing [prepared statements]({% link docs/stable/sql/query_syntax/prepared_statements.md %}) in addition to regular `SELECT` statements.
 To create and execute a prepared statement in the CLI client, use the `PREPARE` clause and the `EXECUTE` statement.
-
-## Known Issues
-
-When querying the `max_memory` or `memory_limit` from the `duckdb_settings` using any of the following versions of Ubuntu, the values are inaccurate:
-- Ubuntu 24.04.2
-- Canonical-Ubuntu-20.04-2025.07.23-0
-
-Example:
-
-```bash
-echo "from duckdb_settings() where name like '%mem%';" | duckdb mydb.duckdb
-```
-
-Output:
-
-```bash
-┌──────────────┬────────────┬─────────────────────────────────────────────┬────────────┬─────────┐
-│     name     │   value    │                 description                 │ input_type │  scope  │
-│   varchar    │  varchar   │                   varchar                   │  varchar   │ varchar │
-├──────────────┼────────────┼─────────────────────────────────────────────┼────────────┼─────────┤
-│ max_memory   │ 1638.3 PiB │ The maximum memory of the system (e.g. 1GB) │ VARCHAR    │ GLOBAL  │
-│ memory_limit │ 1638.3 PiB │ The maximum memory of the system (e.g. 1GB) │ VARCHAR    │ GLOBAL  │
-└──────────────┴────────────┴─────────────────────────────────────────────┴────────────┴─────────┘
-```

--- a/docs/stable/clients/cli/overview.md
+++ b/docs/stable/clients/cli/overview.md
@@ -336,4 +336,14 @@ Example:
 echo "from duckdb_settings() where name like '%mem%';" | duckdb mydb.duckdb
 ```
 
-A workaround for this is to [download the latest WSL release](https://github.com/microsoft/WSL/releases).
+Output:
+
+```bash
+┌──────────────┬────────────┬─────────────────────────────────────────────┬────────────┬─────────┐
+│     name     │   value    │                 description                 │ input_type │  scope  │
+│   varchar    │  varchar   │                   varchar                   │  varchar   │ varchar │
+├──────────────┼────────────┼─────────────────────────────────────────────┼────────────┼─────────┤
+│ max_memory   │ 1638.3 PiB │ The maximum memory of the system (e.g. 1GB) │ VARCHAR    │ GLOBAL  │
+│ memory_limit │ 1638.3 PiB │ The maximum memory of the system (e.g. 1GB) │ VARCHAR    │ GLOBAL  │
+└──────────────┴────────────┴─────────────────────────────────────────────┴────────────┴─────────┘
+```

--- a/docs/stable/clients/cli/overview.md
+++ b/docs/stable/clients/cli/overview.md
@@ -326,7 +326,7 @@ To create and execute a prepared statement in the CLI client, use the `PREPARE` 
 
 ## Known Issues
 
-When querying the `max_memory` or `memory_limit` from the `duckdb_settings` using the on the following versions of Ubuntu, the results are inaccurate:
+When querying the `max_memory` or `memory_limit` from the `duckdb_settings` using any of the following versions of Ubuntu, the values are inaccurate:
 - Ubuntu 24.04.2
 - Canonical-Ubuntu-20.04-2025.07.23-0
 


### PR DESCRIPTION
Hi DuckDB!

This PR addresses https://github.com/duckdb/duckdb/issues/17646, there was not a super obvious place to put this note so I simply added it to the overview page with the noted workaround solution. Unclear if its worth mentioning this caveat for the small user base using WSL and the CLI concurrently, but since the issue was still open and marked for docs I wanted to give it a shot. 