### PR TITLE
Update getting started docs for go on stable version

### DIFF
--- a/docs/stable/clients/go.md
+++ b/docs/stable/clients/go.md
@@ -120,4 +120,4 @@ func main() {
 
 ### More Examples
 
-For more examples, see the [examples in the `duckdb-go` repository](https://github.com/marcboeker/go-duckdb/tree/master/examples).
+For more examples, see the [examples in the `duckdb-go` repository](https://github.com/marcboeker/go-duckdb/tree/main/examples).

--- a/docs/stable/clients/go.md
+++ b/docs/stable/clients/go.md
@@ -20,7 +20,7 @@ For examples on how to use this interface, see the [official documentation](http
 To install the `go-duckdb` client, run:
 
 ```bash
-go get github.com/marcboeker/go-duckdb
+go get github.com/marcboeker/go-duckdb/v2
 ```
 
 ## Importing
@@ -30,7 +30,7 @@ To import the DuckDB Go package, add the following entries to your imports:
 ```go
 import (
 	"database/sql"
-	_ "github.com/marcboeker/go-duckdb"
+	_ "github.com/marcboeker/go-duckdb/v2"
 )
 ```
 
@@ -83,7 +83,7 @@ import (
 	"fmt"
 	"log"
 
-	_ "github.com/marcboeker/go-duckdb"
+	_ "github.com/marcboeker/go-duckdb/v2"
 )
 
 func main() {


### PR DESCRIPTION
This pull request makes the following small changes to the `go.md` file:


1. Updates the reference to `go-duckdb` to use the [latest major version: v2,](https://github.com/marcboeker/go-duckdb/tree/main?tab=readme-ov-file#go-sql-driver-for-duckdb) which supports version 1.2+ of duckdb which is the oldest version available on the doc page. 
   - v2.3.3 of `go-duckdb` is the only version that supports the current stable version of duckdb 1.3.2
   - v2+ of `go-duckdb` changes the [arrow dependency from opt-out to opt-in](https://github.com/marcboeker/go-duckdb/tree/main?tab=readme-ov-file#the-arrow-dependency-is-now-opt-in) potentially making builds faster
   - Allows for scans of JSON into `any` or the `Composite` duckdb type but removes support for scanning JSON directly into a `string` or `[]byte`
2. Updates the linked reference to further examples to use the `main` branch rather than `master`; eliminating an unnecessary (or potentially unsupported at some future point) redirect by Github. 