### PR TITLE
Update editing.md with external editor section

### DIFF
--- a/docs/preview/clients/cli/editing.md
+++ b/docs/preview/clients/cli/editing.md
@@ -81,6 +81,17 @@ DuckDB's CLI uses a line-editing library based on [linenoise](https://github.com
 | `Ctrl`+`X` | Insert a newline after the cursor                                                  |
 | `Ctrl`+`Z` | Suspend CLI and return to shell, use `fg` to re-open                               |
 
+## External Editor Mode
+
+Use `.edit` or `\e` to open a query in an external text editor.
+
+* When entered alone, it opens the previous command for editing.
+* When used inside a multi-line command, it opens the current command in the editor.
+
+The editor is taken from the first set environment variable among `DUCKDB_EDITOR`, `EDITOR` or `VISUAL` (in that order). If none are set, `vi` is used.
+
+> This feature is only available in the linenoise-based CLI editor, which is currently supported on macOS and Linux.
+
 ## Using Read-Line
 
 If you prefer, you can use [`rlwrap`](https://github.com/hanslub42/rlwrap) to use read-line directly with the shell. Then, use `Shift`+`Enter` to insert a newline and `Enter` to execute the query:

--- a/docs/stable/clients/cli/editing.md
+++ b/docs/stable/clients/cli/editing.md
@@ -85,6 +85,17 @@ DuckDB's CLI uses a line-editing library based on [linenoise](https://github.com
 | `Ctrl`+`X` | Insert a newline after the cursor                                                  |
 | `Ctrl`+`Z` | Suspend CLI and return to shell, use `fg` to re-open                               |
 
+## External editor mode
+
+Use `.edit` or `\e` to open a query in an external text editor.
+
+- When entered alone, it opens the previous command for editing.  
+- When used inside a multi-line command, it opens the current command in the editor.  
+
+The editor is taken from the first set environment variable among `DUCKDB_EDITOR`, `EDITOR`, or `VISUAL` (in that order). If none are set, `vi` is used.  
+
+This feature is only available in the linenoise-based CLI editor, which is currently supported on macOS and Linux.
+
 ## Using Read-Line
 
 If you prefer, you can use [`rlwrap`](https://github.com/hanslub42/rlwrap) to use read-line directly with the shell. Then, use `Shift`+`Enter` to insert a newline and `Enter` to execute the query:

--- a/docs/stable/clients/cli/editing.md
+++ b/docs/stable/clients/cli/editing.md
@@ -85,16 +85,16 @@ DuckDB's CLI uses a line-editing library based on [linenoise](https://github.com
 | `Ctrl`+`X` | Insert a newline after the cursor                                                  |
 | `Ctrl`+`Z` | Suspend CLI and return to shell, use `fg` to re-open                               |
 
-## External editor mode
+## External Editor Mode
 
 Use `.edit` or `\e` to open a query in an external text editor.
 
-- When entered alone, it opens the previous command for editing.  
-- When used inside a multi-line command, it opens the current command in the editor.  
+* When entered alone, it opens the previous command for editing.
+* When used inside a multi-line command, it opens the current command in the editor.
 
-The editor is taken from the first set environment variable among `DUCKDB_EDITOR`, `EDITOR`, or `VISUAL` (in that order). If none are set, `vi` is used.  
+The editor is taken from the first set environment variable among `DUCKDB_EDITOR`, `EDITOR` or `VISUAL` (in that order). If none are set, `vi` is used.
 
-This feature is only available in the linenoise-based CLI editor, which is currently supported on macOS and Linux.
+> This feature is only available in the linenoise-based CLI editor, which is currently supported on macOS and Linux.
 
 ## Using Read-Line
 


### PR DESCRIPTION
Feature was implemented as part of this PR: https://github.com/duckdb/duckdb/pull/11447/

There is some current documentation of it inside of `.help` and `.help .edit` but having it in these docs seems very helpful

That PR limits this feature to linenoise compatible CLI editors. It seems like it will support windows when linenoise comes to the windows duckdb CLI.