### PR TITLE
Update window_functions.md

### DIFF
--- a/docs/preview/sql/functions/window_functions.md
+++ b/docs/preview/sql/functions/window_functions.md
@@ -115,7 +115,7 @@ The table below shows the available general window functions.
 
 | **Description** | Returns `expr` evaluated at the row that is `offset` rows (among rows with a non-null value of `expr` if `IGNORE NULLS` is set) before the current row within the window frame; if there is no such row, instead return `default` (which must be of the Same type as `expr`). Both `offset` and `default` are evaluated with respect to the current row. If omitted, `offset` defaults to `1` and default to `NULL`. If an `ORDER BY` clause is specified, the lagged row number is computed within the frame using the provided ordering instead of the frame ordering. |
 | **Return type** | Same type as `expr` |
-| **Aliases** | `lag(column, 3, 0)` |
+| **Example** | `lag(column, 3, 0)` |
 
 #### `last_value(expr[ ORDER BY ordering][ IGNORE NULLS])`
 
@@ -131,7 +131,7 @@ The table below shows the available general window functions.
 
 | **Description** | Returns `expr` evaluated at the row that is `offset` rows after the current row (among rows with a non-null value of `expr` if `IGNORE NULLS` is set) within the window frame; if there is no such row, instead return `default` (which must be of the Same type as `expr`). Both `offset` and `default` are evaluated with respect to the current row. If omitted, `offset` defaults to `1` and default to `NULL`. If an `ORDER BY` clause is specified, the leading row number is computed within the frame using the provided ordering instead of the frame ordering. |
 | **Return type** | Same type as `expr` |
-| **Aliases** | `lead(column, 3, 0)` |
+| **Example** | `lead(column, 3, 0)` |
 
 #### `nth_value(expr, nth[ ORDER BY ordering][ IGNORE NULLS])`
 
@@ -139,7 +139,7 @@ The table below shows the available general window functions.
 
 | **Description** | Returns `expr` evaluated at the nth row (among rows with a non-null value of `expr` if `IGNORE NULLS` is set) of the window frame (counting from 1); `NULL` if no such row. If an `ORDER BY` clause is specified, the nth row number is computed within the frame using the provided ordering instead of the frame ordering. |
 | **Return type** | Same type as `expr` |
-| **Aliases** | `nth_value(column, 2)` |
+| **Example** | `nth_value(column, 2)` |
 
 #### `ntile(num_buckets[ ORDER BY ordering])`
 


### PR DESCRIPTION
fixes https://github.com/duckdb/duckdb-web/issues/5634

@szarnyasg Now that there are separate stable and dev pages, is it acceptable to only change the dev version? 
I'm doing almost all of my contributions by phone (and even on a laptop applying patches to different files intra-repository is not trivial in git) and having to port back changes would severely hamper the ability of users like me to contribute in this way.  I'm not suggesting that _you_ do the work of porting changes to stable, but rather that either 
- duckdb accept that only dev has the most up-to-date and correct version of the docs or 
- duckdb stops having separate stable and dev documentation (including going back to parking some PRs where deemed necessary)
- duckdb accepts having fewer hot-patch phone contributions (tbh, I'm not sure how much you get contributed via this mechanism anyway)