### PR TITLE
Update instantiation.md by fixing typo in CDN wasm example

### DIFF
--- a/docs/stable/clients/wasm/instantiation.md
+++ b/docs/stable/clients/wasm/instantiation.md
@@ -20,7 +20,7 @@ const JSDELIVR_BUNDLES = duckdb.getJsDelivrBundles();
 const bundle = await duckdb.selectBundle(JSDELIVR_BUNDLES);
 
 const worker_url = URL.createObjectURL(
-  new Blob([`importScripts("${bundle.mainWorker!}");`], {type: 'text/javascript'})
+  new Blob([`importScripts("${bundle.mainWorker}");`], {type: 'text/javascript'})
 );
 
 // Instantiate the asynchronus version of DuckDB-Wasm


### PR DESCRIPTION
It seems that the `!` postfix was too much, as with it there are errors in the browser console and in js linter. Without it seems to work.

I am missing anything from vite/js/ts or other things that made this `!` necessary?