### PR TITLE
Update list.md

### DIFF
--- a/_posts/2021-11-12-moving-holistic.md
+++ b/_posts/2021-11-12-moving-holistic.md
@@ -31,7 +31,7 @@ These are called _holistic_ aggregates, and they require more care when implemen
 For some aggregates (like `STRING_AGG`) the order of the values can change the result.
 This is not a problem for windowing because `OVER` clauses can specify an ordering,
 but in a `GROUP BY` clause, the values are unordered.
-To handle this, order sensitive aggregates can include a `WITHIN GROUP(ORDER BY <expr>)` clause
+To handle this, order-sensitive aggregates can include a `WITHIN GROUP(ORDER BY <expr>)` clause
 to specify the order of the values.
 Because the values must all be collected and sorted,
 aggregates that use the `WITHIN GROUP` clause are holistic.

--- a/docs/preview/sql/functions/list.md
+++ b/docs/preview/sql/functions/list.md
@@ -1085,7 +1085,8 @@ The function [`list_aggregate`](#list_aggregatelist-name) allows the execution o
 
 `list_aggregate` accepts additional arguments after the aggregate function name. These extra arguments are passed directly to the aggregate function, which serves as the second argument of `list_aggregate`.
 
-Order sensitive aggregate functions are applied in the order of the list. No `ORDER BY` / `DISTINCT` / `FILTER` clauses are supported by `list_aggregate`. They may instead be emulated using `list_sort` / `list_grade_up` / `list_select` / `list_distinct` / `list_filter`. 
+Order-sensitive aggregate functions are applied in the order of the list. The `ORDER BY`, `DISTINCT` and `FILTER` clauses are not supported by `list_aggregate`.
+They may instead be emulated using `list_sort`, `list_grade_up`, `list_select`, `list_distinct` and `list_filter`.
 
 ```sql
 SELECT list_aggregate([1, 2, -4, NULL], 'min');


### PR DESCRIPTION
fixes https://github.com/duckdb/duckdb/discussions/18696

Please fact check the claim that `list_aggr` applies aggregaes in the order of the list with the team. I've based my claims on the experimental

```sql
CREATE OR REPLACE TABLE df1 AS (SELECT random() AS x FROM range(10_000_000));
CREATE OR REPLACE TABLE df2 AS (SELECT array_agg(x ORDER BY rowid) as x FROM df1);
SELECT
   list_aggr(x, 'sum') -- always the same result
FROM df2;
SELECT
    sum(x) -- different results on each execution
FROM df1;
```