### PR TITLE
Adding Scope to set_variable.md page

### DIFF
--- a/docs/preview/sql/statements/set.md
+++ b/docs/preview/sql/statements/set.md
@@ -38,16 +38,23 @@ Retrieve configuration value:
 SELECT current_setting('threads');
 ```
 
+Set the default collation for the session:
+
+```sql
+SET SESSION default_collation = 'nocase';
+```
+#### Set a Global Variable
+
 Set the default sort order globally:
 
 ```sql
 SET GLOBAL sort_order = 'desc';
 ```
 
-Set the default collation for the session:
+Set the default threads globally: 
 
-```sql
-SET SESSION default_collation = 'nocase';
+```sql 
+SET GLOBAL threads = 4;
 ```
 
 ## Syntax

--- a/docs/preview/sql/statements/set_variable.md
+++ b/docs/preview/sql/statements/set_variable.md
@@ -6,6 +6,15 @@ title: SET VARIABLE and RESET VARIABLE Statements
 
 DuckDB supports the definition of SQL-level variables using the `SET VARIABLE` and `RESET VARIABLE` statements.
 
+### Variable Scopes
+
+DuckDb supports two levels of variable scopes:
+
+| Scope | Description |
+|---|---|
+| `SESSION` | Variables with a `SESSION` scope are local to you and only affect the current session. | 
+| `GLOBAL` | Variables with a `GLOBAL` scope are Specific [configuration option variables](https://duckdb.org/docs/stable/configuration/overview.html#global-configuration-options) that affect the entire DuckDB instance and all sessions. For example, see [Set a Global Variable]({% link docs/stable/sql/statements/set.md%}#set-a-global-variable).|
+
 ## `SET VARIABLE`
 
 The `SET VARIABLE` statement assigns a value to a variable, which can be accessed using the `getvariable` call:

--- a/docs/stable/sql/statements/set.md
+++ b/docs/stable/sql/statements/set.md
@@ -38,7 +38,16 @@ Retrieve configuration value:
 
 ```sql
 SELECT current_setting('threads');
+
 ```
+
+Set the default collation for the session:
+
+```sql
+SET SESSION default_collation = 'nocase';
+```
+
+#### Set a Global Variable
 
 Set the default sort order globally:
 
@@ -46,10 +55,10 @@ Set the default sort order globally:
 SET GLOBAL sort_order = 'desc';
 ```
 
-Set the default collation for the session:
+Set the default threads globally: 
 
-```sql
-SET SESSION default_collation = 'nocase';
+```sql 
+SET GLOBAL threads = 4;
 ```
 
 ## Syntax

--- a/docs/stable/sql/statements/set_variable.md
+++ b/docs/stable/sql/statements/set_variable.md
@@ -8,6 +8,15 @@ title: SET VARIABLE and RESET VARIABLE Statements
 
 DuckDB supports the definition of SQL-level variables using the `SET VARIABLE` and `RESET VARIABLE` statements.
 
+### Variable Scopes
+
+DuckDb supports two levels of variable scopes:
+
+| Scope | Description |
+|---|---|
+| `SESSION` | Variables with a `SESSION` scope are local to you and only affect the current session. | 
+| `GLOBAL` | Variables with a `GLOBAL` scope are Specific [configuration option variables](https://duckdb.org/docs/stable/configuration/overview.html#global-configuration-options) that affect the entire DuckDB instance and all sessions. For example, see [Set a Global Variable]({% link docs/stable/sql/statements/set.md%}#set-a-global-variable).|
+
 ## `SET VARIABLE`
 
 The `SET VARIABLE` statement assigns a value to a variable, which can be accessed using the `getvariable` call:


### PR DESCRIPTION
- Adding the h3 `Variable Scope` section to `docs/preview/sql/statements/set_variable.md`
- Moving the single set global code example to its own section on `docs/stable/sql/statements/set.md`.
- Adding an additional example of setting the global variable `threads` value.