### PR TITLE
Add instructions for installing and loading duckdb-excel extension for Excel export

### DIFF
--- a/docs/stable/guides/file_formats/excel_export.md
+++ b/docs/stable/guides/file_formats/excel_export.md
@@ -9,6 +9,9 @@ title: Excel Export
 
 DuckDB supports exporting data to Excel `.xlsx` files. However, `.xls` files are not supported.
 
+> Note: Excel export requires the duckdb-excel extension.
+> Please run INSTALL 'excel'; LOAD 'excel'; before using FORMAT xlsx.
+
 ## Exporting Excel Sheets
 
 To export a table to an Excel file, use the `COPY` statement with the `FORMAT xlsx` option:
@@ -21,6 +24,12 @@ The result of a query can also be directly exported to an Excel file:
 
 ```sql
 COPY (SELECT * FROM tbl) TO 'output.xlsx' WITH (FORMAT xlsx);
+```
+
+without excel extension:
+
+```
+COPY (SELECT * FROM tbl) TO 'output.xlsx';
 ```
 
 To write the column names as the first row in the Excel file, use the `HEADER` option:


### PR DESCRIPTION
This PR updates the Excel Export documentation to clarify that exporting to Excel (.xlsx) files requires the [duckdb-excel extension](https://github.com/duckdb/duckdb-excel).
It adds instructions to install and load the extension before using WITH (FORMAT xlsx), and explains the error message users may encounter if the extension is not loaded.
Additionally, it notes that omitting WITH (FORMAT xlsx) will result in CSV export, not Excel.