### PR TITLE
Add BIRNE paper

### DIFF
--- a/_science/2025-06-27-birne-mixed-paradigm-workload-execution-in-sql-engines.md
+++ b/_science/2025-06-27-birne-mixed-paradigm-workload-execution-in-sql-engines.md
@@ -1,0 +1,17 @@
+---
+layout: post
+title: "BIRNE: Mixed-paradigm Workload Execution in SQL Engines"
+author: "Tim Fischer, Denis Hirn"
+thumb: "/images/science/thumbs/sigmod-2025.svg"
+image: "/images/science/thumbs/sigmod-2025.png"
+excerpt: ""
+tags: ["Paper"]
+---
+
+[Paper (PDF)](https://dl.acm.org/doi/pdf/10.1145/3735106.3736535)
+
+Venue: DBPL 2025
+
+## Abstract
+
+Previous work on UDF compilation strategies has proven that SQL engines can be used as efficient execution environments for imperative workloads over relational data. In this paper, we present BIRNE, a major extension of our Flummi compiler, with support for mixed-paradigm workloads, such that database-resident programs can be expressed using both imperative and functional constructs. To this end, we introduce a specialized form of control flow graphs that we call control flow plans, that allow us to express the control flow and data dependencies, such that we can use plain SQL as the target for compilation. We show that this approach allows us to compile a wide range of workloads into a single SQL query, and that it can outperform existing approaches in terms of overall runtime in many cases.


### PR DESCRIPTION
This PR adds BIRNE paper from DBPL 2025 (co-located with SIGMOD 2025) which builds and greatly extends upon the [Flummi paper](https://duckdb.org/science/sql-engines-excel-at-execution-of-imperative-programs/) already on the list.

Note that there wasn't a dedicated image/thumbnail for DBPL, so for now I co-opted the image for the co-located SIGMOD. I'm happy to amend this PR appropriately when the proper image becomes available.