### PR TITLE
fix: typos

### DIFF
--- a/docs/preview/clients/java.md
+++ b/docs/preview/clients/java.md
@@ -229,7 +229,7 @@ The DuckDB JDBC driver offers batch write functionality.
 The batch writer supports prepared statements to mitigate the overhead of query parsing.
 
 > The preferred method for bulk inserts is to use the [Appender](#appender) due to its higher performance.
-> However, when using the Appender is not possbile, the batch writer is available as alternative.
+> However, when using the Appender is not possible, the batch writer is available as alternative.
 
 #### Batch Writer with Prepared Statements
 

--- a/docs/preview/clients/node_neo/overview.md
+++ b/docs/preview/clients/node_neo/overview.md
@@ -17,7 +17,7 @@ available separately as [@duckdb/node-bindings](https://www.npmjs.com/package/@d
 
 * Native support for Promises; no need for separate [duckdb-async](https://www.npmjs.com/package/duckdb-async) wrapper.
 * DuckDB-specific API; not based on the [SQLite Node API](https://www.npmjs.com/package/sqlite3).
-* Lossless & efficent support for values of all [DuckDB data types]({% link docs/preview/sql/data_types/overview.md %}).
+* Lossless & efficient support for values of all [DuckDB data types]({% link docs/preview/sql/data_types/overview.md %}).
 * Wraps [released DuckDB binaries](https://github.com/duckdb/duckdb/releases) instead of rebuilding DuckDB.
 * Built on [DuckDB's C API]({% link docs/preview/clients/c/overview.md %}); exposes more functionality.
 
@@ -694,7 +694,7 @@ if (columnType.typeId === DuckDBTypeId.ARRAY) {
 
 if (columnType.typeId === DuckDBTypeId.BIT) {
   const bools = columnValue.toBools(); // array of booleans
-  const bits = columnValue.toBits(); // arrary of 0s and 1s
+  const bits = columnValue.toBits(); // array of 0s and 1s
   const bitString = columnValue.toString(); // string of '0's and '1's
 }
 

--- a/docs/preview/clients/swift.md
+++ b/docs/preview/clients/swift.md
@@ -111,7 +111,7 @@ final class ExoplanetStore {
 
 ### Querying the Database
 
-The following example queires DuckDB from within Swift via an async function. This means the callee won't be blocked while the query is executing. We'll then cast the result columns to Swift native types using DuckDB's `ResultSet` `cast(to:)` family of methods, before finally wrapping them up in a `DataFrame` from the TabularData framework.
+The following example queries DuckDB from within Swift via an async function. This means the callee won't be blocked while the query is executing. We'll then cast the result columns to Swift native types using DuckDB's `ResultSet` `cast(to:)` family of methods, before finally wrapping them up in a `DataFrame` from the TabularData framework.
 
 ```swift
 ...

--- a/docs/preview/clients/wasm/deploying_duckdb_wasm.md
+++ b/docs/preview/clients/wasm/deploying_duckdb_wasm.md
@@ -15,7 +15,7 @@ A DuckDB-Wasm deployment needs to access the following components:
 This is distributed as either TypeScript code or CommonJS JavaScript code in the `npm` duckdb-wasm package, and can be either bundled together with a given application, served in a same origin (sub-)domain and included at runtime or served from a third party CDN like JSDelivery.
 This do need some form of transpilation, and can't be served as-is, given it needs to know the location of the follow up files for this to be functional.
 Details will depend on your given setup, examples can be found at <https://github.com/duckdb/duckdb-wasm/tree/main/examples>.
-Example deployment could be for example <https://shell.duckdb.org>, that transpile the main library componenent together with shell code (first approach). Or the `bare-browser` example at <https://github.com/duckdb/duckdb-wasm/tree/main/examples/bare-browser>.
+Example deployment could be for example <https://shell.duckdb.org>, that transpile the main library component together with shell code (first approach). Or the `bare-browser` example at <https://github.com/duckdb/duckdb-wasm/tree/main/examples/bare-browser>.
 
 ## JS Worker Component
 

--- a/docs/preview/clients/wasm/instantiation.md
+++ b/docs/preview/clients/wasm/instantiation.md
@@ -19,7 +19,7 @@ const worker_url = URL.createObjectURL(
   new Blob([`importScripts("${bundle.mainWorker!}");`], {type: 'text/javascript'})
 );
 
-// Instantiate the asynchronus version of DuckDB-Wasm
+// Instantiate the asynchronous version of DuckDB-Wasm
 const worker = new Worker(worker_url);
 const logger = new duckdb.ConsoleLogger();
 const db = new duckdb.AsyncDuckDB(logger, worker);
@@ -45,7 +45,7 @@ const MANUAL_BUNDLES: duckdb.DuckDBBundles = {
 };
 // Select a bundle based on browser checks
 const bundle = await duckdb.selectBundle(MANUAL_BUNDLES);
-// Instantiate the asynchronus version of DuckDB-Wasm
+// Instantiate the asynchronous version of DuckDB-Wasm
 const worker = new Worker(bundle.mainWorker!);
 const logger = new duckdb.ConsoleLogger();
 const db = new duckdb.AsyncDuckDB(logger, worker);
@@ -73,7 +73,7 @@ const MANUAL_BUNDLES: duckdb.DuckDBBundles = {
 };
 // Select a bundle based on browser checks
 const bundle = await duckdb.selectBundle(MANUAL_BUNDLES);
-// Instantiate the asynchronus version of DuckDB-wasm
+// Instantiate the asynchronous version of DuckDB-wasm
 const worker = new Worker(bundle.mainWorker!);
 const logger = new duckdb.ConsoleLogger();
 const db = new duckdb.AsyncDuckDB(logger, worker);

--- a/docs/preview/core_extensions/spatial/functions.md
+++ b/docs/preview/core_extensions/spatial/functions.md
@@ -21,7 +21,7 @@ title: Spatial Functions
 | [`ST_Azimuth`](#st_azimuth) | Returns the azimuth (a clockwise angle measured from north) of two points in radian. |
 | [`ST_Boundary`](#st_boundary) | Returns the "boundary" of a geometry |
 | [`ST_Buffer`](#st_buffer) | Returns a buffer around the input geometry at the target distance |
-| [`ST_BuildArea`](#st_buildarea) | Creates a polygonal geometry by attemtping to "fill in" the input geometry. |
+| [`ST_BuildArea`](#st_buildarea) | Creates a polygonal geometry by attempting to "fill in" the input geometry. |
 | [`ST_Centroid`](#st_centroid) | Returns the centroid of a geometry |
 | [`ST_Collect`](#st_collect) | Collects a list of geometries into a collection geometry. |
 | [`ST_CollectionExtract`](#st_collectionextract) | Extracts geometries from a GeometryCollection into a typed multi geometry. |
@@ -560,7 +560,7 @@ GEOMETRY ST_BuildArea (geom GEOMETRY)
 
 #### Description
 
-Creates a polygonal geometry by attemtping to "fill in" the input geometry.
+Creates a polygonal geometry by attempting to "fill in" the input geometry.
 
 Unlike ST_Polygonize, this function does not fill in holes.
 
@@ -656,9 +656,9 @@ GEOMETRY ST_CollectionExtract (geom GEOMETRY)
 Extracts geometries from a GeometryCollection into a typed multi geometry.
 
 If the input geometry is a GeometryCollection, the function will return a multi geometry, determined by the `type` parameter.
-- if `type` = 1, returns a MultiPoint containg all the Points in the collection
-- if `type` = 2, returns a MultiLineString containg all the LineStrings in the collection
-- if `type` = 3, returns a MultiPolygon containg all the Polygons in the collection
+- if `type` = 1, returns a MultiPoint containing all the Points in the collection
+- if `type` = 2, returns a MultiLineString containing all the LineStrings in the collection
+- if `type` = 3, returns a MultiPolygon containing all the Polygons in the collection
 
 If no `type` parameters is provided, the function will return a multi geometry matching the highest "surface dimension"
 of the contained geometries. E.g. if the collection contains only Points, a MultiPoint will be returned. But if the
@@ -1488,7 +1488,7 @@ UINTEGER ST_Hilbert (box BOX_2DF, bounds BOX_2DF)
 
 Encodes the X and Y values as the hilbert curve index for a curve covering the given bounding box.
 If a geometry is provided, the center of the approximate bounding box is used as the point to encode.
-If no bounding box is provided, the hilbert curve index is mapped to the full range of a single-presicion float.
+If no bounding box is provided, the hilbert curve index is mapped to the full range of a single-precision float.
 For the BOX_2D and BOX_2DF variants, the center of the box is used as the point to encode.
 
 ----

--- a/docs/preview/data/csv/auto_detection.md
+++ b/docs/preview/data/csv/auto_detection.md
@@ -168,7 +168,7 @@ DuckDB supports the [ISO 8601 format](https://en.wikipedia.org/wiki/ISO_8601) fo
 
 As part of the auto-detection, the system tries to figure out if dates and times are stored in a different representation. This is not always possible – as there are ambiguities in the representation. For example, the date `01-02-2000` can be parsed as either January 2nd or February 1st. Often these ambiguities can be resolved. For example, if we later encounter the date `21-02-2000` then we know that the format must have been `DD-MM-YYYY`. `MM-DD-YYYY` is no longer possible as there is no 21nd month.
 
-If the ambiguities cannot be resolved by looking at the data the system has a list of preferences for which date format to use. If the system choses incorrectly, the user can specify the `dateformat` and `timestampformat` options manually.
+If the ambiguities cannot be resolved by looking at the data the system has a list of preferences for which date format to use. If the system chooses incorrectly, the user can specify the `dateformat` and `timestampformat` options manually.
 
 The system considers the following formats for dates (`dateformat`). Higher entries are chosen over lower entries in case of ambiguities (i.e., ISO 8601 is preferred over `MM-DD-YYYY`).
 

--- a/docs/preview/dev/building/building_extensions.md
+++ b/docs/preview/dev/building/building_extensions.md
@@ -29,7 +29,7 @@ When this flag is set, the [`jemalloc` extension]({% link docs/preview/core_exte
 
 ### `BUILD_TPCE`
 
-When this flag is set, the [TPCE](https://www.tpc.org/tpce/) libray is built. Unlike TPC-H and TPC-DS this is not a proper extension and it's not distributed as such. Enabling this allows TPC-E enabled queries through our test suite.
+When this flag is set, the [TPCE](https://www.tpc.org/tpce/) library is built. Unlike TPC-H and TPC-DS this is not a proper extension and it's not distributed as such. Enabling this allows TPC-E enabled queries through our test suite.
 
 ## Debug Flags
 

--- a/docs/preview/guides/data_viewers/youplot.md
+++ b/docs/preview/guides/data_viewers/youplot.md
@@ -58,7 +58,7 @@ duckdb -s "COPY (SELECT date, sum(purchases) AS total_purchases FROM read_json_a
      | uplot bar -d, -H -t "Top 10 Purchase Dates"
 ```
 
-This tells `uplot` to draw a bar plot, use a comma-seperated delimiter (`-d,`), that the data has a header (`-H`), and give the plot a title (`-t`).
+This tells `uplot` to draw a bar plot, use a comma-separated delimiter (`-d,`), that the data has a header (`-H`), and give the plot a title (`-t`).
 
 ![youplot-top-10](/images/guides/youplot/top-10-plot.png)
 

--- a/docs/preview/guides/odbc/general.md
+++ b/docs/preview/guides/odbc/general.md
@@ -81,10 +81,10 @@ All functions in ODBC return a code which represents the success or failure of t
 | Return code             | Description                                        |
 |-------------------------|----------------------------------------------------|
 | `SQL_SUCCESS`           | The function completed successfully                                                                                                           |
-| `SQL_SUCCESS_WITH_INFO` | The function completed successfully, but additional information is available, including a warnin                                              |
+| `SQL_SUCCESS_WITH_INFO` | The function completed successfully, but additional information is available, including a warning                                              |
 | `SQL_ERROR`             | The function failed                                                                                                                           |
 | `SQL_INVALID_HANDLE`    | The handle provided was invalid, indicating a programming error, i.e., when a handle is not allocated before it is used, or is the wrong type |
-| `SQL_NO_DATA`           | The function completed successfully, but no more data is availabl                                                                             |
+| `SQL_NO_DATA`           | The function completed successfully, but no more data is available                                                                            |
 | `SQL_NEED_DATA`         | More data is needed, such as when a parameter data is sent at execution time, or additional connection information is required                |
 | `SQL_STILL_EXECUTING`   | A function that was asynchronously executed is still executing                                                                                |
 

--- a/docs/preview/guides/performance/file_formats.md
+++ b/docs/preview/guides/performance/file_formats.md
@@ -81,7 +81,7 @@ CSV files are often distributed in compressed format such as GZIP archives (`.cs
 ### Loading Many Small CSV Files
 
 The [CSV reader]({% link docs/preview/data/csv/overview.md %}) runs the [CSV sniffer]({% post_url 2023-10-27-csv-sniffer %}) on all files. For many small files, this may cause an unnecessarily high overhead.
-A potential optimization to speed this up is to turn the sniffer off. Assuming that all files have the same CSV dialect and colum names/types, get the sniffer options as follows:
+A potential optimization to speed this up is to turn the sniffer off. Assuming that all files have the same CSV dialect and column names/types, get the sniffer options as follows:
 
 ```sql
 .mode line

--- a/docs/preview/guides/performance/schema.md
+++ b/docs/preview/guides/performance/schema.md
@@ -82,7 +82,7 @@ In all cases, we take the data from `.csv.gz` files, and measure the time requir
 | Load without primary key then add primary key |        242.0 s |
 
 For this dataset, primary keys will only have a (small) positive effect on highly selective queries such as when filtering on a single identifier.
-Definining primary keys (or indexes) will not have an effect on join and aggregation operators.
+Defining primary keys (or indexes) will not have an effect on join and aggregation operators.
 
 > Bestpractice For best bulk load performance, avoid primary key constraints.
 > If they are required, define them after the bulk loading step.

--- a/docs/preview/internals/overview.md
+++ b/docs/preview/internals/overview.md
@@ -65,7 +65,7 @@ After the logical planner has created the logical query tree, the optimizers are
 
 ## Column Binding Resolver
 
-The column binding resolver converts logical [`BoundColumnRefExpresion`](https://github.com/duckdb/duckdb/blob/main/src/include/duckdb/planner/expression/bound_columnref_expression.hpp) nodes that refer to a column of a specific table into [`BoundReferenceExpression`](https://github.com/duckdb/duckdb/blob/main/src/include/duckdb/planner/expression/bound_reference_expression.hpp) nodes that refer to a specific index into the DataChunks that are passed around in the execution engine.
+The column binding resolver converts logical [`BoundColumnRefExpression`](https://github.com/duckdb/duckdb/blob/main/src/include/duckdb/planner/expression/bound_columnref_expression.hpp) nodes that refer to a column of a specific table into [`BoundReferenceExpression`](https://github.com/duckdb/duckdb/blob/main/src/include/duckdb/planner/expression/bound_reference_expression.hpp) nodes that refer to a specific index into the DataChunks that are passed around in the execution engine.
 
 ## Physical Plan Generator
 

--- a/docs/preview/operations_manual/non-deterministic_behavior.md
+++ b/docs/preview/operations_manual/non-deterministic_behavior.md
@@ -8,7 +8,7 @@ Most notably, SQL uses set semantics, which allows results to be returned in a d
 DuckDB exploits this to improve performance, particularly when performing multi-threaded query execution.
 Other factors, such as using different compilers, operating systems, and hardware architectures, can also cause changes in ordering.
 This page documents the cases where non-determinism is an _expected behavior_.
-If you would like to make your queries determinisic, see the [“Working Around Non-Determinism” section](#working-around-non-determinism).
+If you would like to make your queries deterministic, see the [“Working Around Non-Determinism” section](#working-around-non-determinism).
 
 ## Set Semantics
 

--- a/docs/preview/sql/data_types/typecasting.md
+++ b/docs/preview/sql/data_types/typecasting.md
@@ -68,7 +68,7 @@ So even though the cast operation from `INTEGER` to `TINYINT` is supported, it i
 
 ### Varchar
 
-The [`VARCHAR`]({% link docs/preview/sql/data_types/text.md %}) type acts as a univeral target: any arbitrary value of any arbitrary type can always be cast to the `VARCHAR` type. This type is also used for displaying values in the shell.
+The [`VARCHAR`]({% link docs/preview/sql/data_types/text.md %}) type acts as a universal target: any arbitrary value of any arbitrary type can always be cast to the `VARCHAR` type. This type is also used for displaying values in the shell.
 
 ```sql
 SELECT CAST(42.5 AS VARCHAR);

--- a/docs/preview/sql/expressions/star.md
+++ b/docs/preview/sql/expressions/star.md
@@ -164,7 +164,7 @@ SELECT COLUMNS('(id|numbers?)') FROM numbers;
 The matches of capture groups in regular expressions can be used to rename matching columns.
 The capture groups are one-indexed; `\0` is the original column name.
 
-For example, to select the first three letters of colum names, run:
+For example, to select the first three letters of column names, run:
 
 ```sql
 SELECT COLUMNS('(\w{3}).*') AS '\1' FROM numbers;

--- a/docs/preview/sql/meta/duckdb_table_functions.md
+++ b/docs/preview/sql/meta/duckdb_table_functions.md
@@ -82,7 +82,7 @@ The `duckdb_constraints()` function provides metadata about the constraints avai
 | `expression` | If constraint is a check constraint, the definition of the condition being checked, otherwise `NULL`. | `VARCHAR` |
 | `constraint_column_indexes` | An array of table column indexes referring to the columns that appear in the constraint definition. | `BIGINT[]` |
 | `constraint_column_names` | An array of table column names appearing in the constraint definition. | `VARCHAR[]` |
-| `constraint_name` | The naem of constraint. | `VARCHAR` |
+| `constraint_name` | The name of the constraint. | `VARCHAR` |
 | `referenced_table` | The table referenced by the constraint. | `VARCHAR` |
 | `referenced_column_names` | The column names references the by the constraint. | `VARCHAR[]` |
 
@@ -282,7 +282,7 @@ The `duckdb_secrets()` function provides metadata about the secrets available in
 | `name` | The name of the secret. | `VARCHAR` |
 | `type` | The type of the secret, e.g., `S3`, `GCS`, `R2`, `AZURE`. | `VARCHAR` |
 | `provider` | The provider of the secret. | `VARCHAR` |
-| `persistent` | Denotes whether the secret is persisent. | `BOOLEAN` |
+| `persistent` | Denotes whether the secret is persistent. | `BOOLEAN` |
 | `storage` | The backend for storing the secret. | `VARCHAR` |
 | `scope` | The scope of the secret. | `VARCHAR[]` |
 | `secret_string` | Returns the content of the secret as a string. Sensitive pieces of information, e.g., they access key, are redacted. | `VARCHAR` |

--- a/docs/preview/sql/samples.md
+++ b/docs/preview/sql/samples.md
@@ -86,7 +86,7 @@ DuckDB supports three different types of sampling methods: `reservoir`, `bernoul
 
 Samples require a *sample size*, which is an indication of how many elements will be sampled from the total population. Samples can either be given as a percentage (`10%` or `10 PERCENT`) or as a fixed number of rows (`10` or `10 ROWS`). All three sampling methods support sampling over a percentage, but **only** reservoir sampling supports sampling a fixed number of rows.
 
-Samples are probablistic, that is to say, samples can be different between runs *unless* the seed is specifically specified. Specifying the seed *only* guarantees that the sample is the same if multi-threading is not enabled (i.e., `SET threads = 1`). In the case of multiple threads running over a sample, samples are not necessarily consistent even with a fixed seed.
+Samples are probabilistic, that is to say, samples can be different between runs *unless* the seed is specifically specified. Specifying the seed *only* guarantees that the sample is the same if multi-threading is not enabled (i.e., `SET threads = 1`). In the case of multiple threads running over a sample, samples are not necessarily consistent even with a fixed seed.
 
 ### `reservoir`
 

--- a/docs/preview/sql/statements/attach.md
+++ b/docs/preview/sql/statements/attach.md
@@ -108,7 +108,7 @@ ATTACH 's3://duckdb-blobs/databases/stations.duckdb' AS stations_db (READ_ONLY);
 
 ### Explicit Storage Versions
 
-[DuckDB v1.2.0 introduced the `STORAGE_VERSION` option]({% post_url 2025-02-05-announcing-duckdb-120 %}#explicit-storage-versions), which allows explicilty specifying the storage version.
+[DuckDB v1.2.0 introduced the `STORAGE_VERSION` option]({% post_url 2025-02-05-announcing-duckdb-120 %}#explicit-storage-versions), which allows explicitly specifying the storage version.
 Using this, you can opt-in to newer forwards-incompatible features:
 
 ```sql


### PR DESCRIPTION
Fixes several typos. 
[Spotted with typos-cli](https://github.com/crate-ci/typos) and manually edited (there are many false positives)