### PR TITLE
Adding Alter Database page + TOC update

### DIFF
--- a/_data/menu_docs_preview.json
+++ b/_data/menu_docs_preview.json
@@ -465,6 +465,10 @@
                   "url": "analyze"
                 },
                 {
+                  "page": "ALTER DATABASE",
+                  "url": "alter_database"
+                },
+                {
                   "page": "ALTER TABLE",
                   "url": "alter_table"
                 },

--- a/docs/preview/sql/statements/alter_database.md
+++ b/docs/preview/sql/statements/alter_database.md
@@ -13,10 +13,10 @@ name without needing to detach and reattach it.
 
 ## RENAME DATABASE
 
-The following scenarios are not valid for using `ALTER DATABASE` to rename DuckDB databases:
+The following scenarios are not supported when renaming a DuckDB database with `ALTER DATABASE`:
 
-- You cannot rename a database to certain reserved keywords such as `system` or `temp`.
-- You cannot rename a database to the same name of a database attached in memory.
+- Renaming a database to certain reserved keywords such as `system` or `temp`.
+- Renaming a database to the same name of a database attached in memory.
 
 Rename a database from `old_name` to `new_name`:
 

--- a/docs/preview/sql/statements/alter_database.md
+++ b/docs/preview/sql/statements/alter_database.md
@@ -1,0 +1,32 @@
+---
+layout: docu
+railroad: statements/alter_database.js
+title: ALTER DATABASE Statement
+---
+
+The `ALTER DATABASE` command modifies a DuckDB database. This command can be used to change a database's
+name without needing to detach and reattach it.
+
+## Syntax
+
+<div id="rrdiagram"></div>
+
+## RENAME DATABASE
+
+The following scenarios are not valid for using `ALTER DATABASE` to rename DuckDB databases:
+
+- You cannot rename a database to certain reserved keywords such as `system` or `temp`.
+- You cannot rename a database to the same name of a database attached in memory.
+
+Rename a database from `old_name` to `new_name`:
+
+```sql
+ALTER DATABASE old_name RENAME to new_name;
+```
+
+Check if a database exists and rename it:
+
+```sql
+ALTER DATABASE IF EXISTS non_existent RENAME TO something_else;
+```
+

--- a/js/preview/statements/alter_database.js
+++ b/js/preview/statements/alter_database.js
@@ -1,0 +1,26 @@
+function GenerateAlterDatabase(options = {}) {
+	return Diagram([
+		AutomaticStack([
+			Keyword("ALTER DATABASE"),
+			Optional(Sequence([
+				Keyword("IF EXISTS")
+			])),
+			Expression("database-name"),
+			Keyword("RENAME TO"),
+			Expression("new-name")
+		])
+	]);
+}
+
+function Initialize(options = {}) {
+	document.getElementById("rrdiagram").classList.add("limit-width");
+	document.getElementById("rrdiagram").innerHTML = GenerateAlterDatabase(options).toString();
+}
+
+function Refresh(node_name, set_node) {
+	options[node_name] = set_node;
+	Initialize(options);
+}
+
+options = {};
+Initialize();


### PR DESCRIPTION
Adding `ALTER DATABASE` page per: 
- https://github.com/duckdb/duckdb-web/issues/5769 
- https://github.com/duckdb/duckdb/pull/18970. 

- This page users [ALTER TABLE](https://duckdb.org/docs/stable/sql/statements/alter_table.html) as template page and defines the newly merged `ALTER DATABASE` command which as far as I can tell only can be used to rename a database currently.


### Links:
http://localhost:4000/docs/preview/sql/statements/alter_database#syntax
