### PR TITLE
Adding JSON examples, BLOB options,examples

### DIFF
--- a/docs/stable/sql/statements/copy.md
+++ b/docs/stable/sql/statements/copy.md
@@ -442,7 +442,7 @@ The below options are applicable when writing `BLOB` files.
 
 | Name | Description | Type | Default |
 |:--|:-----|:-|:-|
-| `COMPRESSION` | The compression type for the file. By default this will be detected automatically from the file extension (e.g., `file.json.gz` will use `gzip`, `file.json.zst` will use `zstd`, and `file.json` will use `none`). Options are `none`, `gzip`, `zstd`. | `VARCHAR` | `auto` |
+| `COMPRESSION` | The compression type for the file. By default this will be detected automatically from the file extension (e.g., `file.blob.gz` will use `gzip`, `file.blob.zst` will use `zstd`, and `file.blob` will use `none`). Options are `none`, `gzip`, `zstd`. | `VARCHAR` | `auto` |
 
 Type casts the string value `foo` to the `BLOB` data type and outputs the results to `blob_output.blob`:
 


### PR DESCRIPTION
Updating the COPY page per https://github.com/duckdb/duckdb-web/issues/5912

- I noticed that the `JSON` copy commands were lacking examples, so I added them as part of this PR. This is an extremely powerful feature that I feel needs examples for discoverability.
- Adding `BLOB` format content, as far as I could tell `COMPRESSION` is the only option currently supported for this format option. 
- I added comments for the returned values of the JSON examples, I am open to feedback here, I was just trying to keep the content minimal while still displaying nuances of the various JSON format options.

### Links

Stable: 
http://localhost:4000/docs/stable/sql/statements/copy.html#json-options
http://localhost:4000/docs/stable/sql/statements/copy.html#blob-options


