### PR TITLE
Fix download metrics example query

### DIFF
--- a/community_extensions/download_metrics.md
+++ b/community_extensions/download_metrics.md
@@ -23,7 +23,7 @@ INTO NAME extension VALUE downloads_last_week
 ORDER BY downloads_last_week DESC;
 ```
 
-For example, to return the download counts for the weeks since October 1, 2024:
+For example, to return the download counts for the weeks since September 22, 2025:
 
 ```sql
 PIVOT (
@@ -33,14 +33,14 @@ PIVOT (
                 strftime(x, '%Y/%W')
             )
             FOR x
-            IN range(TIMESTAMP '2024-10-01', now()::TIMESTAMP, INTERVAL 1 WEEK)
+            IN range(TIMESTAMP '2025-09-22', now()::TIMESTAMP, INTERVAL 1 WEEK)
             IF strftime(x, '%W') != '53'
         ], union_by_name := true)
     )
     ON COLUMNS(* EXCLUDE _last_update)
     INTO NAME extension VALUE downloads
 )
-ON date_trunc('day', _last_update)
+ON date_trunc('day', _last_update::TIMESTAMP)
 USING any_value(downloads)
 ORDER BY extension;
 ```


### PR DESCRIPTION
There are two issues with the current "download metrics" [example query](https://duckdb.org/community_extensions/download_metrics):

Latest version of duckdb requires `_last_update` to be explicitly casted. Copying and pasting the query as-is, results in:
```
Binder Error:
No function matches the given name and argument types 'date_trunc(STRING_LITERAL, VARCHAR)'. You might need to add explicit type casts.
	Candidate functions:
	date_trunc(VARCHAR, DATE) -> TIMESTAMP
	date_trunc(VARCHAR, INTERVAL) -> INTERVAL
	date_trunc(VARCHAR, TIMESTAMP) -> TIMESTAMP
	date_trunc(VARCHAR, TIMESTAMP WITH TIME ZONE) -> TIMESTAMP WITH TIME ZONE
```

Additionally, historical data is missing and causes example to fail. Updating to when the data was fixed. If you don't update the date, you'll see errors like:
```
HTTP Error:
Unable to connect to URL "https://community-extensions.duckdb.org/download-stats-weekly/2025/37.json": 404 (Not Found).
```