### PR TITLE
Add pre-commit section to Python dev docs

### DIFF
--- a/docs/stable/dev/building/python.md
+++ b/docs/stable/dev/building/python.md
@@ -104,7 +104,7 @@ uvx pre-commit install
 
 This will run all required checks before letting your commit pass.
 
-You can also install a post-checkout hook that always runs `git submodule update --init --recursive`. When you change branches between main and a bugfixbranch, this makes sure the duckdb submodule is always correctly initialized:
+You can also install a post-checkout hook that always runs `git submodule update --init --recursive`. When you change branches between main and a bugfix branch, this makes sure the duckdb submodule is always correctly initialized:
 
 ```bash
 uvx pre-commit install --hook-type post-checkout


### PR DESCRIPTION
This adds a section about automatically running the linting, formatting and type checking tooling using git hooks.