### PR TITLE
Update 2025-04-22-liberate-analytical-data-management-with-duckdb.md

### DIFF
--- a/_media/2025-04-22-liberate-analytical-data-management-with-duckdb.md
+++ b/_media/2025-04-22-liberate-analytical-data-management-with-duckdb.md
@@ -20,5 +20,5 @@ length: "35 min"
 | **Event** | [Data Council 2025](https://www.datacouncil.ai/bay-2025) |
 | **Speaker** | [Hannes Mühleisen (DuckDB Labs)](https://hannes.muehleisen.org/) |
 | **Slide Deck** | [Download](https://blobs.duckdb.org/slides/data-council-2025-liberate-analytical-data-management-with-duckdb.pdf) |
-| **Youtube** | [Liberate Analytical Data Management with DuckDB](https://www.youtube.com/watch?v=o53onmgnQDU) |
+| **YouTube** | [Liberate Analytical Data Management with DuckDB](https://www.youtube.com/watch?v=o53onmgnQDU) |
 


### PR DESCRIPTION
- using simple table for meta information for science and media posts

@szarnyasg: We can use a simple table for adding the meta information to science and media posts. 