### PR TITLE
docs: fix function names in python export arrow guide

### DIFF
--- a/docs/stable/guides/python/export_arrow.md
+++ b/docs/stable/guides/python/export_arrow.md
@@ -5,7 +5,7 @@ redirect_from:
 title: Export to Apache Arrow
 ---
 
-All results of a query can be exported to an [Apache Arrow Table](https://arrow.apache.org/docs/python/generated/pyarrow.Table.html) using the `arrow` function. Alternatively, results can be returned as a [RecordBatchReader](https://arrow.apache.org/docs/python/generated/pyarrow.ipc.RecordBatchStreamReader.html) using the `fetch_record_batch` function and results can be read one batch at a time. In addition, relations built using DuckDB's [Relational API]({% link docs/stable/guides/python/relational_api_pandas.md %}) can also be exported.
+All results of a query can be exported to an [Apache Arrow Table](https://arrow.apache.org/docs/python/generated/pyarrow.Table.html) using the `fetch_arrow_table` function. Alternatively, results can be returned as a [RecordBatchReader](https://arrow.apache.org/docs/python/generated/pyarrow.ipc.RecordBatchStreamReader.html) using the `arrow` function and results can be read one batch at a time. In addition, relations built using DuckDB's [Relational API]({% link docs/stable/guides/python/relational_api_pandas.md %}) can also be exported.
 
 ## Export to an Arrow Table
 


### PR DESCRIPTION
This PR fixes some minor typos in the Python Guide "Export to Apache Arrow"