### PR TITLE
Overhaul enum docs

### DIFF
--- a/docs/preview/sql/data_types/enum.md
+++ b/docs/preview/sql/data_types/enum.md
@@ -142,7 +142,7 @@ WHERE current_mood = 'sad';
 | Pagliacci | sad          |
 
 
-> Warning This means that comparing against a bogus string always results in `false`:
+> Warning This means that comparing against a random (non-equivalent) string always results in `false` (and does not error):
 
 ```sql
 SELECT * FROM person


### PR DESCRIPTION
This was inspired by https://github.com/duckdb/duckdb/pull/19345

This was the motivation for these changes:
- Remove the very misleading line "The string `sad` is cast to the type `mood`". This is trying to get at the physical optimization that is happening, but logically that is NOT what is happening.
- Adds explicit warnings using `> Warning` of how comparing to raw strings can lead to footguns

While I was at it, I also did a bunch of other improvements:

- Simplifies the section on creating enums, and puts the most common case `CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy');` front and center.
- merges the two sections on creating enums from a SELECT
- renames section on "comparing" to "ordering"
- replaces ordering examples using  'mood' to more clearly ordered 'priority'
- adds examples on case-sensitivity
- uses a more concrete example (sales data and regions) for creating enum from a SELECT
- move the section on functions before the section on removal because I thought that was more important
- merge the example of enum_range() into the functions section
- removes the person_2 table from the examples. I don't think it was needed, and just provided more mental overhead
- add example of creating an enum in a schema
- rename the 'funky' mood to 'bogus' to make it even more clear that this is supposed to be a bogus value.