### PR TITLE
Add ending double quote to R data-docs

### DIFF
--- a/_includes/installation.html
+++ b/_includes/installation.html
@@ -189,7 +189,7 @@ pip install duckdb
 
 <div
     data-environment="r"
-    data-docs="{% link docs/stable/clients/r.md %}>
+    data-docs="{% link docs/stable/clients/r.md %}">
 
 {%- highlight bash -%}
 install.packages("duckdb")


### PR DESCRIPTION
Fixes broken R client documentation page link