### PR TITLE
Update Create Table RR Files

### DIFF
--- a/js/preview/railroad.js
+++ b/js/preview/railroad.js
@@ -1400,7 +1400,7 @@ function GenerateQualifiedTableName(options, tname = "table-name") {
 				Keyword(".")
 			])
 		]),
-		Expression("type-name")
+		Expression("table-name")
 	]);
 }
 

--- a/js/stable/railroad.js
+++ b/js/stable/railroad.js
@@ -1400,7 +1400,7 @@ function GenerateQualifiedTableName(options, tname = "table-name") {
 				Keyword(".")
 			])
 		]),
-		Expression("type-name")
+		Expression("table-name")
 	]);
 }
 


### PR DESCRIPTION
- This fixes a typo mentioned in https://github.com/duckdb/duckdb-web/issues/6007 in the create table railroad diagram, it updates the `type` -> `table`. See before/after screenshots for clarification.
- I know we are not updating preview now, but figured it would be a good fix for future cases.
- Also just a note, was having a hard time to load these changes in the localhost browser, it took several restarts to see the changes in the railroad diagram. Potential caching issue/dynamic build issue? 

Before: 

<img width="2160" height="1095" alt="image" src="https://github.com/user-attachments/assets/4d1a0056-56b4-431f-ac71-a62ebb0c7b2f" />



After: 

<img width="2108" height="1123" alt="image" src="https://github.com/user-attachments/assets/6efa0bdf-7aae-46c9-b294-545ef8991404" />


Links:

http://localhost:4000/docs/stable/sql/statements/create_table

