### PR TITLE
Add MERMAID as EXPLAIN output format

### DIFF
--- a/docs/preview/dev/profiling.md
+++ b/docs/preview/dev/profiling.md
@@ -28,6 +28,7 @@ The `EXPLAIN [ANALYZE]` statement allows exporting to several formats:
 
 * `text` – default ASCII-art style output
 * `graphviz` – produces a DOT output, which can be rendered with [Graphviz](https://graphviz.org/)
+* `mermaid` - produces a Mermaid Flowchart output, which can be rendered with [Mermaid](https://mermaid.js.org/)
 * `html` – produces an HTML output, which can rendered with [treeflex](https://dumptyd.github.io/treeflex/)
 * `json` – produces a JSON output
 

--- a/docs/stable/dev/profiling.md
+++ b/docs/stable/dev/profiling.md
@@ -32,7 +32,6 @@ The `EXPLAIN [ANALYZE]` statement allows exporting to several formats:
 
 * `text` – default ASCII-art style output
 * `graphviz` – produces a DOT output, which can be rendered with [Graphviz](https://graphviz.org/)
-* `mermaid` - produces a Mermaid Flowchart output, which can be rendered with [Mermaid](https://mermaid.js.org/)
 * `html` – produces an HTML output, which can rendered with [treeflex](https://dumptyd.github.io/treeflex/)
 * `json` – produces a JSON output
 


### PR DESCRIPTION
There's a PR at https://github.com/duckdb/duckdb/pull/19581 to add Mermaid as an output format for EXPLAIN plans.

This PR here should only be merged if the above PR is accepted. Thanks!