### PR TITLE
Hotfix to force download binary files

### DIFF
--- a/_includes/installation.html
+++ b/_includes/installation.html
@@ -202,7 +202,7 @@ install.packages("duckdb")
     data-docs="{% link docs/stable/clients/java.md %}">
 
 <h4>Direct Download (JAR)</h4>
-<a href="https://repo1.maven.org/maven2/org/duckdb/duckdb_jdbc/{{ site.current_duckdb_java_version }}/duckdb_jdbc-{{ site.current_duckdb_java_version }}.jar" class="download-btn"="rent_duckdb_java_version }}.jar" download rel="noopener noreferrer">duckdb_jdbc-{{ site.current_duckdb_java_version }}.jar</a>
+<a href="https://repo1.maven.org/maven2/org/duckdb/duckdb_jdbc/{{ site.current_duckdb_java_version }}/duckdb_jdbc-{{ site.current_duckdb_java_version }}.jar" class="download-btn" download="duckdb_jdbc-{{ site.current_duckdb_java_version }}.jar" download rel="noopener noreferrer">duckdb_jdbc-{{ site.current_duckdb_java_version }}.jar</a>
 {%- include checksum_inline.html environment="java" -%}
 
 <h4>Maven</h4>


### PR DESCRIPTION
> [!note]
> This PR attempts to fix a small aspect in #6094, the whole issue is still need to be review and resolve.

This fix basically done in the frontend with HTML code. So instead of  demand browser to open the link in new tab, we make it download file  immediately. This will ensure the visitors doesn't get redirect from  download file and, most importantly, the file can be downloaded.

However, be aware that if visitors access the link directly this is not the  right solution. To actually fix the root of this problem, we have to update  config in Cloudflare R2 to ensure they setup proper HTTP header  `content-type`.

Reference:
- https://developer.mozilla.org/en-US/docs/Web/API/HTMLAnchorElement/download