### PR TITLE
Change references from duckdb.typing to duckdb.sqltypes

### DIFF
--- a/docs/preview/clients/python/conversion.md
+++ b/docs/preview/clients/python/conversion.md
@@ -177,7 +177,7 @@ the function will return a `MAP`, due to [automatic conversion]({% link docs/pre
 To return a `STRUCT`, the `return_type` has to be provided:
 ```python
 import duckdb
-from duckdb.typing import BOOLEAN, INTEGER, VARCHAR
+from duckdb.sqltypes import BOOLEAN, INTEGER, VARCHAR
 from duckdb import list_type, struct_type
 
 duckdb_conn = duckdb.connect()
@@ -199,7 +199,7 @@ duckdb_conn.sql("select get_struct_as_map()").show()
 duckdb_conn.create_function("get_struct", get_struct, return_type=struct_type({
     1: VARCHAR,
     "2": INTEGER,
-    "three": list_type(duckdb.typing.INTEGER),
+    "three": list_type(INTEGER),
     False: BOOLEAN
 }))
 

--- a/docs/preview/clients/python/function.md
+++ b/docs/preview/clients/python/function.md
@@ -10,7 +10,7 @@ Here is an example using a Python function that calls a third-party library.
 
 ```python
 import duckdb
-from duckdb.typing import VARCHAR
+from duckdb.sqltypes import VARCHAR
 from faker import Faker
 
 def generate_random_name():
@@ -164,7 +164,7 @@ When this is not desired, you need to explicitly set this parameter to `"special
 
 ```python
 import duckdb
-from duckdb.typing import BIGINT
+from duckdb.sqltypes import BIGINT
 
 def dont_intercept_null(x):
     return 5
@@ -182,7 +182,7 @@ With `null_handling="special"`:
 
 ```python
 import duckdb
-from duckdb.typing import BIGINT
+from duckdb.sqltypes import BIGINT
 
 def dont_intercept_null(x):
     return 5
@@ -201,7 +201,7 @@ print(res)
 
 ```python
 import duckdb
-from duckdb.typing import VARCHAR
+from duckdb.sqltypes import VARCHAR
 
 
 def return_str_or_none(x: str) -> str | None:
@@ -232,7 +232,7 @@ If you want to disable this behavior, and instead return `NULL`, you'll need to 
 
 ```python
 import duckdb
-from duckdb.typing import BIGINT
+from duckdb.sqltypes import BIGINT
 
 def will_throw():
     raise ValueError("ERROR")
@@ -318,7 +318,7 @@ In general, using an Arrow UDF will be much more efficient than native because i
 ```python
 import duckdb
 import pyarrow as pa
-from duckdb.typing import VARCHAR
+from duckdb.sqltypes import VARCHAR
 from pyarrow import compute as pc
 
 
@@ -354,7 +354,7 @@ This can be useful to interact with Python libraries that don't operate on Arrow
 ```python
 import duckdb
 
-from duckdb.typing import DATE
+from duckdb.sqltypes import DATE
 from faker import Faker
 
 def random_date():

--- a/docs/preview/clients/python/relational_api.md
+++ b/docs/preview/clients/python/relational_api.md
@@ -5326,7 +5326,7 @@ Select columns from the relation, by filtering based on type(s)
 ##### Example
 
 ```python
-import duckdb
+import duckdb.sqltypes
 
 duckdb_conn = duckdb.connect()
 
@@ -5340,7 +5340,7 @@ rel = duckdb_conn.sql("""
     """
 )
 
-rel.select_dtypes(types=[duckdb.typing.VARCHAR]).distinct()
+rel.select_dtypes(types=[duckdb.sqltypes.VARCHAR]).distinct()
 ```
 
 
@@ -5381,7 +5381,7 @@ Select columns from the relation, by filtering based on type(s)
 ##### Example
 
 ```python
-import duckdb
+import duckdb.sqltypes
 
 duckdb_conn = duckdb.connect()
 
@@ -5395,7 +5395,7 @@ rel = duckdb_conn.sql("""
     """
 )
 
-rel.select_types(types=[duckdb.typing.VARCHAR]).distinct()
+rel.select_types(types=[duckdb.sqltypes.VARCHAR]).distinct()
 ```
 
 

--- a/docs/preview/clients/python/types.md
+++ b/docs/preview/clients/python/types.md
@@ -53,10 +53,10 @@ The table below shows the mapping of Numpy DType to DuckDB type.
 Which can also be arbitrarily nested.
 
 ```python
-import duckdb
+import duckdb.sqltypes
 from typing import Union
 
-duckdb.typing.DuckDBPyType(list[dict[Union[str, int], str]])
+duckdb.sqltypes.DuckDBPyType(list[dict[Union[str, int], str]])
 ```
 
 ```text
@@ -68,9 +68,9 @@ MAP(UNION(u1 VARCHAR, u2 BIGINT), VARCHAR)[]
 `dict` type objects map to a `MAP` type of the key type and the value type.
 
 ```python
-import duckdb
+import duckdb.sqltypes
 
-print(duckdb.typing.DuckDBPyType(dict[str, int]))
+print(duckdb.sqltypes.DuckDBPyType(dict[str, int]))
 ```
 
 ```text
@@ -82,9 +82,9 @@ MAP(VARCHAR, BIGINT)
 `dict` objects map to a `STRUCT` composed of the keys and values of the dict.
 
 ```python
-import duckdb
+import duckdb.sqltypes
 
-print(duckdb.typing.DuckDBPyType({'a': str, 'b': int}))
+print(duckdb.sqltypes.DuckDBPyType({'a': str, 'b': int}))
 ```
 
 ```text
@@ -96,10 +96,10 @@ STRUCT(a VARCHAR, b BIGINT)
 `typing.Union` objects map to a `UNION` type of the provided types.
 
 ```python
-import duckdb
+import duckdb.sqltypes
 from typing import Union
 
-print(duckdb.typing.DuckDBPyType(Union[int, str, bool, bytearray]))
+print(duckdb.sqltypes.DuckDBPyType(Union[int, str, bool, bytearray]))
 ```
 
 ```text
@@ -108,7 +108,7 @@ UNION(u1 BIGINT, u2 VARCHAR, u3 BOOLEAN, u4 BLOB)
 
 ### Creation Functions
 
-For the built-in types, you can use the constants defined in `duckdb.typing`:
+For the built-in types, you can use the constants defined in `duckdb.sqltypes`:
 
 <div class="monospace_table"></div>
 

--- a/docs/preview/guides/snippets/create_synthetic_data.md
+++ b/docs/preview/guides/snippets/create_synthetic_data.md
@@ -18,7 +18,7 @@ For example:
 ```python
 import duckdb
 
-from duckdb.typing import *
+from duckdb.sqltypes import *
 from faker import Faker
 
 fake = Faker()

--- a/docs/stable/clients/python/conversion.md
+++ b/docs/stable/clients/python/conversion.md
@@ -183,7 +183,7 @@ the function will return a `MAP`, due to [automatic conversion]({% link docs/sta
 To return a `STRUCT`, the `return_type` has to be provided:
 ```python
 import duckdb
-from duckdb.typing import BOOLEAN, INTEGER, VARCHAR
+from duckdb.sqltypes import BOOLEAN, INTEGER, VARCHAR
 from duckdb import list_type, struct_type
 
 duckdb_conn = duckdb.connect()
@@ -205,7 +205,7 @@ duckdb_conn.sql("select get_struct_as_map()").show()
 duckdb_conn.create_function("get_struct", get_struct, return_type=struct_type({
     1: VARCHAR,
     "2": INTEGER,
-    "three": list_type(duckdb.typing.INTEGER),
+    "three": list_type(INTEGER),
     False: BOOLEAN
 }))
 

--- a/docs/stable/clients/python/function.md
+++ b/docs/stable/clients/python/function.md
@@ -14,7 +14,7 @@ Here is an example using a Python function that calls a third-party library.
 
 ```python
 import duckdb
-from duckdb.typing import VARCHAR
+from duckdb.sqltypes import VARCHAR
 from faker import Faker
 
 def generate_random_name():
@@ -168,7 +168,7 @@ When this is not desired, you need to explicitly set this parameter to `"special
 
 ```python
 import duckdb
-from duckdb.typing import BIGINT
+from duckdb.sqltypes import BIGINT
 
 def dont_intercept_null(x):
     return 5
@@ -186,7 +186,7 @@ With `null_handling="special"`:
 
 ```python
 import duckdb
-from duckdb.typing import BIGINT
+from duckdb.sqltypes import BIGINT
 
 def dont_intercept_null(x):
     return 5
@@ -205,7 +205,7 @@ print(res)
 
 ```python
 import duckdb
-from duckdb.typing import VARCHAR
+from duckdb.sqltypes import VARCHAR
 
 
 def return_str_or_none(x: str) -> str | None:
@@ -236,7 +236,7 @@ If you want to disable this behavior, and instead return `NULL`, you'll need to 
 
 ```python
 import duckdb
-from duckdb.typing import BIGINT
+from duckdb.sqltypes import BIGINT
 
 def will_throw():
     raise ValueError("ERROR")
@@ -322,7 +322,7 @@ In general, using an Arrow UDF will be much more efficient than native because i
 ```python
 import duckdb
 import pyarrow as pa
-from duckdb.typing import VARCHAR
+from duckdb.sqltypes import VARCHAR
 from pyarrow import compute as pc
 
 
@@ -358,7 +358,7 @@ This can be useful to interact with Python libraries that don't operate on Arrow
 ```python
 import duckdb
 
-from duckdb.typing import DATE
+from duckdb.sqltypes import DATE
 from faker import Faker
 
 def random_date():

--- a/docs/stable/clients/python/relational_api.md
+++ b/docs/stable/clients/python/relational_api.md
@@ -5331,7 +5331,7 @@ Select columns from the relation, by filtering based on type(s)
 ##### Example
 
 ```python
-import duckdb
+import duckdb.sqltypes
 
 duckdb_conn = duckdb.connect()
 
@@ -5345,7 +5345,7 @@ rel = duckdb_conn.sql("""
     """
 )
 
-rel.select_dtypes(types=[duckdb.typing.VARCHAR]).distinct()
+rel.select_dtypes(types=[duckdb.sqltypes.VARCHAR]).distinct()
 ```
 
 
@@ -5386,7 +5386,7 @@ Select columns from the relation, by filtering based on type(s)
 ##### Example
 
 ```python
-import duckdb
+import duckdb.sqltypes
 
 duckdb_conn = duckdb.connect()
 
@@ -5400,7 +5400,7 @@ rel = duckdb_conn.sql("""
     """
 )
 
-rel.select_types(types=[duckdb.typing.VARCHAR]).distinct()
+rel.select_types(types=[duckdb.sqltypes.VARCHAR]).distinct()
 ```
 
 

--- a/docs/stable/clients/python/types.md
+++ b/docs/stable/clients/python/types.md
@@ -57,10 +57,10 @@ The table below shows the mapping of Numpy DType to DuckDB type.
 Which can also be arbitrarily nested.
 
 ```python
-import duckdb
+import duckdb.sqltypes
 from typing import Union
 
-duckdb.typing.DuckDBPyType(list[dict[Union[str, int], str]])
+duckdb.sqltypes.DuckDBPyType(list[dict[Union[str, int], str]])
 ```
 
 ```text
@@ -72,9 +72,9 @@ MAP(UNION(u1 VARCHAR, u2 BIGINT), VARCHAR)[]
 `dict` type objects map to a `MAP` type of the key type and the value type.
 
 ```python
-import duckdb
+import duckdb.sqltypes
 
-print(duckdb.typing.DuckDBPyType(dict[str, int]))
+print(duckdb.sqltypes.DuckDBPyType(dict[str, int]))
 ```
 
 ```text
@@ -86,9 +86,9 @@ MAP(VARCHAR, BIGINT)
 `dict` objects map to a `STRUCT` composed of the keys and values of the dict.
 
 ```python
-import duckdb
+import duckdb.sqltypes
 
-print(duckdb.typing.DuckDBPyType({'a': str, 'b': int}))
+print(duckdb.sqltypes.DuckDBPyType({'a': str, 'b': int}))
 ```
 
 ```text
@@ -100,10 +100,10 @@ STRUCT(a VARCHAR, b BIGINT)
 `typing.Union` objects map to a `UNION` type of the provided types.
 
 ```python
-import duckdb
+import duckdb.sqltypes
 from typing import Union
 
-print(duckdb.typing.DuckDBPyType(Union[int, str, bool, bytearray]))
+print(duckdb.sqltypes.DuckDBPyType(Union[int, str, bool, bytearray]))
 ```
 
 ```text
@@ -112,7 +112,7 @@ UNION(u1 BIGINT, u2 VARCHAR, u3 BOOLEAN, u4 BLOB)
 
 ### Creation Functions
 
-For the built-in types, you can use the constants defined in `duckdb.typing`:
+For the built-in types, you can use the constants defined in `duckdb.sqltypes`:
 
 <div class="monospace_table"></div>
 

--- a/docs/stable/guides/snippets/create_synthetic_data.md
+++ b/docs/stable/guides/snippets/create_synthetic_data.md
@@ -20,7 +20,7 @@ For example:
 ```python
 import duckdb
 
-from duckdb.typing import *
+from duckdb.sqltypes import *
 from faker import Faker
 
 fake = Faker()

--- a/scripts/generate_python_relational_docs_details.py
+++ b/scripts/generate_python_relational_docs_details.py
@@ -13,7 +13,7 @@ class PythonRelAPIParamDetails:
 @dataclass
 class PythonRelAPIDetails:
     # Configure details for each method
-    additional_description: str = ''  # text to be appended to the method description
+    additional_description: str = ""  # text to be appended to the method description
     aliases: list[str] = None  # list of methods the methods is alias of
     parameters: list[PythonRelAPIParamDetails] = None  # method parameter description
     example: str = (
@@ -49,7 +49,7 @@ PLACEHOLDER_EXAMPLE = "```python\n{code_example}\n```"
 PLACEHOLDER_RESULT = "```{result_type}\n{result}\n```"
 
 CREATION_METHODS_MAP = {
-    'from_arrow': PythonRelAPIDetails(
+    "from_arrow": PythonRelAPIDetails(
         example="""
 import duckdb
 import pyarrow as pa
@@ -81,7 +81,7 @@ rel.show()
             )
         ],
     ),
-    'from_csv_auto': PythonRelAPIDetails(
+    "from_csv_auto": PythonRelAPIDetails(
         example="""
 import csv
 import duckdb
@@ -107,7 +107,7 @@ rel.show()
 └───────┴─────────┘
 """,
         use_default_example=False,
-        aliases=['read_csv'],
+        aliases=["read_csv"],
         parameters=[
             PythonRelAPIParamDetails(
                 parameter_name="path_or_buffer",
@@ -337,7 +337,7 @@ rel.show()
             ),
         ],
     ),
-    'from_df': PythonRelAPIDetails(
+    "from_df": PythonRelAPIDetails(
         example="""
 import duckdb
 import pandas as pd
@@ -367,7 +367,7 @@ rel.show()
             )
         ],
     ),
-    'from_parquet': PythonRelAPIDetails(
+    "from_parquet": PythonRelAPIDetails(
         example="""
 import duckdb
 import pyarrow as pa
@@ -394,7 +394,7 @@ rel.show()
 └──────┴─────────┘
 """,
         use_default_example=False,
-        aliases=['read_parquet'],
+        aliases=["read_parquet"],
         parameters=[
             PythonRelAPIParamDetails(
                 parameter_name="file_glob",
@@ -438,7 +438,7 @@ rel.show()
             ),
         ],
     ),
-    'from_query': PythonRelAPIDetails(
+    "from_query": PythonRelAPIDetails(
         example="""
 import duckdb
 
@@ -477,7 +477,7 @@ rel.show()
             ),
         ],
     ),
-    'query': PythonRelAPIDetails(
+    "query": PythonRelAPIDetails(
         example="""
 import duckdb
 
@@ -516,7 +516,7 @@ rel.show()
             ),
         ],
     ),
-    'read_csv': PythonRelAPIDetails(
+    "read_csv": PythonRelAPIDetails(
         example="""
 import csv
 import duckdb
@@ -542,7 +542,7 @@ rel.show()
 └───────┴─────────┘
 """,
         use_default_example=False,
-        aliases=['from_csv_auto'],
+        aliases=["from_csv_auto"],
         parameters=[
             PythonRelAPIParamDetails(
                 parameter_name="path_or_buffer",
@@ -772,7 +772,7 @@ rel.show()
             ),
         ],
     ),
-    'read_json': PythonRelAPIDetails(
+    "read_json": PythonRelAPIDetails(
         example="""
 import duckdb
 import json
@@ -898,7 +898,7 @@ rel.show()
             ),
         ],
     ),
-    'read_parquet': PythonRelAPIDetails(
+    "read_parquet": PythonRelAPIDetails(
         example="""
 import duckdb
 import pyarrow as pa
@@ -925,7 +925,7 @@ rel.show()
 └──────┴─────────┘
 """,
         use_default_example=False,
-        aliases=['from_parquet'],
+        aliases=["from_parquet"],
         parameters=[
             PythonRelAPIParamDetails(
                 parameter_name="file_glob",
@@ -969,7 +969,7 @@ rel.show()
             ),
         ],
     ),
-    'sql': PythonRelAPIDetails(
+    "sql": PythonRelAPIDetails(
         example="""
 import duckdb
 
@@ -1008,7 +1008,7 @@ rel.show()
             ),
         ],
     ),
-    'table': PythonRelAPIDetails(
+    "table": PythonRelAPIDetails(
         example="""
 import duckdb
 
@@ -1037,7 +1037,7 @@ rel.show()
             )
         ],
     ),
-    'table_function': PythonRelAPIDetails(
+    "table_function": PythonRelAPIDetails(
         example='''
 import duckdb
 
@@ -1074,7 +1074,7 @@ rel.show()
             ),
         ],
     ),
-    'values': PythonRelAPIDetails(
+    "values": PythonRelAPIDetails(
         example="""
 import duckdb
 
@@ -1094,7 +1094,7 @@ rel.show()
 """,
         use_default_example=False,
     ),
-    'view': PythonRelAPIDetails(
+    "view": PythonRelAPIDetails(
         example="""
 import duckdb
 
@@ -1126,12 +1126,12 @@ rel.show()
 }
 
 DEFINITION_METHODS_MAP = {
-    'columns': PythonRelAPIDetails(
-        example='rel.columns',
+    "columns": PythonRelAPIDetails(
+        example="rel.columns",
         result=" ['id', 'description', 'value', 'created_timestamp']",
     ),
-    'describe': PythonRelAPIDetails(
-        example='rel.describe()',
+    "describe": PythonRelAPIDetails(
+        example="rel.describe()",
         result="""
 ┌─────────┬──────────────────────────────────────┬─────────────────┬────────────────────┬────────────────────────────┐
 │  aggr   │                  id                  │   description   │       value        │     created_timestamp      │
@@ -1146,8 +1146,8 @@ DEFINITION_METHODS_MAP = {
 └─────────┴──────────────────────────────────────┴─────────────────┴────────────────────┴────────────────────────────┘ 
 """,
     ),
-    'description': PythonRelAPIDetails(
-        example='rel.description',
+    "description": PythonRelAPIDetails(
+        example="rel.description",
         result="""
 [('id', 'UUID', None, None, None, None, None),
  ('description', 'STRING', None, None, None, None, None),
@@ -1155,18 +1155,18 @@ DEFINITION_METHODS_MAP = {
  ('created_timestamp', 'DATETIME', None, None, None, None, None)]  
 """,
     ),
-    'dtypes': PythonRelAPIDetails(
-        example='rel.dtypes',
-        result=' [UUID, VARCHAR, BIGINT, TIMESTAMP WITH TIME ZONE]',
-        aliases=['types'],
+    "dtypes": PythonRelAPIDetails(
+        example="rel.dtypes",
+        result=" [UUID, VARCHAR, BIGINT, TIMESTAMP WITH TIME ZONE]",
+        aliases=["types"],
     ),
-    'explain': PythonRelAPIDetails(
-        example='rel.explain()',
+    "explain": PythonRelAPIDetails(
+        example="rel.explain()",
         result="""
 ┌───────────────────────────┐\n│         PROJECTION        │\n│    ────────────────────   │\n│             id            │\n│        description        │\n│           value           │\n│     created_timestamp     │\n│                           │\n│          ~9 Rows          │\n└─────────────┬─────────────┘\n┌─────────────┴─────────────┐\n│           RANGE           │\n│    ────────────────────   │\n│      Function: RANGE      │\n│                           │\n│          ~9 Rows          │\n└───────────────────────────┘\n\n
 """,
     ),
-    'query-1': PythonRelAPIDetails(
+    "query-1": PythonRelAPIDetails(
         example='rel.query(virtual_table_name="rel_view", sql_query="from rel")\n\nduckdb_conn.sql("show rel_view")',
         result="""
 ┌───────────────────┬──────────────────────────┬─────────┬─────────┬─────────┬─────────┐
@@ -1192,9 +1192,9 @@ DEFINITION_METHODS_MAP = {
             ),
         ],
     ),
-    'set_alias': PythonRelAPIDetails(
+    "set_alias": PythonRelAPIDetails(
         example="rel.set_alias('abc').select('abc.id')",
-        result='In the SQL query, the alias will be `abc`',
+        result="In the SQL query, the alias will be `abc`",
         parameters=[
             PythonRelAPIParamDetails(
                 parameter_name="alias",
@@ -1203,12 +1203,12 @@ DEFINITION_METHODS_MAP = {
             )
         ],
     ),
-    'alias': PythonRelAPIDetails(
-        example='rel.alias', result='unnamed_relation_43c808c247431be5'
+    "alias": PythonRelAPIDetails(
+        example="rel.alias", result="unnamed_relation_43c808c247431be5"
     ),
-    'shape': PythonRelAPIDetails(example='rel.shape', result='(9, 4)'),
-    'show': PythonRelAPIDetails(
-        example='rel.show()',
+    "shape": PythonRelAPIDetails(example="rel.shape", result="(9, 4)"),
+    "show": PythonRelAPIDetails(
+        example="rel.show()",
         result="""
 ┌──────────────────────────────────────┬─────────────────┬───────┬────────────────────────────┐
 │                  id                  │   description   │ value │     created_timestamp      │
@@ -1253,8 +1253,8 @@ DEFINITION_METHODS_MAP = {
             ),
         ],
     ),
-    'sql_query': PythonRelAPIDetails(
-        example='rel.sql_query()',
+    "sql_query": PythonRelAPIDetails(
+        example="rel.sql_query()",
         result="""SELECT 
     gen_random_uuid() AS id, 
     concat('value is ', CASE  WHEN ((mod("range", 2) = 0)) THEN ('even') ELSE 'uneven' END) AS description, 
@@ -1264,11 +1264,11 @@ FROM "range"(1, 10)
 """,
         result_type="sql",
     ),
-    'type': PythonRelAPIDetails(example='rel.type', result='QUERY_RELATION'),
-    'types': PythonRelAPIDetails(
-        example='rel.types',
-        result='[UUID, VARCHAR, BIGINT, TIMESTAMP WITH TIME ZONE]',
-        aliases=['dtypes'],
+    "type": PythonRelAPIDetails(example="rel.type", result="QUERY_RELATION"),
+    "types": PythonRelAPIDetails(
+        example="rel.types",
+        result="[UUID, VARCHAR, BIGINT, TIMESTAMP WITH TIME ZONE]",
+        aliases=["dtypes"],
     ),
 }
 
@@ -1297,7 +1297,7 @@ TRANSFORMATION_METHODS_MAP = {
             ),
         ],
     ),
-    'apply': PythonRelAPIDetails(
+    "apply": PythonRelAPIDetails(
         example="""
 rel.apply(
     function_name="count", 
@@ -1347,7 +1347,7 @@ rel.apply(
             ),
         ],
     ),
-    'cross': PythonRelAPIDetails(
+    "cross": PythonRelAPIDetails(
         example='rel.cross(other_rel=rel.set_alias("other_rel"))',
         result="""
 ┌─────────────────────────────┬─────────────────┬───────┬───────────────────────────┬──────────────────────────────────────┬─────────────────┬───────┬───────────────────────────┐
@@ -1366,7 +1366,7 @@ rel.apply(
             )
         ],
     ),
-    'except_': PythonRelAPIDetails(
+    "except_": PythonRelAPIDetails(
         example='rel.except_(other_rel=rel.set_alias("other_rel"))',
         result="""
 The relation query is executed twice, therefore generating different ids and timestamps:
@@ -1387,7 +1387,7 @@ The relation query is executed twice, therefore generating different ids and tim
             )
         ],
     ),
-    'filter': PythonRelAPIDetails(
+    "filter": PythonRelAPIDetails(
         example='rel.filter("value = 2")',
         result="""
 ┌──────────────────────────────────────┬───────────────┬───────┬───────────────────────────┐
@@ -1406,7 +1406,7 @@ The relation query is executed twice, therefore generating different ids and tim
             )
         ],
     ),
-    'insert': PythonRelAPIDetails(
+    "insert": PythonRelAPIDetails(
         example='''
 import duckdb
 
@@ -1455,7 +1455,7 @@ rel.filter("value = 10")
             )
         ],
     ),
-    'insert_into': PythonRelAPIDetails(
+    "insert_into": PythonRelAPIDetails(
         example='''
 import duckdb
 
@@ -1504,7 +1504,7 @@ duckdb_conn.table("code_example").filter("value = 10")
             )
         ],
     ),
-    'intersect': PythonRelAPIDetails(
+    "intersect": PythonRelAPIDetails(
         example='rel.intersect(other_rel=rel.set_alias("other_rel"))',
         result="""
 The relation query is executed once with `rel` and once with `other_rel`,
@@ -1526,7 +1526,7 @@ therefore generating different ids and timestamps:
             )
         ],
     ),
-    'join': PythonRelAPIDetails(
+    "join": PythonRelAPIDetails(
         example="""
 rel = rel.set_alias("rel").join(
     other_rel=rel.set_alias("other_rel"), 
@@ -1628,8 +1628,8 @@ ON ((unnamed_relation_41bc15e744037078.id = unnamed_relation_307e245965aa2c2b.id
             ),
         ],
     ),
-    'limit': PythonRelAPIDetails(
-        example='rel.limit(1)',
+    "limit": PythonRelAPIDetails(
+        example="rel.limit(1)",
         result="""
 ┌──────────────────────────────────────┬─────────────────┬───────┬────────────────────────────┐
 │                  id                  │   description   │ value │     created_timestamp      │
@@ -1653,7 +1653,7 @@ ON ((unnamed_relation_41bc15e744037078.id = unnamed_relation_307e245965aa2c2b.id
             ),
         ],
     ),
-    'map': PythonRelAPIDetails(
+    "map": PythonRelAPIDetails(
         example="""
 import duckdb
 from pandas import DataFrame
@@ -1691,7 +1691,7 @@ rel.map(multiply_by_2, schema={"id": int, "text": str})
             ),
         ],
     ),
-    'order': PythonRelAPIDetails(
+    "order": PythonRelAPIDetails(
         example='rel.order("value desc").limit(1, offset=4)',
         result="""
 ┌──────────────────────────────────────┬─────────────────┬───────┬────────────────────────────┐
@@ -1710,7 +1710,7 @@ rel.map(multiply_by_2, schema={"id": int, "text": str})
             )
         ],
     ),
-    'project': PythonRelAPIDetails(
+    "project": PythonRelAPIDetails(
         example='rel.project("description").limit(1)',
         result="""
 ┌─────────────────┐
@@ -1721,7 +1721,7 @@ rel.map(multiply_by_2, schema={"id": int, "text": str})
 └─────────────────┘
 """,
         use_default_example=True,
-        aliases=['select'],
+        aliases=["select"],
         parameters=[
             PythonRelAPIParamDetails(
                 parameter_name="groups",
@@ -1731,7 +1731,7 @@ rel.map(multiply_by_2, schema={"id": int, "text": str})
             )
         ],
     ),
-    'select': PythonRelAPIDetails(
+    "select": PythonRelAPIDetails(
         example='rel.select("description").limit(1)',
         result="""
 ┌─────────────────┐
@@ -1742,7 +1742,7 @@ rel.map(multiply_by_2, schema={"id": int, "text": str})
 └─────────────────┘
 """,
         use_default_example=True,
-        aliases=['project'],
+        aliases=["project"],
         parameters=[
             PythonRelAPIParamDetails(
                 parameter_name="groups",
@@ -1752,7 +1752,7 @@ rel.map(multiply_by_2, schema={"id": int, "text": str})
             )
         ],
     ),
-    'sort': PythonRelAPIDetails(
+    "sort": PythonRelAPIDetails(
         example='rel.sort("description")',
         result="""
 ┌──────────────────────────────────────┬─────────────────┬───────┬────────────────────────────┐
@@ -1765,7 +1765,7 @@ rel.map(multiply_by_2, schema={"id": int, "text": str})
 """,
         use_default_example=True,
     ),
-    'union': PythonRelAPIDetails(
+    "union": PythonRelAPIDetails(
         example='rel = rel.union(union_rel=rel)\n\nrel.count("*")',
         result="""
 ┌──────────────┐
@@ -1785,7 +1785,7 @@ rel.map(multiply_by_2, schema={"id": int, "text": str})
             )
         ],
     ),
-    'update': PythonRelAPIDetails(
+    "update": PythonRelAPIDetails(
         example='''
 import duckdb
 
@@ -1840,7 +1840,7 @@ rel.show()
 }
 
 FUNCTION_METHODS_MAP = {
-    'any_value': PythonRelAPIDetails(
+    "any_value": PythonRelAPIDetails(
         example="rel.any_value('id')",
         result="""
 ┌──────────────────────────────────────┐
@@ -1876,7 +1876,7 @@ FUNCTION_METHODS_MAP = {
             ),
         ],
     ),
-    'arg_max': PythonRelAPIDetails(
+    "arg_max": PythonRelAPIDetails(
         example='rel.arg_max(arg_column="value", value_column="value", groups="description", projected_columns="description")',
         result="""
 ┌─────────────────┬───────────────────────────┐
@@ -1918,7 +1918,7 @@ FUNCTION_METHODS_MAP = {
             ),
         ],
     ),
-    'arg_min': PythonRelAPIDetails(
+    "arg_min": PythonRelAPIDetails(
         example='rel.arg_min(arg_column="value", value_column="value", groups="description", projected_columns="description")',
         result="""
 ┌─────────────────┬───────────────────────────┐
@@ -1960,7 +1960,7 @@ FUNCTION_METHODS_MAP = {
             ),
         ],
     ),
-    'avg': PythonRelAPIDetails(
+    "avg": PythonRelAPIDetails(
         example="rel.avg('value')",
         result="""
 ┌──────────────┐
@@ -1996,7 +1996,7 @@ FUNCTION_METHODS_MAP = {
             ),
         ],
     ),
-    'bit_and': PythonRelAPIDetails(
+    "bit_and": PythonRelAPIDetails(
         example="""
 rel = rel.select("description, value::bit as value_bit")
 
@@ -2037,7 +2037,7 @@ rel.bit_and(column="value_bit", groups="description", projected_columns="descrip
             ),
         ],
     ),
-    'bit_or': PythonRelAPIDetails(
+    "bit_or": PythonRelAPIDetails(
         example="""
 rel = rel.select("description, value::bit as value_bit")
 
@@ -2078,7 +2078,7 @@ rel.bit_or(column="value_bit", groups="description", projected_columns="descript
             ),
         ],
     ),
-    'bit_xor': PythonRelAPIDetails(
+    "bit_xor": PythonRelAPIDetails(
         example="""
 rel = rel.select("description, value::bit as value_bit")
 
@@ -2119,7 +2119,7 @@ rel.bit_xor(column="value_bit", groups="description", projected_columns="descrip
             ),
         ],
     ),
-    'bitstring_agg': PythonRelAPIDetails(
+    "bitstring_agg": PythonRelAPIDetails(
         example='rel.bitstring_agg(column="value", groups="description", projected_columns="description", min=1, max=9)',
         result="""
 ┌─────────────────┬────────────────────────┐
@@ -2168,7 +2168,7 @@ rel.bit_xor(column="value_bit", groups="description", projected_columns="descrip
             ),
         ],
     ),
-    'bool_and': PythonRelAPIDetails(
+    "bool_and": PythonRelAPIDetails(
         example="""
 rel = rel.select("description, mod(value,2)::boolean as uneven")
 
@@ -2209,7 +2209,7 @@ rel.bool_and(column="uneven", groups="description", projected_columns="descripti
             ),
         ],
     ),
-    'bool_or': PythonRelAPIDetails(
+    "bool_or": PythonRelAPIDetails(
         example="""
 rel = rel.select("description, mod(value,2)::boolean as uneven")
 
@@ -2250,7 +2250,7 @@ rel.bool_or(column="uneven", groups="description", projected_columns="descriptio
             ),
         ],
     ),
-    'count': PythonRelAPIDetails(
+    "count": PythonRelAPIDetails(
         example='rel.count("id")',
         result="""
 ┌───────────┐
@@ -2286,7 +2286,7 @@ rel.bool_or(column="uneven", groups="description", projected_columns="descriptio
             ),
         ],
     ),
-    'cume_dist': PythonRelAPIDetails(
+    "cume_dist": PythonRelAPIDetails(
         example='rel.cume_dist(window_spec="over (partition by description order by value)", projected_columns="description, value")',
         result="""
 ┌─────────────────┬───────┬──────────────────────────────────────────────────────────────┐
@@ -2318,7 +2318,7 @@ rel.bool_or(column="uneven", groups="description", projected_columns="descriptio
             ),
         ],
     ),
-    'dense_rank': PythonRelAPIDetails(
+    "dense_rank": PythonRelAPIDetails(
         example=' rel.dense_rank(window_spec="over (partition by description order by value)", projected_columns="description, value")',
         result="""
 ┌─────────────────┬───────┬───────────────────────────────────────────────────────────────┐
@@ -2336,7 +2336,7 @@ rel.bool_or(column="uneven", groups="description", projected_columns="descriptio
 │ value is uneven │     9 │                                                             5 │
 └─────────────────┴───────┴───────────────────────────────────────────────────────────────┘
 """,
-        aliases=['rank_dense'],
+        aliases=["rank_dense"],
         parameters=[
             PythonRelAPIParamDetails(
                 parameter_name="window_spec",
@@ -2351,7 +2351,7 @@ rel.bool_or(column="uneven", groups="description", projected_columns="descriptio
             ),
         ],
     ),
-    'distinct': PythonRelAPIDetails(
+    "distinct": PythonRelAPIDetails(
         example="""
 import duckdb
 
@@ -2375,7 +2375,7 @@ rel.distinct().order("range")
 """,
         use_default_example=False,
     ),
-    'favg': PythonRelAPIDetails(
+    "favg": PythonRelAPIDetails(
         example='rel.favg(column="value", groups="description", projected_columns="description")',
         result="""
 ┌─────────────────┬───────────────┐
@@ -2412,7 +2412,7 @@ rel.distinct().order("range")
             ),
         ],
     ),
-    'first': PythonRelAPIDetails(
+    "first": PythonRelAPIDetails(
         example='rel.first(column="value", groups="description", projected_columns="description")',
         result="""
 ┌─────────────────┬──────────────────┐
@@ -2443,7 +2443,7 @@ rel.distinct().order("range")
             ),
         ],
     ),
-    'first_value': PythonRelAPIDetails(
+    "first_value": PythonRelAPIDetails(
         example='rel.first_value(column="value", window_spec="over (partition by description order by value)", projected_columns="description").distinct()',
         result="""
 ┌─────────────────┬───────────────────────────────────────────────────────────────────────┐
@@ -2474,7 +2474,7 @@ rel.distinct().order("range")
             ),
         ],
     ),
-    'fsum': PythonRelAPIDetails(
+    "fsum": PythonRelAPIDetails(
         example='rel.fsum(column="value", groups="description", projected_columns="description")',
         result="""
 ┌─────────────────┬───────────────┐
@@ -2511,7 +2511,7 @@ rel.distinct().order("range")
             ),
         ],
     ),
-    'geomean': PythonRelAPIDetails(
+    "geomean": PythonRelAPIDetails(
         example='rel.geomean(column="value", groups="description", projected_columns="description")',
         result="""
 ┌─────────────────┬───────────────────┐
@@ -2542,7 +2542,7 @@ rel.distinct().order("range")
             ),
         ],
     ),
-    'histogram': PythonRelAPIDetails(
+    "histogram": PythonRelAPIDetails(
         example='rel.histogram(column="value", groups="description", projected_columns="description")',
         result="""
 ┌─────────────────┬───────────────────────────┐
@@ -2573,7 +2573,7 @@ rel.distinct().order("range")
             ),
         ],
     ),
-    'lag': PythonRelAPIDetails(
+    "lag": PythonRelAPIDetails(
         example='rel.lag(column="description", window_spec="over (order by value)", projected_columns="description, value")',
         result="""
 ┌─────────────────┬───────┬───────────────────────────────────────────────────┐
@@ -2628,7 +2628,7 @@ rel.distinct().order("range")
             ),
         ],
     ),
-    'last': PythonRelAPIDetails(
+    "last": PythonRelAPIDetails(
         example='rel.last(column="value", groups="description", projected_columns="description")',
         result="""
 ┌─────────────────┬─────────────────┐
@@ -2659,7 +2659,7 @@ rel.distinct().order("range")
             ),
         ],
     ),
-    'last_value': PythonRelAPIDetails(
+    "last_value": PythonRelAPIDetails(
         example='rel.last_value(column="value", window_spec="over (order by description)", projected_columns="description").distinct()',
         result="""
 ┌─────────────────┬─────────────────────────────────────────────────┐
@@ -2690,7 +2690,7 @@ rel.distinct().order("range")
             ),
         ],
     ),
-    'lead': PythonRelAPIDetails(
+    "lead": PythonRelAPIDetails(
         example='rel.lead(column="description", window_spec="over (order by value)", projected_columns="description, value")',
         result="""
 ┌─────────────────┬───────┬────────────────────────────────────────────────────┐
@@ -2745,7 +2745,7 @@ rel.distinct().order("range")
             ),
         ],
     ),
-    'list': PythonRelAPIDetails(
+    "list": PythonRelAPIDetails(
         example='rel.list(column="value", groups="description", projected_columns="description")',
         result="""
 ┌─────────────────┬─────────────────┐
@@ -2782,7 +2782,7 @@ rel.distinct().order("range")
             ),
         ],
     ),
-    'max': PythonRelAPIDetails(
+    "max": PythonRelAPIDetails(
         example=' rel.max(column="value", groups="description", projected_columns="description")',
         result="""
 ┌─────────────────┬──────────────┐
@@ -2819,7 +2819,7 @@ rel.distinct().order("range")
             ),
         ],
     ),
-    'mean': PythonRelAPIDetails(
+    "mean": PythonRelAPIDetails(
         example='rel.mean(column="value", groups="description", projected_columns="description")',
         result="""
 ┌─────────────────┬──────────────┐
@@ -2856,7 +2856,7 @@ rel.distinct().order("range")
             ),
         ],
     ),
-    'median': PythonRelAPIDetails(
+    "median": PythonRelAPIDetails(
         example='rel.median(column="value", groups="description", projected_columns="description")',
         result="""
 ┌─────────────────┬─────────────────┐
@@ -2893,7 +2893,7 @@ rel.distinct().order("range")
             ),
         ],
     ),
-    'min': PythonRelAPIDetails(
+    "min": PythonRelAPIDetails(
         example='rel.min(column="value", groups="description", projected_columns="description")',
         result="""
 ┌─────────────────┬──────────────┐
@@ -2930,7 +2930,7 @@ rel.distinct().order("range")
             ),
         ],
     ),
-    'mode': PythonRelAPIDetails(
+    "mode": PythonRelAPIDetails(
         example='rel.mode(column="value", groups="description", projected_columns="description")',
         result="""
 ┌─────────────────┬─────────────────┐
@@ -2967,7 +2967,7 @@ rel.distinct().order("range")
             ),
         ],
     ),
-    'n_tile': PythonRelAPIDetails(
+    "n_tile": PythonRelAPIDetails(
         example='rel.n_tile(window_spec="over (partition by description)", num_buckets=2, projected_columns="description, value")',
         result="""
 ┌─────────────────┬───────┬──────────────────────────────────────────┐
@@ -3004,7 +3004,7 @@ rel.distinct().order("range")
             ),
         ],
     ),
-    'nth_value': PythonRelAPIDetails(
+    "nth_value": PythonRelAPIDetails(
         example='rel.nth_value(column="value", window_spec="over (partition by description)", projected_columns="description", offset=1)',
         result="""
 ┌─────────────────┬───────────────────────────────────────────────────────┐
@@ -3052,7 +3052,7 @@ rel.distinct().order("range")
             ),
         ],
     ),
-    'percent_rank': PythonRelAPIDetails(
+    "percent_rank": PythonRelAPIDetails(
         example='rel.percent_rank(window_spec="over (partition by description order by value)", projected_columns="description, value")',
         result="""
 ┌─────────────────┬───────┬─────────────────────────────────────────────────────────────────┐
@@ -3084,7 +3084,7 @@ rel.distinct().order("range")
             ),
         ],
     ),
-    'product': PythonRelAPIDetails(
+    "product": PythonRelAPIDetails(
         example='rel.product(column="value", groups="description", projected_columns="description")',
         result="""
 ┌─────────────────┬──────────────────┐
@@ -3121,7 +3121,7 @@ rel.distinct().order("range")
             ),
         ],
     ),
-    'quantile': PythonRelAPIDetails(
+    "quantile": PythonRelAPIDetails(
         example='rel.quantile(column="value", groups="description", projected_columns="description")',
         result="""
 ┌─────────────────┬──────────────────────────────────┐
@@ -3164,7 +3164,7 @@ rel.distinct().order("range")
             ),
         ],
     ),
-    'quantile_cont': PythonRelAPIDetails(
+    "quantile_cont": PythonRelAPIDetails(
         example='rel.quantile_cont(column="value", groups="description", projected_columns="description")',
         result="""
 ┌─────────────────┬──────────────────────────────────┐
@@ -3207,7 +3207,7 @@ rel.distinct().order("range")
             ),
         ],
     ),
-    'quantile_disc': PythonRelAPIDetails(
+    "quantile_disc": PythonRelAPIDetails(
         example='rel.quantile_disc(column="value", groups="description", projected_columns="description")',
         result="""
 ┌─────────────────┬──────────────────────────────────┐
@@ -3250,7 +3250,7 @@ rel.distinct().order("range")
             ),
         ],
     ),
-    'rank': PythonRelAPIDetails(
+    "rank": PythonRelAPIDetails(
         example='rel.rank(window_spec="over (partition by description order by value)", projected_columns="description, value")',
         result="""
 ┌─────────────────┬───────┬─────────────────────────────────────────────────────────┐
@@ -3282,7 +3282,7 @@ rel.distinct().order("range")
             ),
         ],
     ),
-    'rank_dense': PythonRelAPIDetails(
+    "rank_dense": PythonRelAPIDetails(
         example=' rel.rank_dense(window_spec="over (partition by description order by value)", projected_columns="description, value")',
         result="""
 ┌─────────────────┬───────┬───────────────────────────────────────────────────────────────┐
@@ -3300,7 +3300,7 @@ rel.distinct().order("range")
 │ value is even   │     8 │                                                             4 │
 └─────────────────┴───────┴───────────────────────────────────────────────────────────────┘
 """,
-        aliases=['dense_rank'],
+        aliases=["dense_rank"],
         parameters=[
             PythonRelAPIParamDetails(
                 parameter_name="window_spec",
@@ -3315,7 +3315,7 @@ rel.distinct().order("range")
             ),
         ],
     ),
-    'row_number': PythonRelAPIDetails(
+    "row_number": PythonRelAPIDetails(
         example='rel.row_number(window_spec="over (partition by description order by value)", projected_columns="description, value")',
         result="""
 ┌─────────────────┬───────┬───────────────────────────────────────────────────────────────┐
@@ -3347,8 +3347,8 @@ rel.distinct().order("range")
             ),
         ],
     ),
-    'select_dtypes': PythonRelAPIDetails(
-        example='rel.select_dtypes(types=[duckdb.typing.VARCHAR]).distinct()',
+    "select_dtypes": PythonRelAPIDetails(
+        example="rel.select_dtypes(types=[duckdb.sqltypes.VARCHAR]).distinct()",
         result="""
 ┌─────────────────┐
 │   description   │
@@ -3358,7 +3358,7 @@ rel.distinct().order("range")
 │ value is uneven │
 └─────────────────┘
 """,
-        aliases=['select_types'],
+        aliases=["select_types"],
         parameters=[
             PythonRelAPIParamDetails(
                 parameter_name="types",
@@ -3367,8 +3367,8 @@ rel.distinct().order("range")
             )
         ],
     ),
-    'select_types': PythonRelAPIDetails(
-        example='rel.select_types(types=[duckdb.typing.VARCHAR]).distinct()',
+    "select_types": PythonRelAPIDetails(
+        example="rel.select_types(types=[duckdb.sqltypes.VARCHAR]).distinct()",
         result="""
 ┌─────────────────┐
 │   description   │
@@ -3378,7 +3378,7 @@ rel.distinct().order("range")
 │ value is uneven │
 └─────────────────┘
 """,
-        aliases=['select_dtypes'],
+        aliases=["select_dtypes"],
         parameters=[
             PythonRelAPIParamDetails(
                 parameter_name="types",
@@ -3387,7 +3387,7 @@ rel.distinct().order("range")
             )
         ],
     ),
-    'std': PythonRelAPIDetails(
+    "std": PythonRelAPIDetails(
         example='rel.std(column="value", groups="description", projected_columns="description")',
         result="""
 ┌─────────────────┬──────────────────────┐
@@ -3398,7 +3398,7 @@ rel.distinct().order("range")
 │ value is even   │    2.581988897471611 │
 └─────────────────┴──────────────────────┘
 """,
-        aliases=['stddev', 'stddev_samp'],
+        aliases=["stddev", "stddev_samp"],
         parameters=[
             PythonRelAPIParamDetails(
                 parameter_name="column",
@@ -3425,7 +3425,7 @@ rel.distinct().order("range")
             ),
         ],
     ),
-    'stddev': PythonRelAPIDetails(
+    "stddev": PythonRelAPIDetails(
         example='rel.stddev(column="value", groups="description", projected_columns="description")',
         result="""
 ┌─────────────────┬──────────────────────┐
@@ -3436,7 +3436,7 @@ rel.distinct().order("range")
 │ value is uneven │   3.1622776601683795 │
 └─────────────────┴──────────────────────┘
 """,
-        aliases=['std', 'stddev_samp'],
+        aliases=["std", "stddev_samp"],
         parameters=[
             PythonRelAPIParamDetails(
                 parameter_name="column",
@@ -3463,7 +3463,7 @@ rel.distinct().order("range")
             ),
         ],
     ),
-    'stddev_pop': PythonRelAPIDetails(
+    "stddev_pop": PythonRelAPIDetails(
         example='rel.stddev_pop(column="value", groups="description", projected_columns="description")',
         result="""
 ┌─────────────────┬─────────────────────┐
@@ -3500,7 +3500,7 @@ rel.distinct().order("range")
             ),
         ],
     ),
-    'stddev_samp': PythonRelAPIDetails(
+    "stddev_samp": PythonRelAPIDetails(
         example='rel.stddev_samp(column="value", groups="description", projected_columns="description")',
         result="""
 ┌─────────────────┬──────────────────────┐
@@ -3511,7 +3511,7 @@ rel.distinct().order("range")
 │ value is uneven │   3.1622776601683795 │
 └─────────────────┴──────────────────────┘
 """,
-        aliases=['stddev', 'std'],
+        aliases=["stddev", "std"],
         parameters=[
             PythonRelAPIParamDetails(
                 parameter_name="column",
@@ -3538,7 +3538,7 @@ rel.distinct().order("range")
             ),
         ],
     ),
-    'string_agg': PythonRelAPIDetails(
+    "string_agg": PythonRelAPIDetails(
         example='rel.string_agg(column="value", sep=",", groups="description", projected_columns="description")',
         result="""
 ┌─────────────────┬──────────────────────────┐
@@ -3581,7 +3581,7 @@ rel.distinct().order("range")
             ),
         ],
     ),
-    'sum': PythonRelAPIDetails(
+    "sum": PythonRelAPIDetails(
         example='rel.sum(column="value", groups="description", projected_columns="description")',
         result="""
 ┌─────────────────┬──────────────┐
@@ -3618,7 +3618,7 @@ rel.distinct().order("range")
             ),
         ],
     ),
-    'unique': PythonRelAPIDetails(
+    "unique": PythonRelAPIDetails(
         example='rel.unique(unique_aggr="description")',
         result="""
 ┌─────────────────┐
@@ -3637,7 +3637,7 @@ rel.distinct().order("range")
             )
         ],
     ),
-    'value_counts': PythonRelAPIDetails(
+    "value_counts": PythonRelAPIDetails(
         example='rel.value_counts(column="description", groups="description")',
         result="""
 ┌─────────────────┬────────────────────┐
@@ -3662,7 +3662,7 @@ rel.distinct().order("range")
             ),
         ],
     ),
-    'var': PythonRelAPIDetails(
+    "var": PythonRelAPIDetails(
         example='rel.var(column="value", groups="description", projected_columns="description")',
         result="""
 ┌─────────────────┬───────────────────┐
@@ -3673,7 +3673,7 @@ rel.distinct().order("range")
 │ value is uneven │              10.0 │
 └─────────────────┴───────────────────┘
 """,
-        aliases=['variance', 'var_samp'],
+        aliases=["variance", "var_samp"],
         parameters=[
             PythonRelAPIParamDetails(
                 parameter_name="column",
@@ -3700,7 +3700,7 @@ rel.distinct().order("range")
             ),
         ],
     ),
-    'var_pop': PythonRelAPIDetails(
+    "var_pop": PythonRelAPIDetails(
         example='rel.var_pop(column="value", groups="description", projected_columns="description")',
         result="""
 ┌─────────────────┬──────────────────┐
@@ -3737,7 +3737,7 @@ rel.distinct().order("range")
             ),
         ],
     ),
-    'var_samp': PythonRelAPIDetails(
+    "var_samp": PythonRelAPIDetails(
         example='rel.var_samp(column="value", groups="description", projected_columns="description")',
         result="""
 ┌─────────────────┬───────────────────┐
@@ -3748,7 +3748,7 @@ rel.distinct().order("range")
 │ value is uneven │              10.0 │
 └─────────────────┴───────────────────┘
 """,
-        aliases=['variance', 'var'],
+        aliases=["variance", "var"],
         parameters=[
             PythonRelAPIParamDetails(
                 parameter_name="column",
@@ -3775,7 +3775,7 @@ rel.distinct().order("range")
             ),
         ],
     ),
-    'variance': PythonRelAPIDetails(
+    "variance": PythonRelAPIDetails(
         example='rel.variance(column="value", groups="description", projected_columns="description")',
         result="""
 ┌─────────────────┬───────────────────┐
@@ -3786,7 +3786,7 @@ rel.distinct().order("range")
 │ value is uneven │              10.0 │
 └─────────────────┴───────────────────┘
 """,
-        aliases=['var', 'var_samp'],
+        aliases=["var", "var_samp"],
         parameters=[
             PythonRelAPIParamDetails(
                 parameter_name="column",
@@ -3816,8 +3816,8 @@ rel.distinct().order("range")
 }
 
 OUTPUT_METHODS_MAP = {
-    'arrow': PythonRelAPIDetails(
-        example='pa_table = rel.arrow()\n\npa_table',
+    "arrow": PythonRelAPIDetails(
+        example="pa_table = rel.arrow()\n\npa_table",
         result="""
 pyarrow.Table
 id: string
@@ -3831,7 +3831,7 @@ value: [[1,2,3,4,5,6,7,8,9]]
 created_timestamp: [[2025-04-10 09:07:12.614000Z,2025-04-10 09:08:12.614000Z,2025-04-10 09:09:12.614000Z,2025-04-10 09:10:12.614000Z,2025-04-10 09:11:12.614000Z,2025-04-10 09:12:12.614000Z,2025-04-10 09:13:12.614000Z,2025-04-10 09:14:12.614000Z,2025-04-10 09:15:12.614000Z]]
 """,
         use_default_example=True,
-        aliases=['fetch_arrow_table', 'to_arrow_table'],
+        aliases=["fetch_arrow_table", "to_arrow_table"],
         parameters=[
             PythonRelAPIParamDetails(
                 parameter_name="batch_size",
@@ -3842,7 +3842,7 @@ created_timestamp: [[2025-04-10 09:07:12.614000Z,2025-04-10 09:08:12.614000Z,202
         ],
     ),
     # 'close': PythonRelAPIDetails(example=  '', result=  '', use_default_example=False)
-    'create': PythonRelAPIDetails(
+    "create": PythonRelAPIDetails(
         example='rel.create("table_code_example")\n\nduckdb_conn.table("table_code_example").limit(1)',
         result="""
 ┌──────────────────────────────────────┬─────────────────┬───────┬────────────────────────────┐
@@ -3863,7 +3863,7 @@ created_timestamp: [[2025-04-10 09:07:12.614000Z,2025-04-10 09:08:12.614000Z,202
             )
         ],
     ),
-    'create_view': PythonRelAPIDetails(
+    "create_view": PythonRelAPIDetails(
         example='rel.create_view("view_code_example", replace=True)\n\nduckdb_conn.table("view_code_example").limit(1)',
         result="""
 ┌──────────────────────────────────────┬─────────────────┬───────┬────────────────────────────┐
@@ -3890,8 +3890,8 @@ created_timestamp: [[2025-04-10 09:07:12.614000Z,2025-04-10 09:08:12.614000Z,202
             ),
         ],
     ),
-    'df': PythonRelAPIDetails(
-        example='rel.df()',
+    "df": PythonRelAPIDetails(
+        example="rel.df()",
         result="""
                                      id      description  value                created_timestamp
 0  3ac9e0ba-8390-4a02-ad72-33b1caea6354  value is uneven      1 2025-04-10 11:07:12.614000+02:00
@@ -3900,7 +3900,7 @@ created_timestamp: [[2025-04-10 09:07:12.614000Z,2025-04-10 09:08:12.614000Z,202
 ...
 """,
         use_default_example=True,
-        aliases=['fetchdf', 'to_df'],
+        aliases=["fetchdf", "to_df"],
         parameters=[
             PythonRelAPIParamDetails(
                 parameter_name="date_as_object",
@@ -3910,8 +3910,8 @@ created_timestamp: [[2025-04-10 09:07:12.614000Z,2025-04-10 09:08:12.614000Z,202
             )
         ],
     ),
-    'execute': PythonRelAPIDetails(
-        example='rel.execute()',
+    "execute": PythonRelAPIDetails(
+        example="rel.execute()",
         result="""
 ┌──────────────────────────────────────┬─────────────────┬───────┬────────────────────────────┐
 │                  id                  │   description   │ value │     created_timestamp      │
@@ -3923,8 +3923,8 @@ created_timestamp: [[2025-04-10 09:07:12.614000Z,2025-04-10 09:08:12.614000Z,202
 """,
         use_default_example=True,
     ),
-    'fetch_arrow_reader': PythonRelAPIDetails(
-        example='pa_reader = rel.fetch_arrow_reader(batch_size=1)\n\npa_reader.read_next_batch()',
+    "fetch_arrow_reader": PythonRelAPIDetails(
+        example="pa_reader = rel.fetch_arrow_reader(batch_size=1)\n\npa_reader.read_next_batch()",
         result="""
 pyarrow.RecordBatch
 id: string
@@ -3947,8 +3947,8 @@ created_timestamp: [2025-04-10 09:25:51.259000Z]
             )
         ],
     ),
-    'fetch_arrow_table': PythonRelAPIDetails(
-        example='rel.fetch_arrow_table()',
+    "fetch_arrow_table": PythonRelAPIDetails(
+        example="rel.fetch_arrow_table()",
         result="""
 pyarrow.Table
 id: string
@@ -3962,7 +3962,7 @@ value: [[1,2,3,4,5,6,7,8,9]]
 created_timestamp: [[2025-04-10 09:24:51.259000Z,2025-04-10 09:25:51.259000Z,2025-04-10 09:26:51.259000Z,2025-04-10 09:27:51.259000Z,2025-04-10 09:28:51.259000Z,2025-04-10 09:29:51.259000Z,2025-04-10 09:30:51.259000Z,2025-04-10 09:31:51.259000Z,2025-04-10 09:32:51.259000Z]]
 """,
         use_default_example=True,
-        aliases=['arrow', 'to_arrow_table'],
+        aliases=["arrow", "to_arrow_table"],
         parameters=[
             PythonRelAPIParamDetails(
                 parameter_name="batch_size",
@@ -3972,8 +3972,8 @@ created_timestamp: [[2025-04-10 09:24:51.259000Z,2025-04-10 09:25:51.259000Z,202
             )
         ],
     ),
-    'fetch_df_chunk': PythonRelAPIDetails(
-        example='rel.fetch_df_chunk()',
+    "fetch_df_chunk": PythonRelAPIDetails(
+        example="rel.fetch_df_chunk()",
         result="""
                                      id      description  value                created_timestamp
 0  1587b4b0-3023-49fe-82cf-06303ca136ac  value is uneven      1 2025-04-10 11:24:51.259000+02:00
@@ -3997,8 +3997,8 @@ created_timestamp: [[2025-04-10 09:24:51.259000Z,2025-04-10 09:25:51.259000Z,202
             ),
         ],
     ),
-    'fetchall': PythonRelAPIDetails(
-        example='rel.limit(1).fetchall()',
+    "fetchall": PythonRelAPIDetails(
+        example="rel.limit(1).fetchall()",
         result="""
 [(UUID('1587b4b0-3023-49fe-82cf-06303ca136ac'),
   'value is uneven',
@@ -4007,8 +4007,8 @@ created_timestamp: [[2025-04-10 09:24:51.259000Z,2025-04-10 09:25:51.259000Z,202
 """,
         use_default_example=True,
     ),
-    'fetchdf': PythonRelAPIDetails(
-        example='rel.fetchdf()',
+    "fetchdf": PythonRelAPIDetails(
+        example="rel.fetchdf()",
         result="""
                                      id      description  value                created_timestamp
 0  1587b4b0-3023-49fe-82cf-06303ca136ac  value is uneven      1 2025-04-10 11:24:51.259000+02:00
@@ -4017,7 +4017,7 @@ created_timestamp: [[2025-04-10 09:24:51.259000Z,2025-04-10 09:25:51.259000Z,202
 ...
 """,
         use_default_example=True,
-        aliases=['df', 'to_df'],
+        aliases=["df", "to_df"],
         parameters=[
             PythonRelAPIParamDetails(
                 parameter_name="date_as_object",
@@ -4027,7 +4027,7 @@ created_timestamp: [[2025-04-10 09:24:51.259000Z,2025-04-10 09:25:51.259000Z,202
             )
         ],
     ),
-    'fetchmany': PythonRelAPIDetails(
+    "fetchmany": PythonRelAPIDetails(
         example="""
 while res := rel.fetchmany(size=1):
     print(res)
@@ -4079,8 +4079,8 @@ while res := rel.fetchmany(size=1):
             )
         ],
     ),
-    'fetchnumpy': PythonRelAPIDetails(
-        example='rel.fetchnumpy()',
+    "fetchnumpy": PythonRelAPIDetails(
+        example="rel.fetchnumpy()",
         result="""
 {'id': array([UUID('1587b4b0-3023-49fe-82cf-06303ca136ac'),
         UUID('e4ab8cb4-4609-40cb-ad7e-4304ed5ed4bd'),
@@ -4104,7 +4104,7 @@ while res := rel.fetchmany(size=1):
 """,
         use_default_example=True,
     ),
-    'fetchone': PythonRelAPIDetails(
+    "fetchone": PythonRelAPIDetails(
         example="""
 while res := rel.fetchone():
     print(res)
@@ -4148,8 +4148,8 @@ while res := rel.fetchone():
 >```
 ''',
     ),
-    'pl': PythonRelAPIDetails(
-        example='rel.pl(batch_size=1)',
+    "pl": PythonRelAPIDetails(
+        example="rel.pl(batch_size=1)",
         result="""
 shape: (9, 4)
 ┌─────────────────────────────────┬─────────────────┬───────┬────────────────────────────────┐
@@ -4169,8 +4169,8 @@ shape: (9, 4)
             )
         ],
     ),
-    'record_batch': PythonRelAPIDetails(
-        example='pa_batch = rel.record_batch(batch_size=1)\n\npa_batch.read_next_batch()',
+    "record_batch": PythonRelAPIDetails(
+        example="pa_batch = rel.record_batch(batch_size=1)\n\npa_batch.read_next_batch()",
         result="""
 pyarrow.RecordBatch
 id: string
@@ -4193,7 +4193,7 @@ created_timestamp: [2025-04-10 09:52:55.249000Z]
             )
         ],
     ),
-    'tf': PythonRelAPIDetails(
+    "tf": PythonRelAPIDetails(
         example='rel.select("description, value").tf()',
         result="""
 {'description': <tf.Tensor: shape=(9,), dtype=string, numpy=
@@ -4205,8 +4205,8 @@ created_timestamp: [2025-04-10 09:52:55.249000Z]
 """,
         use_default_example=True,
     ),
-    'to_arrow_table': PythonRelAPIDetails(
-        example='rel.to_arrow_table()',
+    "to_arrow_table": PythonRelAPIDetails(
+        example="rel.to_arrow_table()",
         result="""
 pyarrow.Table
 id: string
@@ -4220,7 +4220,7 @@ value: [[1,2,3,4,5,6,7,8,9]]
 created_timestamp: [[2025-04-10 09:54:24.015000Z,2025-04-10 09:55:24.015000Z,2025-04-10 09:56:24.015000Z,2025-04-10 09:57:24.015000Z,2025-04-10 09:58:24.015000Z,2025-04-10 09:59:24.015000Z,2025-04-10 10:00:24.015000Z,2025-04-10 10:01:24.015000Z,2025-04-10 10:02:24.015000Z]]
 """,
         use_default_example=True,
-        aliases=['fetch_arrow_table', 'arrow'],
+        aliases=["fetch_arrow_table", "arrow"],
         parameters=[
             PythonRelAPIParamDetails(
                 parameter_name="batch_size",
@@ -4230,11 +4230,11 @@ created_timestamp: [[2025-04-10 09:54:24.015000Z,2025-04-10 09:55:24.015000Z,202
             )
         ],
     ),
-    'to_csv': PythonRelAPIDetails(
+    "to_csv": PythonRelAPIDetails(
         example='rel.to_csv("code_example.csv")',
-        result='The data is exported to a CSV file, named code_example.csv',
+        result="The data is exported to a CSV file, named code_example.csv",
         use_default_example=True,
-        aliases=['write_csv'],
+        aliases=["write_csv"],
         parameters=[
             PythonRelAPIParamDetails(
                 parameter_name="file_name",
@@ -4334,8 +4334,8 @@ created_timestamp: [[2025-04-10 09:54:24.015000Z,2025-04-10 09:55:24.015000Z,202
             ),
         ],
     ),
-    'to_df': PythonRelAPIDetails(
-        example='rel.to_df()',
+    "to_df": PythonRelAPIDetails(
+        example="rel.to_df()",
         result="""
                                      id      description  value                created_timestamp
 0  e1f79925-60fd-4ee2-ae67-5eff6b0543d1  value is uneven      1 2025-04-10 11:56:04.452000+02:00
@@ -4344,7 +4344,7 @@ created_timestamp: [[2025-04-10 09:54:24.015000Z,2025-04-10 09:55:24.015000Z,202
 ...
 """,
         use_default_example=True,
-        aliases=['fetchdf', 'df'],
+        aliases=["fetchdf", "df"],
         parameters=[
             PythonRelAPIParamDetails(
                 parameter_name="date_as_object",
@@ -4354,11 +4354,11 @@ created_timestamp: [[2025-04-10 09:54:24.015000Z,2025-04-10 09:55:24.015000Z,202
             )
         ],
     ),
-    'to_parquet': PythonRelAPIDetails(
+    "to_parquet": PythonRelAPIDetails(
         example='rel.to_parquet("code_example.parquet")',
-        result='The data is exported to a Parquet file, named code_example.parquet',
+        result="The data is exported to a Parquet file, named code_example.parquet",
         use_default_example=True,
-        aliases=['write_parquet'],
+        aliases=["write_parquet"],
         parameters=[
             PythonRelAPIParamDetails(
                 parameter_name="file_name",
@@ -4428,9 +4428,9 @@ created_timestamp: [[2025-04-10 09:54:24.015000Z,2025-04-10 09:55:24.015000Z,202
             ),
         ],
     ),
-    'to_table': PythonRelAPIDetails(
+    "to_table": PythonRelAPIDetails(
         example='rel.to_table("table_code_example")',
-        result='A table, named table_code_example, is created with the data of the relation',
+        result="A table, named table_code_example, is created with the data of the relation",
         use_default_example=True,
         aliases=["create"],
         parameters=[
@@ -4442,9 +4442,9 @@ created_timestamp: [[2025-04-10 09:54:24.015000Z,2025-04-10 09:55:24.015000Z,202
             )
         ],
     ),
-    'to_view': PythonRelAPIDetails(
+    "to_view": PythonRelAPIDetails(
         example='rel.to_view("view_code_example", replace=True)',
-        result='A view, named view_code_example, is created with the query definition of the relation',
+        result="A view, named view_code_example, is created with the query definition of the relation",
         use_default_example=True,
         aliases=["create_view"],
         parameters=[
@@ -4462,16 +4462,16 @@ created_timestamp: [[2025-04-10 09:54:24.015000Z,2025-04-10 09:55:24.015000Z,202
             ),
         ],
     ),
-    'torch': PythonRelAPIDetails(
+    "torch": PythonRelAPIDetails(
         example='rel.select("value").torch()',
         result="{'value': tensor([1, 2, 3, 4, 5, 6, 7, 8, 9])}",
         use_default_example=True,
     ),
-    'write_csv': PythonRelAPIDetails(
+    "write_csv": PythonRelAPIDetails(
         example='rel.write_csv("code_example.csv")',
-        result='The data is exported to a CSV file, named code_example.csv',
+        result="The data is exported to a CSV file, named code_example.csv",
         use_default_example=True,
-        aliases=['to_csv'],
+        aliases=["to_csv"],
         parameters=[
             PythonRelAPIParamDetails(
                 parameter_name="file_name",
@@ -4571,11 +4571,11 @@ created_timestamp: [[2025-04-10 09:54:24.015000Z,2025-04-10 09:55:24.015000Z,202
             ),
         ],
     ),
-    'write_parquet': PythonRelAPIDetails(
+    "write_parquet": PythonRelAPIDetails(
         example='rel.write_parquet("code_example.parquet")',
-        result='The data is exported to a Parquet file, named code_example.parquet',
+        result="The data is exported to a Parquet file, named code_example.parquet",
         use_default_example=True,
-        aliases=['to_parquet'],
+        aliases=["to_parquet"],
         parameters=[
             PythonRelAPIParamDetails(
                 parameter_name="file_name",


### PR DESCRIPTION
The move from duckdb.typing to duckdb.sqltypes is a change I made in the python package a while ago due to shadowing issues.

Ref: https://github.com/duckdb/duckdb-python/issues/160