### PR TITLE
Add missing comma in `sagemaker` docs

### DIFF
--- a/docs/preview/core_extensions/iceberg/amazon_sagemaker_lakehouse.md
+++ b/docs/preview/core_extensions/iceberg/amazon_sagemaker_lakehouse.md
@@ -41,7 +41,7 @@ Then, connect to the catalog:
 ```sql
 ATTACH '⟨account_id⟩' AS glue_catalog (
     TYPE iceberg,
-    ENDPOINT 'glue.⟨REGION⟩.amazonaws.com/iceberg'
+    ENDPOINT 'glue.⟨REGION⟩.amazonaws.com/iceberg',
     AUTHORIZATION_TYPE 'sigv4'
 );
 ```

--- a/docs/stable/core_extensions/iceberg/amazon_sagemaker_lakehouse.md
+++ b/docs/stable/core_extensions/iceberg/amazon_sagemaker_lakehouse.md
@@ -44,7 +44,7 @@ Then, connect to the catalog:
 ```sql
 ATTACH '⟨account_id⟩' AS glue_catalog (
     TYPE iceberg,
-    ENDPOINT 'glue.⟨REGION⟩.amazonaws.com/iceberg'
+    ENDPOINT 'glue.⟨REGION⟩.amazonaws.com/iceberg',
     AUTHORIZATION_TYPE 'sigv4'
 );
 ```


### PR DESCRIPTION
Nothing huge, just a missing `,` 

I looked at the scripts for generating docs but I don't believe these pages are generated 