### PR TITLE
Add Tip To Contributing.md

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -188,11 +188,12 @@ bundle install
 Dynamic page regeneration might not apply to includes, railroad diagrams, or other content.
 To force regeneration of a page or include so that it is rendered in your localhost browser, perform the following steps: 
 
-1. Stop the terminal session where you ran the Jekyll build command i.e. `scripts/serve-latest.sh`
-2. Run `git add myfile.md` for your particular page
-3. Run `git clean` to trigger a full Jekyll rebuild
-4. Run the `scripts/serve-latest.sh` from your terminal again
-5. Navigate to the page and refresh your browser, any changes will now be visible from your local branch
+1. Stop the terminal session where you ran the Jekyll build command, i.e., `scripts/serve-latest.sh`.
+1. Run `git add myfile.md` for your particular page.
+1. Stop Jekyll and run `rm -rf _site` to  cleanup the previously generated file.
+1. If the site is still not regenerating, run `git clean` to cleanup the repository but be careful not to loose any unstaged/uncommitted changes.
+1. Run the `scripts/serve-latest.sh` from your terminal again.
+1. If the page your editing is open in your browser, it should refresh automatically. If this doesn't happen, refresh manually. The changes from your local branch should be visible now.
 
 ### Bundle update fails
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,13 +165,7 @@ Many of the documentation's pages are auto-generated. Before editing, please che
 
 > [!TIP]
 > Dynamic page regeneration might not apply to includes, railroad diagrams, or other content.
-> To force regeneration of a page or include so that it is rendered in your localhost browser, perform the following steps: 
-> 1. Stop the terminal session where you ran the Jekyll build command, i.e., `scripts/serve-latest.sh`.
-> 1. Run `git add myfile.md` for your particular page.
-> 1. Stop Jekyll and run `rm -rf _site` to  cleanup the previously generated file.
-> 1. If the site is still not regenerating, run `git clean` to cleanup the repository but be careful not to loose any unstaged/uncommitted changes.
-> 1. Run the `scripts/serve-latest.sh` from your terminal again.
-> 1. If the page your editing is open in your browser, it should refresh automatically. If this doesn't happen, refresh manually. The changes from your local branch should be visible now.
+> To force regeneration of a page or include so that it is rendered in your localhost browser, perform the steps described in the `BUILDING.md` guide's “Jekyll Content Not Rendering Properly” section.
 
 ### Generated SQL Function Lists
 


### PR DESCRIPTION
- Adding a tip based on correspondence from https://github.com/duckdb/duckdb-web/pull/6074#issuecomment-3471516953 to the `CONTRIBUTING.md` file.
- Also adding the same content to `BUILDING.md` for extra visiblity.
- Not sure if its possible to use an include for this content since these pages are not actual docs pages and closer to a `README.md` file. But that would be an improvement if possible.
