### PR TITLE
Update iceberg extension dependency information

### DIFF
--- a/docs/stable/lakehouse_formats.md
+++ b/docs/stable/lakehouse_formats.md
@@ -34,7 +34,7 @@ DuckDB supports Iceberg, Delta and DuckLake as first-class citizens. The followi
 
 `*` Through the `uc_catalog` extension
 
-DuckDB aims to build native extensions with minimal dependencies. The `iceberg` extension for example, has dependencies on third-party Iceberg libraries, which means all data and metadata operations are implemented natively in the DuckDB extension. For the `delta` extension, we use the [`delta-kernel-rs` project](https://github.com/delta-io/delta-kernel-rs), which is meant to be a lightweight platform for engines to build delta integrations that are as close to native as possible.
+DuckDB aims to build native extensions with minimal dependencies. The `iceberg` extension for example, has no dependencies on third-party Iceberg libraries, which means all data and metadata operations are implemented natively in the DuckDB extension. For the `delta` extension, we use the [`delta-kernel-rs` project](https://github.com/delta-io/delta-kernel-rs), which is meant to be a lightweight platform for engines to build delta integrations that are as close to native as possible.
 
 > **Why do native implementations matter?** Native implementations allow DuckDB to do more performance optimizations such as complex filter pushdowns (with file-level and row-group level pruning) and improve memory management.
 


### PR DESCRIPTION
small typo, iceberg has no dependencies on third party libraries