### PR TITLE
Update BUILDING.md

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -191,7 +191,7 @@ To force regeneration of a page or include so that it is rendered in your localh
 1. Stop the terminal session where you ran the Jekyll build command, i.e., `scripts/serve-latest.sh`.
 1. Run `git add myfile.md` for your particular page.
 1. Stop Jekyll and run `rm -rf _site` to  cleanup the previously generated file.
-1. If the site is still not regenerating, run `git clean` to cleanup the repository but be careful not to loose any unstaged/uncommitted changes.
+1. If the site is still not regenerating, run `git clean -f` to cleanup the repository but be careful not to loose any unstaged/uncommitted changes.
 1. Run the `scripts/serve-latest.sh` from your terminal again.
 1. If the page your editing is open in your browser, it should refresh automatically. If this doesn't happen, refresh manually. The changes from your local branch should be visible now.
 


### PR DESCRIPTION
Adding `-f` to git clean command, today when I attempted to use the command `git clean` I got the following error, the solution was to use  `git clean -f`: 

```bash
$ git clean
fatal: clean.requireForce defaults to true and neither -i, -n, nor -f given; refusing to clean
(base)
Ian@DESKTOP-6L1B155 MINGW64 /c/repos/duckdb-web (blog-post-merge-statement)
$ git clean -f
```