### PR TITLE
visualizer: Copy button visualizer & Attach to be folded down

### DIFF
--- a/_sass/components/_copy_button.scss
+++ b/_sass/components/_copy_button.scss
@@ -2,6 +2,11 @@
 @use '../abstracts/variables' as *;
 @use '../abstracts/mixins' as *;
 
+.wasm .highlight button.copy{
+	top: 16px;
+	right: 16px;
+}
+
 pre.highlight > button,
 .highlight button.copy{
 	position: absolute;

--- a/visualizer/index.html
+++ b/visualizer/index.html
@@ -12,6 +12,7 @@ It's showcases how duckdb-wasm can efficiently query on the fly remote resources
 -->
 
 <script src="{{ '/js/regular-table.js' | relative_url }}" defer></script>
+<script src="/js/copy_button.js" defer></script>
 
 <div class="content-container">
 <div class="wrap pagetitle pagetitle--small mb-5" style="margin-bottom:0px !important">
@@ -86,8 +87,9 @@ It's showcases how duckdb-wasm can efficiently query on the fly remote resources
       </div>
 
   </div>
-<pre><code id="last_query" class="language-sql"></code></pre>
-<p id="last_query_status">1/4: HTML loaded</p>
+<div class="language-sql highlighter-rouge"><div class="highlight"><pre class="highlight" style="position:relative;min-height:62px;"><code id="last_query">
+</code></pre></div></div>
+<p id="last_query_status">1/5: HTML loaded</p>
 </div>
 
 <div class="datasettable">


### PR DESCRIPTION
@Franz-Kafka: in particular on the copy button, I hacked so that it's aligned to the drop-down icons, but I suppose it's a more general problem that those are at offset 16px and the copy button at 7px?

Attach folded down less sure, but I think the extra space is nice