### PR TITLE
Update installation commands for iceberg extension

### DIFF
--- a/docs/stable/core_extensions/iceberg/overview.md
+++ b/docs/stable/core_extensions/iceberg/overview.md
@@ -20,8 +20,8 @@ The `iceberg` extension is installed and loaded automatically on first use.
 If you would like to install and load it manually, run:
 
 ```sql
-INSTALL json;
-LOAD json;
+INSTALL iceberg;
+LOAD iceberg;
 ```
 
 ## Updating the Extension


### PR DESCRIPTION
It incorrectly listed the json extension instead of the iceberg extension.