### PR TITLE
Doc: advise building extensions with BUILD_EXTENSIONS

### DIFF
--- a/docs/stable/dev/building/building_extensions.md
+++ b/docs/stable/dev/building/building_extensions.md
@@ -9,16 +9,16 @@ title: Building Extensions
 
 ## Building Extensions
 
-To build using extension flags, set the `CORE_EXTENSIONS` flag to the list of extensions that you want to be build. For example:
+To build using extension flags, set the `BUILD_EXTENSIONS` flag to the list of extensions that you want to be build. For example:
 
 ```bash
-CORE_EXTENSIONS='autocomplete;httpfs;icu;json;tpch' GEN=ninja make
+BUILD_EXTENSIONS='autocomplete;httpfs;icu;json;tpch' GEN=ninja make
 ```
 
 This option also accepts out-of-tree extensions such as [`delta`]({% link docs/stable/core_extensions/delta.md %}):
 
 ```bash
-CORE_EXTENSIONS='autocomplete;httpfs;icu;json;tpch;delta' GEN=ninja make
+BUILD_EXTENSIONS='autocomplete;httpfs;icu;json;tpch;delta' GEN=ninja make
 ```
 
 In most cases, extension will be directly linked in the resulting DuckDB executable.


### PR DESCRIPTION
Building with `CORE_EXTENSIONS` triggers a warning about its deprecation: https://github.com/duckdb/duckdb/blob/bc8ddb5833e163d605ce5a3eb10796b64e346cb9/extension/extension_build_tools.cmake#L515.

This MR updates the doc to match the Makefile recommandation of `BUILD_EXTENSIONS`.