### PR TITLE
Update aggregates.md

### DIFF
--- a/docs/stable/sql/functions/aggregates.md
+++ b/docs/stable/sql/functions/aggregates.md
@@ -329,7 +329,7 @@ The table below shows the available general aggregate functions.
 <div class="nostroke_table"></div>
 
 | **Description** | Returns a `MAP` of key-value pairs representing the requested elements and their counts. A catch-all element specific to the data-type is automatically added to count other elements when they appear, see [`is_histogram_other_bin`]({% link docs/stable/sql/functions/utility.md %}#is_histogram_other_binarg). |
-| **Example** | `histogram_exact(A, [0, 1, 10])` |
+| **Example** | `histogram_exact(A, ['a', 'b', 'c'])` |
 
 #### `histogram_values(source, col_name, technique, bin_count)`
 


### PR DESCRIPTION
I find discrete elements (like strings) less confusing than using the same `[0, 1, 10]` that's used for the example of the regular `histogram(...)` function, to emphasize the distinction between the `histogram(..., upper_boundaries_of_interval)` and `histogram_exact(..., finitely_many_elements_i_care_for)`.