### PR TITLE
Adding Single Line Install Command MacOS

### DIFF
--- a/_includes/installation.html
+++ b/_includes/installation.html
@@ -104,9 +104,9 @@ docker run --rm -it -v "$(pwd):/workspace" -w /workspace duckdb/duckdb
 <a href="https://install.duckdb.org/v{{ site.current_duckdb_version }}/{{ f }}" class="download-btn" download="{{ f }}" rel="noopener noreferrer">{{ f }}</a>
 {%- include checksum_inline.html environment="cli" platform="macos" -%}
 
-<h4>Single Line Specific Version (bash)</h4>
+<h4>Install Specific Version</h4>
 {%- highlight bash -%}
-curl install.duckdb.org | DUCKDB_VERSION=1.4.3 bash
+curl https://install.duckdb.org | DUCKDB_VERSION=1.4.3 sh
 {%- endhighlight -%}
 
 </div>


### PR DESCRIPTION
## Description

- Addressing #5576 which brought up that a specific version of DuckDB could be installed via single line command. This PR Adds a single line alternative (tested) for MacOS bash installation via curl command.
- Possible this could also apply to linux instructions.

<img width="2611" height="1763" alt="image" src="https://github.com/user-attachments/assets/103579d3-394e-4b9b-b194-7b0e0ca925a4" />


## Links

- http://localhost:4000/install/?platform=macos&environment=cli

## Issues
https://github.com/duckdb/duckdb-web/issues/5576

## Self-Review Checklist
- [x] I have reviewed the [DuckDB Code Of Conduct](https://duckdb.org/code_of_conduct).
- [x] I have reviewed [CONTRIBUTING.md](https://github.com/duckdb/duckdb-web/blob/main/CONTRIBUTING.md#contributing-to-the-duckdb-documentation).
- [x] I have reviewed the [DuckDB Style Guide](https://github.com/duckdb/duckdb-web/blob/main/CONTRIBUTING.md#style-guide).
- [x] I have verified that all GitHub Actions checks are passing.
- [x] I have verified that all links are working correctly.
- [x] I have checked for spelling and grammatical errors.