### PR TITLE
Update Python overview with thread safety details

### DIFF
--- a/docs/stable/clients/python/overview.md
+++ b/docs/stable/clients/python/overview.md
@@ -214,21 +214,33 @@ The connection object and the `duckdb` module can be used interchangeably – th
 
 > If you are developing a package designed for others to use, and use DuckDB in the package, it is recommend that you create connection objects instead of using the methods on the `duckdb` module. That is because the `duckdb` module uses a shared global database – which can cause hard to debug issues if used from within multiple different packages.
 
-### Using Connections in Parallel Python Programs
+### Using Connections in Parallel Python Programs 
 
-The `DuckDBPyConnection` object is not thread-safe. If you would like to write to the same database from multiple threads, create a cursor for each thread with the [`DuckDBPyConnection.cursor()` method]({% link docs/stable/clients/python/reference/index.md %}#duckdb.DuckDBPyConnection.cursor).
-
-## Loading and Installing Extensions
-
-DuckDB's Python API provides functions for installing and loading [extensions]({% link docs/stable/extensions/overview.md %}), which perform the equivalent operations to running the `INSTALL` and `LOAD` SQL commands, respectively. An example that installs and loads the [`spatial` extension]({% link docs/stable/core_extensions/spatial/overview.md %}) looks like follows:
-
-```python
-import duckdb
-
-con = duckdb.connect()
-con.install_extension("spatial")
-con.load_extension("spatial")
+#### Thread Safety of `duckdb.sql()` and the Global Connection
+`duckdb.sql()` and `duckdb.connect(':default:')` use a shared global in-memory connection. This connection is not thread-safe, and running queries on it from multiple threads can cause issues. To run DuckDB in parallel, each thread must have its own connection: 
 ```
+def good_use():
+    con = duckdb.connect()
+    # uses new connection
+    con.sql("SELECT 1").fetchall()
+ ```
+Conversely, the following could cause concurrency issues because they rely on a global connection:
+```
+def bad_use():
+    con = duckdb.connect(':default:')
+    # uses global connection
+    return con.sql("SELECT 1").fetchall()
+```
+Or 
+``` 
+def also_bad():
+    return duckdb.sql("SELECT 1").fetchall()
+    # uses global connection 
+```
+Avoid using `duckdb.sql()` or sharing a single connection across threads. 
+
+#### About `cursor()` 
+A [`DuckDBPyConnection.cursor()` method]({% link docs/stable/clients/python/reference/index.md %}#duckdb.DuckDBPyConnection.cursor) creates another handle on the same connection. It does not open a new connection. Therefore, all cursors created from one connection cannot run queries at the same time.
 
 ### Community Extensions
 


### PR DESCRIPTION
Hi. I added thread safety information for DuckDB connections and SQL execution.

Closes duckdb/duckdb#13498