### PR TITLE
docs: fix invalid SQL syntax in CTE example

### DIFF
--- a/docs/stable/sql/query_syntax/with.md
+++ b/docs/stable/sql/query_syntax/with.md
@@ -40,7 +40,7 @@ You can specify column names for CTEs:
 
 ```sql
 WITH cte(j) AS (SELECT 42 AS i)
-Select * FROM cte;
+SELECT * FROM cte;
 ```
 
 | j  |


### PR DESCRIPTION
The example demonstrating column aliasing for CTEs was missing a  SELECT statement (showing only `FROM cte`). 

This commit updates the snippet to include `SELECT *` to ensure  the example contains valid, executable SQL.