### PR TITLE
[#6341] Add "of count input-values" to entropy function documentation

### DIFF
--- a/docs/stable/sql/functions/aggregates.md
+++ b/docs/stable/sql/functions/aggregates.md
@@ -490,7 +490,7 @@ They all ignore `NULL` values (in the case of a single input column `x`), or pai
 
 <div class="nostroke_table"></div>
 
-| **Description** | The log-2 entropy. |
+| **Description** | Returns the log-2 entropy of count input-values. |
 | **Formula** | - |
 
 #### `kurtosis_pop(x)`


### PR DESCRIPTION
Fixes #6341

Add "of count input-values" to entropy function documentation

It doesn't appear this is generated from content of https://github.com/duckdb/duckdb/blame/43a67ee2be35bb7ec2c283de3a68eb13f70d9430/extension/core_functions/aggregate/distributive/functions.json#L106