### PR TITLE
Clarify read_* `filename` argument in the documentation.

### DIFF
--- a/docs/stable/data/multiple_files/overview.md
+++ b/docs/stable/data/multiple_files/overview.md
@@ -143,7 +143,7 @@ FROM read_csv(['flights1.csv', 'flights2.csv'], union_by_name = true, filename =
 | 1988-01-02 | New York, NY   | Los Angeles, CA | NULL          | flights1.csv |
 | 1988-01-03 | New York, NY   | Los Angeles, CA | AA            | flights2.csv |
 
-> The `filename` argument also accepts a string (e.g. `filename = 'input_file'`). When provided, the string is used as the name of the added column. This is useful when the source data already contains a filename column and you want to avoid a name collision.
+> The `filename` argument also accepts a string (e.g., `filename = 'input_file'`). When provided, the string is used as the name of the added column. This is useful when the source data already contains a `filename` column and you want to avoid a name collision.
 
 ## Glob Function to Find Filenames
 


### PR DESCRIPTION
This (very usefu!l) behavior is not documented - the error you get if you try to use `filename = true` when loading files that have a `filename` field already defined sort of tells you what to do, but it's not super clear and it would be better for the documentation to state this clearly.