### PR TITLE
docs: fix incorrect SQLNULL value in CSV docs

### DIFF
--- a/docs/stable/data/csv/overview.md
+++ b/docs/stable/data/csv/overview.md
@@ -135,7 +135,7 @@ Usage example:
 SELECT * FROM read_csv('csv_file.csv', auto_type_candidates = ['BIGINT', 'DATE']);
 ```
 
-The default value for the `auto_type_candidates` option is `['SQLNULL', 'BOOLEAN', 'BIGINT', 'DOUBLE', 'TIME', 'DATE', 'TIMESTAMP', 'VARCHAR']`.
+The default value for the `auto_type_candidates` option is `['NULL', 'BOOLEAN', 'BIGINT', 'DOUBLE', 'TIME', 'DATE', 'TIMESTAMP', 'VARCHAR']`.
 
 ## CSV Functions
 


### PR DESCRIPTION
Fixes #6377

Change `SQLNULL` to `NULL` in the `auto_type_candidates` default value documentation.

The correct value is `NULL` as shown in the [auto_detection page](https://duckdb.org/docs/stable/data/csv/auto_detection#type-detection).