### PR TITLE
docs: Improve writing style and fix errors in data section docs

### DIFF
--- a/docs/stable/data/appender.md
+++ b/docs/stable/data/appender.md
@@ -5,7 +5,7 @@ redirect_from:
 title: Appender
 ---
 
-The Appender can be used to load bulk data into a DuckDB database. It is currently available in the [C, C++, Go, Java, and Rust APIs](#appender-support-in-other-clients). The Appender is tied to a connection, and will use the transaction context of that connection when appending. An Appender always appends to a single table in the database file.
+The Appender can be used to load bulk data into a DuckDB database. It is currently available in the [C, C++, Go, Java and Rust APIs](#appender-support-in-other-clients). The Appender is tied to a connection, and will use the transaction context of that connection when appending. An Appender always appends to a single table in the database file.
 
 In the [C++ API]({% link docs/stable/clients/cpp.md %}), the Appender works as follows:
 
@@ -63,7 +63,7 @@ appender.AppendRow(
 
 ## Commit Frequency
 
-By default, the appender performs a commits every 204,800 rows.
+By default, the appender performs commits every 204,800 rows.
 You can change this by explicitly using [transactions]({% link docs/stable/sql/statements/transactions.md %}) and surrounding your batches of `AppendRow` calls by `BEGIN TRANSACTION` and `COMMIT` statements.
 
 ## Handling Constraint Violations

--- a/docs/stable/data/csv/auto_detection.md
+++ b/docs/stable/data/csv/auto_detection.md
@@ -9,9 +9,9 @@ title: CSV Auto Detection
 When using `read_csv`, the system tries to automatically infer how to read the CSV file using the [CSV sniffer]({% post_url 2023-10-27-csv-sniffer %}).
 This step is necessary because CSV files are not self-describing and come in many different dialects. The auto-detection works roughly as follows:
 
-* Detect the dialect of the CSV file (delimiter, quoting rule, escape)
-* Detect the types of each of the columns
-* Detect whether or not the file has a header row
+* Detect the dialect of the CSV file (delimiter, quoting rule, escape).
+* Detect the types of each of the columns.
+* Detect whether or not the file has a header row.
 
 By default the system will try to auto-detect all options. However, options can be individually overridden by the user. This can be useful in case the system makes a mistake. For example, if the delimiter is chosen incorrectly, we can override it by calling the `read_csv` with an explicit delimiter (e.g., `read_csv('file.csv', delim = '|')`).
 
@@ -97,10 +97,10 @@ FlightDate|UniqueCarrier|OriginCityName|DestCityName
 
 In this file, the dialect detection works as follows:
 
-* If we split by a `|` every row is split into `4` columns
-* If we split by a `,` rows 2-4 are split into `3` columns, while the first row is split into `1` column
-* If we split by `;`, every row is split into `1` column
-* If we split by `\t`, every row is split into `1` column
+* If we split by a `|` every row is split into `4` columns.
+* If we split by a `,` rows 2-4 are split into `3` columns, while the first row is split into `1` column.
+* If we split by `;`, every row is split into `1` column.
+* If we split by `\t`, every row is split into `1` column.
 
 In this example – the system selects the `|` as the delimiter. All rows are split into the same amount of columns, and there is more than one column per row meaning the delimiter was actually found in the CSV file.
 
@@ -155,7 +155,7 @@ The detected types can be individually overridden using the `types` option. This
 * A list of type definitions (e.g., `types = ['INTEGER', 'VARCHAR', 'DATE']`). This overrides the types of the columns in-order of occurrence in the CSV file.
 * Alternatively, `types` takes a `name` → `type` map which overrides options of individual columns (e.g., `types = {'quarter': 'INTEGER'}`).
 
-The set of column types that may be specified using the `types` option is not as limited as the types available for the `auto_type_candidates` option: any valid type definition is acceptable to the `types`-option. (To get a valid type definition, use the [`typeof()`]({% link docs/stable/sql/functions/utility.md %}#typeofexpression) function, or use the `column_type` column  of the [`DESCRIBE`]({% link docs/stable/guides/meta/describe.md %}) result.)
+The set of column types that may be specified using the `types` option is not as limited as the types available for the `auto_type_candidates` option: any valid type definition is acceptable to the `types`-option. (To get a valid type definition, use the [`typeof()`]({% link docs/stable/sql/functions/utility.md %}#typeofexpression) function, or use the `column_type` column of the [`DESCRIBE`]({% link docs/stable/guides/meta/describe.md %}) result.)
 
 The `sniff_csv()` function's `Column` field returns a struct with column names and types that can be used as a basis for overriding types.
 
@@ -171,7 +171,7 @@ Note that headers cannot be detected correctly if all columns are of type `VARCH
 
 DuckDB supports the [ISO 8601 format](https://en.wikipedia.org/wiki/ISO_8601) format by default for timestamps, dates and times. Unfortunately, not all dates and times are formatted using this standard. For that reason, the CSV reader also supports the `dateformat` and `timestampformat` options. Using this format the user can specify a [format string]({% link docs/stable/sql/functions/dateformat.md %}) that specifies how the date or timestamp should be read.
 
-As part of the auto-detection, the system tries to figure out if dates and times are stored in a different representation. This is not always possible – as there are ambiguities in the representation. For example, the date `01-02-2000` can be parsed as either January 2nd or February 1st. Often these ambiguities can be resolved. For example, if we later encounter the date `21-02-2000` then we know that the format must have been `DD-MM-YYYY`. `MM-DD-YYYY` is no longer possible as there is no 21nd month.
+As part of the auto-detection, the system tries to figure out if dates and times are stored in a different representation. This is not always possible – as there are ambiguities in the representation. For example, the date `01-02-2000` can be parsed as either January 2nd or February 1st. Often these ambiguities can be resolved. For example, if we later encounter the date `21-02-2000` then we know that the format must have been `DD-MM-YYYY`. `MM-DD-YYYY` is no longer possible as there is no 21st month.
 
 If the ambiguities cannot be resolved by looking at the data the system has a list of preferences for which date format to use. If the system chooses incorrectly, the user can specify the `dateformat` and `timestampformat` options manually.
 

--- a/docs/stable/data/csv/overview.md
+++ b/docs/stable/data/csv/overview.md
@@ -119,7 +119,7 @@ Below are parameters that can be passed to the [`read_csv` function](#csv-functi
 | `union_by_name` | Align columns from different files [by column name]({% link docs/stable/data/multiple_files/combining_schemas.md %}#union-by-name) instead of position. Using this option increases memory consumption. | `BOOL` | `false` |
 
 > Tip DuckDB's CSV reader supports `UTF-8` (default), `UTF-16` and `Latin-1` encodings as well as many other `encoding` options
-> natively through the `encoding` extension, for details see [All Supported Encodings]({% link docs/stable/core_extensions/encodings.md%}#all-supported-encodings).
+> natively through the `encoding` extension, for details see [All Supported Encodings]({% link docs/stable/core_extensions/encodings.md %}#all-supported-encodings).
 > To convert files with different encodings, we recommend using the [`iconv` command-line tool](https://linux.die.net/man/1/iconv).
 >
 > ```batch

--- a/docs/stable/data/csv/reading_faulty_csv_files.md
+++ b/docs/stable/data/csv/reading_faulty_csv_files.md
@@ -5,7 +5,7 @@ redirect_from:
 title: Reading Faulty CSV Files
 ---
 
-CSV files can come in all shapes and forms, with some presenting many errors that make the process of cleanly reading them inherently difficult. To help users read these files, DuckDB supports detailed error messages, the ability to skip faulty lines, and the possibility of storing faulty lines in a temporary table to assist users with a data cleaning step.
+CSV files can come in all shapes and forms, with some presenting many errors that make the process of cleanly reading them inherently difficult. To help users read these files, DuckDB supports detailed error messages, the ability to skip faulty lines and the possibility of storing faulty lines in a temporary table to assist users with a data cleaning step.
 
 ## Structural Errors
 
@@ -60,7 +60,7 @@ Possible solutions:
   all_varchar=0
 ```
 
-The first block provides us with information regarding where the error occurred, including the line number, the original CSV line, and which field was problematic:
+The first block provides us with information regarding where the error occurred, including the line number, the original CSV line and which field was problematic:
 
 ```console
 Conversion Error:
@@ -138,7 +138,7 @@ Outputs:
 Being able to read faulty CSV files is important, but for many data cleaning operations, it is also necessary to know exactly which lines are corrupted and what errors the parser discovered on them. For scenarios like these, it is possible to use DuckDB's CSV Rejects Table feature.
 By default, this feature creates two temporary tables.
 
-1. `reject_scans`: Stores information regarding the parameters of the CSV Scanner
+1. `reject_scans`: Stores information regarding the parameters of the CSV Scanner.
 2. `reject_errors`: Stores information regarding each CSV faulty line and in which CSV Scanner they happened.
 
 Note that any of the errors described in our Structural Error section will be stored in the rejects tables. Also, if a line has multiple errors, multiple entries will be stored for the same line, one for each error.

--- a/docs/stable/data/data_sources.md
+++ b/docs/stable/data/data_sources.md
@@ -5,7 +5,7 @@ redirect_from:
 title: Data Sources
 ---
 
-DuckDB sources several data sources, including file formats, network protocols, and database systems:
+DuckDB sources several data sources, including file formats, network protocols and database systems:
 
 * [AWS S3 buckets and storage with S3-compatible API]({% link docs/stable/core_extensions/httpfs/s3api.md %})
 * [Azure Blob Storage]({% link docs/stable/core_extensions/azure.md %})

--- a/docs/stable/data/json/json_functions.md
+++ b/docs/stable/data/json/json_functions.md
@@ -134,7 +134,7 @@ Note that DuckDB's JSON data type uses [0-based indexing]({% link docs/stable/da
 
 If multiple values need to be extracted from the same JSON, it is more efficient to extract a list of paths:
 
-The following will cause the JSON to be parsed twice,:
+The following will cause the JSON to be parsed twice:
 
 Resulting in a slower query that uses more memory:
 
@@ -177,7 +177,7 @@ We support two kinds of notations to describe locations within JSON: [JSON Point
 | `json_contains(json_haystack, json_needle)` | Returns `true` if `json_needle` is contained in `json_haystack`. Both parameters are of JSON type, but `json_needle` can also be a numeric value or a string, however the string must be wrapped in double quotes.                                                                 |
 | `json_keys(json[, path])`                   | Returns the keys of `json` as a `LIST` of `VARCHAR`, if `json` is a JSON object. If `path` is specified, return the keys of the JSON object at the given `path`. If `path` is a `LIST`, the result will be `LIST` of `LIST` of `VARCHAR`.                                          |
 | `json_structure(json)`                      | Return the structure of `json`. Defaults to `JSON` if the structure is inconsistent (e.g., incompatible types in an array).                                                                                                                                                        |
-| `json_type(json[, path])`                   | Return the type of the supplied `json`, which is one of `ARRAY`, `BIGINT`, `BOOLEAN`, `DOUBLE`, `OBJECT`, `UBIGINT`, `VARCHAR`, and `NULL`. If `path` is specified, return the type of the element at the given `path`. If `path` is a `LIST`, the result will be `LIST` of types. |
+| `json_type(json[, path])`                   | Return the type of the supplied `json`, which is one of `ARRAY`, `BIGINT`, `BOOLEAN`, `DOUBLE`, `OBJECT`, `UBIGINT`, `VARCHAR` and `NULL`. If `path` is specified, return the type of the element at the given `path`. If `path` is a `LIST`, the result will be `LIST` of types. |
 | `json_valid(json)`                          | Return whether `json` is valid JSON.                                                                                                                                                                                                                                               |
 | `json(json)`                                | Parse and minify `json`.                                                                                                                                                                                                                                                           |
 

--- a/docs/stable/data/json/loading_json.md
+++ b/docs/stable/data/json/loading_json.md
@@ -332,7 +332,7 @@ CREATE TABLE numbers (i BIGINT);
 COPY numbers FROM 'numbers.json' (ARRAY true);
 ```
 
-The format can be detected automatically the format like so:
+The format can be detected automatically like so:
 
 ```sql
 CREATE TABLE numbers (i BIGINT);

--- a/docs/stable/data/json/overview.md
+++ b/docs/stable/data/json/overview.md
@@ -24,7 +24,7 @@ DuckDB implements multiple interfaces for JSON extraction: [JSONPath](https://go
 
 Note that DuckDB only supports lookups in JSONPath, i.e., extracting fields with `.<key>` or array elements with `[<index>]`.
 Arrays can be indexed from the back and both approaches support the wildcard `*`.
-DuckDB _not_ support the full JSONPath syntax because SQL is readily available for any further transformations.
+DuckDB does _not_ support the full JSONPath syntax because SQL is readily available for any further transformations.
 
 > It's best to pick either the JSONPath or the JSON Pointer syntax and use it in your entire application.
 

--- a/docs/stable/data/json/sql_to_and_from_json.md
+++ b/docs/stable/data/json/sql_to_and_from_json.md
@@ -14,7 +14,7 @@ DuckDB provides functions to serialize and deserialize `SELECT` statements betwe
 | `json_serialize_sql(varchar, skip_default := boolean, skip_empty := boolean, skip_null := boolean, format := boolean)` | Scalar | Serialize a set of semicolon-separated (`;`) select statements to an equivalent list of `json` serialized statements. |
 | `PRAGMA json_execute_serialized_sql(varchar)` | Pragma | Pragma version of the `json_execute_serialized_sql` function. |
 
-The `json_serialize_sql(varchar)` function takes three optional parameters, `skip_empty`, `skip_null`, and `format` that can be used to control the output of the serialized statements.
+The `json_serialize_sql(varchar)` function takes three optional parameters, `skip_empty`, `skip_null` and `format` that can be used to control the output of the serialized statements.
 
 If you run the `json_execute_serialized_sql(varchar)` table function inside of a transaction the serialized statements will not be able to see any transaction local changes. This is because the statements are executed in a separate query context. You can use the `PRAGMA json_execute_serialized_sql(varchar)` pragma version to execute the statements in the same query context as the pragma, although with the limitation that the serialized JSON must be provided as a constant string, i.e., you cannot do `PRAGMA json_execute_serialized_sql(json_serialize_sql(...))`.
 

--- a/docs/stable/data/multiple_files/combining_schemas.md
+++ b/docs/stable/data/multiple_files/combining_schemas.md
@@ -25,7 +25,7 @@ SELECT * FROM read_csv('flights*.csv', union_by_name = true);
 
 When reading from multiple files, we have to **combine schemas** from those files. That is because each file has its own schema that can differ from the other files. DuckDB offers two ways of unifying schemas of multiple files: **by column position** and **by column name**.
 
-By default, DuckDB reads the schema of the first file provided, and then unifies columns in subsequent files by column position. This works correctly as long as all files have the same schema. If the schema of the files differs, you might want to use the `union_by_name` option  to allow DuckDB to construct the schema by reading all of the names instead.
+By default, DuckDB reads the schema of the first file provided, and then unifies columns in subsequent files by column position. This works correctly as long as all files have the same schema. If the schema of the files differs, you might want to use the `union_by_name` option to allow DuckDB to construct the schema by reading all of the names instead.
 
 Below is an example of how both methods work.
 

--- a/docs/stable/data/overview.md
+++ b/docs/stable/data/overview.md
@@ -116,5 +116,5 @@ SELECT *, filename FROM 'test.parquet';
 
 ## Appender
 
-In several APIs (C, C++, Go, Java, and Rust), the [Appender]({% link docs/stable/data/appender.md %}) can be used as an alternative for bulk data loading.
+In several APIs (C, C++, Go, Java and Rust), the [Appender]({% link docs/stable/data/appender.md %}) can be used as an alternative for bulk data loading.
 This class can be used to efficiently add rows to the database system without using SQL statements.

--- a/docs/stable/data/partitioning/partitioned_writes.md
+++ b/docs/stable/data/partitioning/partitioned_writes.md
@@ -62,8 +62,8 @@ SET partitioned_write_max_open_files = 10;
 
 By default, files will be named `data_0.parquet` or `data_0.csv`. With the flag `FILENAME_PATTERN` a pattern with `{i}` or `{uuid}` can be defined to create specific filenames:
 
-* `{i}` will be replaced by an index
-* `{uuid}` will be replaced by a 128 bits long UUID
+* `{i}` will be replaced by an index.
+* `{uuid}` will be replaced by a 128 bits long UUID.
 
 Write a table to a Hive partitioned dataset of .parquet files, with an index in the filename:
 


### PR DESCRIPTION
- Fix 5 typos/grammar errors (performs a commits, DuckDB _not_ support, 21nd, etc.)
- Convert list markers from - to * per style guide
- Remove 7 Oxford commas
- Add missing periods to 9 list items
- Fix 2 double spaces in prose
- Fix broken Jekyll link syntax in csv/overview.md