### PR TITLE
docs: Improve writing style in core_extensions section

### DIFF
--- a/docs/stable/core_extensions/azure.md
+++ b/docs/stable/core_extensions/azure.md
@@ -244,7 +244,7 @@ CREATE SECRET azure_spn_cert (
 
 #### Configuring a Proxy
 
-To configure proxy information when using secrets, you can add `HTTP_PROXY`, `PROXY_USER_NAME`, and `PROXY_PASSWORD` in the secret definition. For example:
+To configure proxy information when using secrets, you can add `HTTP_PROXY`, `PROXY_USER_NAME` and `PROXY_PASSWORD` in the secret definition. For example:
 
 ```sql
 CREATE SECRET secret5 (

--- a/docs/stable/core_extensions/encodings.md
+++ b/docs/stable/core_extensions/encodings.md
@@ -12,8 +12,8 @@ title: Encodings Extension
 > Warning The Encodings extension will be available with the release of DuckDB v1.3.0.
 
 The `encodings` extension adds supports for reading CSVs using more than 1,000 character encodings.
-- For a complete list of supported `encodings`, see [All Supported Encodings](#all-supported-encodings). 
-- For detailed information on character encoding, see the [ICU data repository](https://github.com/unicode-org/icu-data/tree/main/charset/data/ucm).
+* For a complete list of supported `encodings`, see [All Supported Encodings](#all-supported-encodings).
+* For detailed information on character encoding, see the [ICU data repository](https://github.com/unicode-org/icu-data/tree/main/charset/data/ucm).
 
 ## Installing and Loading
 

--- a/docs/stable/core_extensions/full_text_search.md
+++ b/docs/stable/core_extensions/full_text_search.md
@@ -77,7 +77,7 @@ When an index is built, this retrieval macro is created that can be used to sear
 |:--|:--|:----------|
 | `input_id` | `VARCHAR` | Column name of document identifier, e.g., `'document_identifier'` |
 | `query_string` | `VARCHAR` | The string to search the index for |
-| `fields` | `VARCHAR` | Comma-separarated list of fields to search in, e.g., `'text_field_2, text_field_N'`. Defaults to `NULL` to search all indexed fields |
+| `fields` | `VARCHAR` | Comma-separated list of fields to search in, e.g., `'text_field_2, text_field_N'`. Defaults to `NULL` to search all indexed fields |
 | `k` | `DOUBLE` | Parameter _k<sub>1</sub>_ in the Okapi BM25 retrieval model. Defaults to `1.2` |
 | `b` | `DOUBLE` | Parameter _b_ in the Okapi BM25 retrieval model. Defaults to `0.75` |
 | `conjunctive` | `BOOLEAN` | Whether to make the query conjunctive i.e., all terms in the query string must be present in order for a document to be retrieved |

--- a/docs/stable/core_extensions/httpfs/s3api.md
+++ b/docs/stable/core_extensions/httpfs/s3api.md
@@ -12,7 +12,7 @@ The `httpfs` extension supports reading/writing/[globbing](#globbing) files on o
 
 ## Platforms
 
-The `httpfs` filesystem is tested with [AWS S3](https://aws.amazon.com/s3/), [Minio](https://min.io/), [Google Cloud](https://cloud.google.com/storage/docs/interoperability), and [lakeFS](https://docs.lakefs.io/integrations/duckdb.html). Other services that implement the S3 API (such as [Cloudflare R2](https://www.cloudflare.com/en-gb/developer-platform/r2/)) should also work, but not all features may be supported.
+The `httpfs` filesystem is tested with [AWS S3](https://aws.amazon.com/s3/), [Minio](https://min.io/), [Google Cloud](https://cloud.google.com/storage/docs/interoperability) and [lakeFS](https://docs.lakefs.io/integrations/duckdb.html). Other services that implement the S3 API (such as [Cloudflare R2](https://www.cloudflare.com/en-gb/developer-platform/r2/)) should also work, but not all features may be supported.
 
 The following table shows which parts of the S3 API are required for each `httpfs` feature.
 

--- a/docs/stable/core_extensions/iceberg/iceberg_rest_catalogs.md
+++ b/docs/stable/core_extensions/iceberg/iceberg_rest_catalogs.md
@@ -77,10 +77,10 @@ The following options can only be passed to a `CREATE SECRET` statement, and the
 
 The DuckDB Iceberg extensions supports the following operations when used with a REST catalog attached:
 
-- `CREATE/DROP SCHEMA`
-- `CREATE/DROP TABLE`
-- `INSERT INTO`
-- `SELECT`
+* `CREATE/DROP SCHEMA`
+* `CREATE/DROP TABLE`
+* `INSERT INTO`
+* `SELECT`
 
 Since these operations are supported, the following would also work:
 
@@ -134,10 +134,10 @@ CALL iceberg_to_ducklake('iceberg_datalake', 'my_ducklake', skip_tables := ['tab
 
 The following operations are not supported by the Iceberg DuckDB extension:
 
-- `UPDATE`
-- `DELETE`
-- `MERGE INTO`
-- `ALTER TABLE`
+* `UPDATE`
+* `DELETE`
+* `MERGE INTO`
+* `ALTER TABLE`
 
 ## Specific Catalog Examples
 

--- a/docs/stable/core_extensions/iceberg/overview.md
+++ b/docs/stable/core_extensions/iceberg/overview.md
@@ -62,7 +62,7 @@ FROM iceberg_scan('data/iceberg/lineitem_iceberg', allow_moved_paths = true);
 > The `allow_moved_paths` option ensures that some path resolution is performed, 
 > which allows scanning Iceberg tables that are moved.
 
-You can also address specify the current manifest directly in the query, this may be resolved from the catalog prior to the query, in this example the manifest version is a UUID.
+You can also directly specify the current manifest in the query, this may be resolved from the catalog prior to the query, in this example the manifest version is a UUID.
 To do so, navigate to the `data/iceberg` directory and run:
 
 ```sql
@@ -184,8 +184,8 @@ FROM iceberg_scan(
 
 ## Limitations
 
-- Inserts into v3 Iceberg specification tables.
-- Reads from v3 tables with v2 data types.
-- Geometry data type
+* Inserts into v3 Iceberg specification tables.
+* Reads from v3 tables with v2 data types.
+* Geometry data type.
 
 For a set of unsupported operations when attaching to an Iceberg catalog, see [Unsupported Operations]({% link docs/stable/core_extensions/iceberg/iceberg_rest_catalogs.md %}#unsupported-operations).

--- a/docs/stable/core_extensions/spatial/functions.md
+++ b/docs/stable/core_extensions/spatial/functions.md
@@ -34,7 +34,7 @@ title: Spatial Functions
 | [`ST_ContainsProperly`](#st_containsproperly) | Returns true if the first geometry \"properly\" contains the second geometry |
 | [`ST_ConvexHull`](#st_convexhull) | Returns the convex hull enclosing the geometry |
 | [`ST_CoverageInvalidEdges`](#st_coverageinvalidedges) | Returns the invalid edges in a polygonal coverage, which are edges that are not shared by two polygons. |
-| [`ST_CoverageSimplify`](#st_coveragesimplify) | Simplify the edges in a polygonal coverage, preserving the coverange by ensuring that the there are no seams between the resulting simplified polygons. |
+| [`ST_CoverageSimplify`](#st_coveragesimplify) | Simplify the edges in a polygonal coverage, preserving the coverage by ensuring that there are no seams between the resulting simplified polygons. |
 | [`ST_CoverageUnion`](#st_coverageunion) | Union all geometries in a polygonal coverage into a single geometry. |
 | [`ST_CoveredBy`](#st_coveredby) | Returns true if geom1 is "covered by" geom2 |
 | [`ST_Covers`](#st_covers) | Returns true if the geom1 "covers" geom2 |
@@ -66,7 +66,7 @@ title: Spatial Functions
 | [`ST_GeomFromHEXWKB`](#st_geomfromhexwkb) | Deserialize a GEOMETRY from a HEX(E)WKB encoded string |
 | [`ST_GeomFromText`](#st_geomfromtext) | Deserialize a GEOMETRY from a WKT encoded string |
 | [`ST_GeomFromWKB`](#st_geomfromwkb) | Deserializes a GEOMETRY from a WKB encoded blob |
-| [`ST_GeometryType`](#st_geometrytype) | Returns a 'GEOMETRY_TYPE' enum identifying the input geometry type. Possible enum return types are: `POINT`, `LINESTRING`, `POLYGON`, `MULTIPOINT`, `MULTILINESTRING`, `MULTIPOLYGON`, and `GEOMETRYCOLLECTION`. |
+| [`ST_GeometryType`](#st_geometrytype) | Returns a 'GEOMETRY_TYPE' enum identifying the input geometry type. Possible enum return types are: `POINT`, `LINESTRING`, `POLYGON`, `MULTIPOINT`, `MULTILINESTRING`, `MULTIPOLYGON` and `GEOMETRYCOLLECTION`. |
 | [`ST_HasM`](#st_hasm) | Check if the input geometry has M values. |
 | [`ST_HasZ`](#st_hasz) | Check if the input geometry has Z values. |
 | [`ST_Hilbert`](#st_hilbert) | Encodes the X and Y values as the hilbert curve index for a curve covering the given bounding box. |
@@ -604,10 +604,10 @@ GEOMETRY ST_Collect (geoms GEOMETRY[])
 #### Description
 
 Collects a list of geometries into a collection geometry.
-- If all geometries are `POINT`'s, a `MULTIPOINT` is returned.
-- If all geometries are `LINESTRING`'s, a `MULTILINESTRING` is returned.
-- If all geometries are `POLYGON`'s, a `MULTIPOLYGON` is returned.
-- Otherwise if the input collection contains a mix of geometry types, a `GEOMETRYCOLLECTION` is returned.
+* If all geometries are `POINT`'s, a `MULTIPOINT` is returned.
+* If all geometries are `LINESTRING`'s, a `MULTILINESTRING` is returned.
+* If all geometries are `POLYGON`'s, a `MULTIPOLYGON` is returned.
+* Otherwise if the input collection contains a mix of geometry types, a `GEOMETRYCOLLECTION` is returned.
 
 Empty and `NULL` geometries are ignored. If all geometries are empty or `NULL`, a `GEOMETRYCOLLECTION EMPTY` is returned.
 
@@ -662,9 +662,9 @@ GEOMETRY ST_CollectionExtract (geom GEOMETRY)
 Extracts geometries from a GeometryCollection into a typed multi geometry.
 
 If the input geometry is a GeometryCollection, the function will return a multi geometry, determined by the `type` parameter.
-- if `type` = 1, returns a MultiPoint containg all the Points in the collection
-- if `type` = 2, returns a MultiLineString containg all the LineStrings in the collection
-- if `type` = 3, returns a MultiPolygon containg all the Polygons in the collection
+* If `type` = 1, returns a MultiPoint containing all the Points in the collection.
+* If `type` = 2, returns a MultiLineString containing all the LineStrings in the collection.
+* If `type` = 3, returns a MultiPolygon containing all the Polygons in the collection.
 
 If no `type` parameters is provided, the function will return a multi geometry matching the highest "surface dimension"
 of the contained geometries. E.g. if the collection contains only Points, a MultiPoint will be returned. But if the
@@ -782,7 +782,7 @@ GEOMETRY ST_CoverageSimplify (geoms GEOMETRY[], tolerance DOUBLE)
 
 #### Description
 
-Simplify the edges in a polygonal coverage, preserving the coverange by ensuring that the there are no seams between the resulting simplified polygons.
+Simplify the edges in a polygonal coverage, preserving the coverage by ensuring that there are no seams between the resulting simplified polygons.
 
 By default, the boundary of the coverage is also simplified, but this can be controlled with the optional third 'simplify_boundary' parameter.
 
@@ -924,10 +924,10 @@ INTEGER ST_Dimension (geom GEOMETRY)
 
 Returns the "topological dimension" of a geometry.
 
-- For POINT and MULTIPOINT geometries, returns `0`
-- For LINESTRING and MULTILINESTRING, returns `1`
-- For POLYGON and MULTIPOLYGON, returns `2`
-- For GEOMETRYCOLLECTION, returns the maximum dimension of the contained geometries, or 0 if the collection is empty
+* For POINT and MULTIPOINT geometries, returns `0`.
+* For LINESTRING and MULTILINESTRING, returns `1`.
+* For POLYGON and MULTIPOLYGON, returns `2`.
+* For GEOMETRYCOLLECTION, returns the maximum dimension of the contained geometries, or 0 if the collection is empty.
 
 #### Example
 
@@ -1014,9 +1014,9 @@ DOUBLE ST_Distance_Sphere (point1 POINT_2D, point2 POINT_2D)
 
 Returns the haversine (great circle) distance between two geometries.
 
-- Only supports POINT geometries.
-- Returns the distance in meters.
-- The input is expected to be in WGS84 (EPSG:4326) coordinates, using a [latitude, longitude] axis order.
+* Only supports POINT geometries.
+* Returns the distance in meters.
+* The input is expected to be in WGS84 (EPSG:4326) coordinates, using a [latitude, longitude] axis order.
 
 ----
 
@@ -1231,10 +1231,10 @@ GEOMETRY ST_Force3DM (geom GEOMETRY, m DOUBLE)
 Forces the vertices of a geometry to have X, Y and M components
 
 The following cases apply:
-- If the input geometry has a Z component but no M component, the Z component will be replaced with the new M value.
-- If the input geometry has a M component but no Z component, it will be returned as is.
-- If the input geometry has both a Z component and a M component, the Z component will be removed.
-- Otherwise, if the input geometry has neither a Z or M component, the new M value will be added to the vertices of the input geometry.
+* If the input geometry has a Z component but no M component, the Z component will be replaced with the new M value.
+* If the input geometry has a M component but no Z component, it will be returned as is.
+* If the input geometry has both a Z component and a M component, the Z component will be removed.
+* Otherwise, if the input geometry has neither a Z or M component, the new M value will be added to the vertices of the input geometry.
 
 ----
 
@@ -1252,10 +1252,10 @@ GEOMETRY ST_Force3DZ (geom GEOMETRY, z DOUBLE)
 Forces the vertices of a geometry to have X, Y and Z components
 
 The following cases apply:
-- If the input geometry has a M component but no Z component, the M component will be replaced with the new Z value.
-- If the input geometry has a Z component but no M component, it will be returned as is.
-- If the input geometry has both a Z component and a M component, the M component will be removed.
-- Otherwise, if the input geometry has neither a Z or M component, the new Z value will be added to the vertices of the input geometry.
+* If the input geometry has a M component but no Z component, the M component will be replaced with the new Z value.
+* If the input geometry has a Z component but no M component, it will be returned as is.
+* If the input geometry has both a Z component and a M component, the M component will be removed.
+* Otherwise, if the input geometry has neither a Z or M component, the new Z value will be added to the vertices of the input geometry.
 
 ----
 
@@ -1273,10 +1273,10 @@ GEOMETRY ST_Force4D (geom GEOMETRY, z DOUBLE, m DOUBLE)
 Forces the vertices of a geometry to have X, Y, Z and M components
 
 The following cases apply:
-- If the input geometry has a Z component but no M component, the new M value will be added to the vertices of the input geometry.
-- If the input geometry has a M component but no Z component, the new Z value will be added to the vertices of the input geometry.
-- If the input geometry has both a Z component and a M component, the geometry will be returned as is.
-- Otherwise, if the input geometry has neither a Z or M component, the new Z and M values will be added to the vertices of the input geometry.
+* If the input geometry has a Z component but no M component, the new M value will be added to the vertices of the input geometry.
+* If the input geometry has a M component but no Z component, the new Z value will be added to the vertices of the input geometry.
+* If the input geometry has both a Z component and a M component, the geometry will be returned as is.
+* Otherwise, if the input geometry has neither a Z or M component, the new Z and M values will be added to the vertices of the input geometry.
 
 ----
 
@@ -1385,7 +1385,7 @@ ANY ST_GeometryType (wkb WKB_BLOB)
 
 #### Description
 
-Returns a 'GEOMETRY_TYPE' enum identifying the input geometry type. Possible enum return types are: `POINT`, `LINESTRING`, `POLYGON`, `MULTIPOINT`, `MULTILINESTRING`, `MULTIPOLYGON`, and `GEOMETRYCOLLECTION`.
+Returns a 'GEOMETRY_TYPE' enum identifying the input geometry type. Possible enum return types are: `POINT`, `LINESTRING`, `POLYGON`, `MULTIPOINT`, `MULTILINESTRING`, `MULTIPOLYGON` and `GEOMETRYCOLLECTION`.
 
 #### Example
 
@@ -1891,7 +1891,7 @@ STRUCT(center GEOMETRY, nearest GEOMETRY, radius DOUBLE) ST_MaximumInscribedCirc
 Returns the maximum inscribed circle of the input geometry, optionally with a tolerance.
 
 By default, the tolerance is computed as `max(width, height) / 1000`.
-The return value is a struct with the center of the circle, the nearest point to the center on the boundary of the geometry, and the radius of the circle.
+The return value is a struct with the center of the circle, the nearest point to the center on the boundary of the geometry and the radius of the circle.
 
 #### Example
 
@@ -3232,7 +3232,7 @@ ST_GeneratePoints (col0 BOX_2D, col1 BIGINT, col2 BIGINT)
 
 Generates a set of random points within the specified bounding box.
 
-Takes a bounding box (min_x, min_y, max_x, max_y), a count of points to generate, and optionally a seed for the random number generator.
+Takes a bounding box (min_x, min_y, max_x, max_y), a count of points to generate and optionally a seed for the random number generator.
 
 #### Example
 

--- a/docs/stable/core_extensions/spatial/r-tree_indexes.md
+++ b/docs/stable/core_extensions/spatial/r-tree_indexes.md
@@ -26,9 +26,9 @@ By traversing the R-tree from top to bottom, it is possible to very quickly sear
 
 Before you get started using the R-tree index, there are some limitations to be aware of:
 
-- The R-tree index is only supported for the `GEOMETRY` data type.
-- The R-tree index will only be used to perform "index scans" when the table is filtered (using a `WHERE` clause) with one of the following spatial predicate functions (as they all imply intersection): `ST_Equals`, `ST_Intersects`, `ST_Touches`, `ST_Crosses`, `ST_Within`, `ST_Contains`, `ST_Overlaps`, `ST_Covers`, `ST_CoveredBy`, `ST_ContainsProperly`.
-- One of the arguments to the spatial predicate function must be a “constant” (i.e., an expression whose result is known at query planning time). This is because the query planner needs to know the bounding box of the query region _before_ the query itself is executed in order to use the R-tree index scan.
+* The R-tree index is only supported for the `GEOMETRY` data type.
+* The R-tree index will only be used to perform "index scans" when the table is filtered (using a `WHERE` clause) with one of the following spatial predicate functions (as they all imply intersection): `ST_Equals`, `ST_Intersects`, `ST_Touches`, `ST_Crosses`, `ST_Within`, `ST_Contains`, `ST_Overlaps`, `ST_Covers`, `ST_CoveredBy`, `ST_ContainsProperly`.
+* One of the arguments to the spatial predicate function must be a "constant" (i.e., an expression whose result is known at query planning time). This is because the query planner needs to know the bounding box of the query region _before_ the query itself is executed to use the R-tree index scan.
 
 In the future we want to enable R-tree indexes to be used to accelerate additional predicate functions and more complex queries such a spatial joins.
 
@@ -50,7 +50,7 @@ You can also pass in additional options when creating an R-tree index using the 
 CREATE INDEX my_idx ON my_table USING RTREE (geom) WITH (max_node_capacity = 16);
 ```
 
-The impact tweaking these options will have on performance is highly dependent on the system setup DuckDB is running on, the spatial distribution of the dataset, and the query patterns of your specific workload. The defaults should be good enough, but you if you want to experiment with different parameters, see the [full list of options here](#options).
+The impact tweaking these options will have on performance is highly dependent on the system setup DuckDB is running on, the spatial distribution of the dataset and the query patterns of your specific workload. The defaults should be good enough, but you if you want to experiment with different parameters, see the [full list of options here](#options).
 
 ## Example
 

--- a/docs/stable/core_extensions/tpch.md
+++ b/docs/stable/core_extensions/tpch.md
@@ -73,13 +73,13 @@ This function returns a table with columns `query_nr` and `query`.
 
 ### Listing Expected Answers
 
-To produced the expected results for all queries on scale factors 0.01, 0.1, and 1, run:
+To produce the expected results for all queries on scale factors 0.01, 0.1 and 1, run:
 
 ```sql
 FROM tpch_answers();
 ```
 
-This function returns a table with columns `query_nr`, `scale_factor`, and `answer`.
+This function returns a table with columns `query_nr`, `scale_factor` and `answer`.
 
 ## Generating the Schema
 

--- a/docs/stable/core_extensions/ui.md
+++ b/docs/stable/core_extensions/ui.md
@@ -39,7 +39,7 @@ Running either of these will open the UI in your default browser.
 The UI connects to the DuckDB instance it was started from,
 so any data you’ve already loaded will be available.
 Since this instance is a native process (not Wasm), it can leverage all
-the resources of your local environment: all cores, memory, and files.
+the resources of your local environment: all cores, memory and files.
 Closing this instance will cause the UI to stop working.
 
 The UI is served from an HTTP server embedded in DuckDB.


### PR DESCRIPTION
- Fix typos: separarated, coverange, address specify, produced
- Fix grammar: the there → there
- Convert list markers to asterisks for consistency
- Remove Oxford commas in lists of 3+ items
- Simplify "in order to" → "to"
- Add missing periods to list items