### PR TITLE
Improve writing style in remaining documentation sections

### DIFF
--- a/docs/stable/configuration/overview.md
+++ b/docs/stable/configuration/overview.md
@@ -56,7 +56,7 @@ Write a single log message with the `debug` level and a `connection` scope:
 SELECT write_log('A new client has connected.', level := 'debug', scope := 'connection');
 ```
 
-Write a single log message with the a `debug` level and a `connection` scope and a custom `log_type`:
+Write a single log message with a `debug` level and a `connection` scope and a custom `log_type`:
 
 ```sql
 SELECT write_log(

--- a/docs/stable/extensions/extension_distribution.md
+++ b/docs/stable/extensions/extension_distribution.md
@@ -35,13 +35,13 @@ By default, DuckDB uses its built-in public keys to verify the integrity of exte
 All core and community extensions are signed by the DuckDB team.
 
 Signing the extension simplifies their distribution, this is why they can be distributed over HTTP without the need for HTTPS,
-which is itself is supported through an extension ([`httpfs`]({% link docs/stable/core_extensions/httpfs/overview.md %})).
+which itself is supported through an extension ([`httpfs`]({% link docs/stable/core_extensions/httpfs/overview.md %})).
 
 ### Unsigned Extensions
 
 > Warning Only load unsigned extensions from sources you trust.
 > Avoid loading unsigned extensions over HTTP.
-> Consult the [Securing DuckDB page]({% link docs/stable/operations_manual/securing_duckdb/securing_extensions.md %}) for guidelines on how set up DuckDB in a secure manner.
+> Consult the [Securing DuckDB page]({% link docs/stable/operations_manual/securing_duckdb/securing_extensions.md %}) for guidelines on how to set up DuckDB in a secure manner.
 
 If you wish to load your own extensions or extensions from third-parties you will need to enable the `allow_unsigned_extensions` flag.
 To load unsigned extensions using the [CLI client]({% link docs/stable/clients/cli/overview.md %}), pass the `-unsigned` flag to it on startup:
@@ -96,7 +96,7 @@ When installing an extension from a custom repository, DuckDB will search for bo
 INSTALL icu FROM '⟨custom_repository⟩';
 ```
 
-The execution of this statement will first look `icu.duckdb_extension.gz`, then `icu.duckdb_extension` in the repository's directory structure.
+The execution of this statement will first look for `icu.duckdb_extension.gz`, then `icu.duckdb_extension` in the repository's directory structure.
 
 If the custom repository is served over HTTPS or S3, the [`httpfs` extension]({% link docs/stable/core_extensions/httpfs/overview.md %}) is required. DuckDB will attempt to [autoload]({% link docs/stable/extensions/overview.md %}#autoloading-extensions)
 the `httpfs` extension when an installation over HTTPS or S3 is attempted.

--- a/docs/stable/extensions/troubleshooting.md
+++ b/docs/stable/extensions/troubleshooting.md
@@ -21,7 +21,7 @@ For more info, visit https://duckdb.org/docs/stable/extensions/troubleshooting?v
 ```
 
 There are multiple scenarios for which an extensions might not be available in a given extension repository at a given time:
-* the extension have not been uploaded yet, here some delay after a given release date might be expected. Consider checking the issues at [`duckdb/duckdb`](https://github.com/duckdb/duckdb) or [`duckdb/community-extensions`](https://github.com/duckdb/community-extensions), or creating one yourself.
+* the extension has not been uploaded yet, here some delay after a given release date might be expected. Consider checking the issues at [`duckdb/duckdb`](https://github.com/duckdb/duckdb) or [`duckdb/community-extensions`](https://github.com/duckdb/community-extensions), or creating one yourself.
 * the extension is available, but in a different repository, try for example `INSTALL <name> FROM core;` or `INSTALL <name> FROM community;` or `INSTALL <name> FROM core_nightly;` (see the [Installing Extensions page]({% link docs/stable/extensions/installing_extensions.md %}#extension-repositories)).
 * networking issues, so extension exists at the endpoint but it's not reachable from your local DuckDB. Here you can try visiting the given URL via a browser directly pasting the link from the error message in the search bar.
 

--- a/docs/stable/internals/overview.md
+++ b/docs/stable/internals/overview.md
@@ -69,7 +69,7 @@ After the logical planner has created the logical query tree, the optimizers are
 
 ## Column Binding Resolver
 
-The column binding resolver converts logical [`BoundColumnRefExpresion`](https://github.com/duckdb/duckdb/blob/main/src/include/duckdb/planner/expression/bound_columnref_expression.hpp) nodes that refer to a column of a specific table into [`BoundReferenceExpression`](https://github.com/duckdb/duckdb/blob/main/src/include/duckdb/planner/expression/bound_reference_expression.hpp) nodes that refer to a specific index into the DataChunks that are passed around in the execution engine.
+The column binding resolver converts logical [`BoundColumnRefExpression`](https://github.com/duckdb/duckdb/blob/main/src/include/duckdb/planner/expression/bound_columnref_expression.hpp) nodes that refer to a column of a specific table into [`BoundReferenceExpression`](https://github.com/duckdb/duckdb/blob/main/src/include/duckdb/planner/expression/bound_reference_expression.hpp) nodes that refer to a specific index into the DataChunks that are passed around in the execution engine.
 
 ## Physical Plan Generator
 

--- a/docs/stable/internals/pivot.md
+++ b/docs/stable/internals/pivot.md
@@ -12,7 +12,7 @@ Each `PIVOT` is implemented as set of aggregations into lists and then the dedic
 Additional pre-processing steps are required if the columns to be created when pivoting are detected dynamically (which occurs when the `IN` clause is not in use).
 
 DuckDB, like most SQL engines, requires that all column names and types be known at the start of a query.
-In order to automatically detect the columns that should be created as a result of a `PIVOT` statement, it must be translated into multiple queries.
+To automatically detect the columns that should be created as a result of a `PIVOT` statement, it must be translated into multiple queries.
 [`ENUM` types]({% link docs/stable/sql/data_types/enum.md %}) are used to find the distinct values that should become columns.
 Each `ENUM` is then injected into one of the `PIVOT` statement's `IN` clauses.
 

--- a/docs/stable/internals/storage.md
+++ b/docs/stable/internals/storage.md
@@ -188,4 +188,4 @@ The message implies that the database file was created with a newer DuckDB versi
 There are two potential workarounds:
 
 1. Update your DuckDB version to the latest stable version.
-2. Open the database with the latest version of DuckDB, export it to a standard format (e.g., Parquet), then import it using to any version of DuckDB. See the [`EXPORT/IMPORT DATABASE` statements]({% link docs/stable/sql/statements/export.md %}) for details.
+2. Open the database with the latest version of DuckDB, export it to a standard format (e.g., Parquet), then import it to any version of DuckDB. See the [`EXPORT/IMPORT DATABASE` statements]({% link docs/stable/sql/statements/export.md %}) for details.

--- a/docs/stable/internals/vector.md
+++ b/docs/stable/internals/vector.md
@@ -52,7 +52,7 @@ Dictionary vectors are physically stored as a child vector, and a selection vect
 
 <img src="/images/internals/dictionary.png" alt="Dictionary Vector example" style="max-width:40%;width:40%;height:auto;margin:auto"/>
 
-Dictionary vectors are emitted by the storage when decompressing from dictionary
+Dictionary vectors are emitted by the storage when decompressing from dictionary compression.
 
 Just like constant vectors, dictionary vectors are also emitted by the storage.
 When deserializing a dictionary compressed column segment, we store this in a dictionary vector so we can keep the data compressed during query execution.


### PR DESCRIPTION
## Summary
* Fix typos and grammar issues in extensions, internals, configuration sections
* Simplify "in order to" phrase to "to"
* Fix incomplete sentences and duplicate words

**Sections covered:** extensions, internals, configuration, connect (16 files total, 7 modified)

**Fixes (9 total):**
- `extension_distribution.md`: "which is itself is" → "which itself is"
- `extension_distribution.md`: "how set up" → "how to set up"
- `extension_distribution.md`: "look \`icu" → "look for \`icu"
- `troubleshooting.md`: "extension have" → "extension has"
- `pivot.md`: "In order to" → "To"
- `overview.md` (internals): "BoundColumnRefExpresion" → "BoundColumnRefExpression"
- `storage.md`: "import it using to" → "import it to"
- `vector.md`: incomplete sentence → added "compression."
- `overview.md` (configuration): "with the a" → "with a"

## Test plan
- [ ] Verify pages render correctly
- [ ] Check no broken links introduced