### PR TITLE
Remove redundant example

### DIFF
--- a/docs/stable/guides/network_cloud_storage/http_import.md
+++ b/docs/stable/guides/network_cloud_storage/http_import.md
@@ -31,12 +31,6 @@ For example:
 SELECT * FROM read_parquet('https://duckdb.org/data/prices.parquet');
 ```
 
-The function `read_parquet` can be omitted if the URL ends with `.parquet`:
-
-```sql
-SELECT * FROM read_parquet('https://duckdb.org/data/holdings.parquet');
-```
-
 Moreover, the `read_parquet` function itself can also be omitted thanks to DuckDB's [replacement scan mechanism]({% link docs/stable/clients/c/replacement_scans.md %}):
 
 ```sql


### PR DESCRIPTION
Remove redundant usage of 'omit read_parquet function' example. The example right below it restates the same thing but adds more detail. (Also the code doesn't match the description).