### PR TITLE
Add a warning about using expressions in the relational API

### DIFF
--- a/docs/stable/clients/python/relational_api.md
+++ b/docs/stable/clients/python/relational_api.md
@@ -2730,15 +2730,15 @@ rel.show()
 
 This section contains the functions which can be applied to a relation to get a (scalar) result. The functions are [lazy evaluated](#lazy-evaluation).
 
->Warning These functions may take arbitrary expressions as arguments, also when the parameter is named `column`.
->Make sure to properly validate and escape input.
->```python
->import duckdb
->
->with duckdb.connect() as con:
->    rel = con.sql('select 1')
->    rel.max("(SELECT t FROM read_text('/etc/hostname') as t)")
->```
+> Warning These functions may take arbitrary expressions as arguments, also when the parameter is named `column`.
+> Make sure to properly validate and escape input.
+> ```python
+> import duckdb
+> 
+> with duckdb.connect() as con:
+>     rel = con.sql('select 1')
+>     rel.max("(select t from read_text('/etc/hostname') as t)")
+> ```
 
 | Name | Description |
 |:--|:-------|


### PR DESCRIPTION
Related to https://github.com/duckdblabs/duckdb-internal/issues/7128 and https://github.com/duckdb/duckdb-python/pull/272