### PR TITLE
docs: add Azure Blob Storage write support documentation

### DIFF
--- a/docs/stable/core_extensions/azure.md
+++ b/docs/stable/core_extensions/azure.md
@@ -7,7 +7,7 @@ redirect_from:
 title: Azure Extension
 ---
 
-The `azure` extension is a loadable extension that adds a filesystem abstraction for the [Azure Blob storage](https://azure.microsoft.com/en-us/products/storage/blobs) to DuckDB.
+The `azure` extension is a loadable extension that adds a filesystem abstraction for [Azure Blob Storage](https://azure.microsoft.com/en-us/products/storage/blobs) to DuckDB, enabling both reading and writing data.
 
 ## Installing and Loading
 
@@ -88,6 +88,31 @@ FROM 'abfss://⟨my_storage_account⟩.dfs.core.windows.net/⟨my_filesystem⟩/
 SELECT *
 FROM 'abfss://⟨my_storage_account⟩.dfs.core.windows.net/⟨my_filesystem⟩/⟨path⟩/*.csv';
 ```
+
+## Writing to Azure Blob Storage
+
+You can write data directly to Azure Blob Storage using the [`COPY` statement]({% link docs/stable/sql/statements/copy.md %}).
+
+```sql
+-- Write query results to a Parquet file
+COPY (SELECT * FROM my_table)
+TO 'az://⟨my_container⟩/⟨path⟩/output.parquet';
+```
+
+```sql
+-- Write a table to a CSV file
+COPY my_table
+TO 'az://⟨my_container⟩/⟨path⟩/output.csv';
+```
+
+You can also use fully qualified paths:
+
+```sql
+COPY my_table
+TO 'az://⟨my_storage_account⟩.blob.core.windows.net/⟨my_container⟩/⟨path⟩/output.parquet';
+```
+
+> Writing to Azure Data Lake Storage (ADLS) via `abfss://` paths is not yet supported. Only Azure Blob Storage (`az://` or `azure://`) paths support writes.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- Update introduction to mention both reading and writing capabilities.
- Add new "Writing to Azure Blob Storage" section with `COPY` statement examples.
- Document limitation: ADLS (`abfss://`) writes not yet supported, only Blob Storage (`az://`) paths.

This documents the write support added in v1.4.3 (duckdb-azure#131).

## Test plan
- [ ] Verify introduction mentions reading and writing.
- [ ] Verify write examples use consistent placeholder format.
- [ ] Verify limitation note is clear.