### PR TITLE
Add documentation for SHOW SCHEMAS statement

### DIFF
--- a/docs/preview/sql/statements/show.md
+++ b/docs/preview/sql/statements/show.md
@@ -1,6 +1,6 @@
 ---
 layout: docu
-title: SHOW and SHOW DATABASE Statements
+title: SHOW, SHOW DATABASES, and SHOW SCHEMAS Statements
 ---
 
 ## `SHOW` Statement
@@ -30,3 +30,21 @@ SHOW DATABASES;
 | database_name |
 |---------------|
 | memory        |
+
+## `SHOW SCHEMAS` Statement
+
+> This statement was introduced in DuckDB v1.5.
+
+The `SHOW SCHEMAS` statement shows a list of all schemas across non-internal databases:
+
+```sql
+SHOW SCHEMAS;
+```
+
+| database_name | schema_name        | current |
+|---------------|--------------------|---------|
+| memory        | main               | true    |
+| memory        | pg_catalog         | false   |
+| memory        | information_schema | false   |
+
+The `current` column indicates which schema is the default schema (set via the [`USE` statement]({% link docs/preview/sql/statements/use.md %})).


### PR DESCRIPTION
## Summary
- Documents the new `SHOW SCHEMAS` statement that displays all schemas across non-internal databases
- Shows output columns: `database_name`, `schema_name`, and `current`
- Added to preview docs as this feature was introduced in DuckDB v1.5

Fixes #6393