### PR TITLE
Document deprecation of recursive `UNION`s in `USING KEY` CTEs

### DIFF
--- a/docs/preview/sql/query_syntax/with.md
+++ b/docs/preview/sql/query_syntax/with.md
@@ -352,8 +352,8 @@ ORDER BY length(path), path;
 > DuckDB 1.5.0 also introduces a new setting to configure the `USING KEY` syntax.
 >
 > ```sql
-> SET using_key_syntax = 'DEFAULT';
-> SET using_key_syntax = 'UNION_AS_UNION_ALL';
+> SET deprecated_using_key_syntax = 'DEFAULT';
+> SET deprecated_using_key_syntax = 'UNION_AS_UNION_ALL';
 > ```
 >
 > Currently, `DEFAULT` enables both syntax styles, i.e., allows both recursive
@@ -364,8 +364,8 @@ ORDER BY length(path), path;
 >
 > DuckDB 1.6.0 disables the `UNION` syntax by default.
 >
-> DuckDB 1.7.0 removes the `using_key_syntax` flag and fully deprecates the
-> `UNION` syntax.
+> DuckDB 1.7.0 removes the `deprecated_using_key_syntax` flag and fully
+> deprecates the `UNION` syntax.
 
 `USING KEY` alters the behavior of a regular recursive CTE.
 


### PR DESCRIPTION
These are the relevant additions to document the deprecation of recursive `UNION`s for `USING KEY` CTEs in favor of recursive `UNION ALL`s—as discussed and implemented in https://github.com/duckdb/duckdb/pull/20689.