### PR TITLE
Update installation instructions for Arch Linux (AUR -> Extra)

### DIFF
--- a/docs/stable/dev/building/linux.md
+++ b/docs/stable/dev/building/linux.md
@@ -55,6 +55,13 @@ The following instructions are intended for Arch Linux and Arch-based distributi
 
 #### CLI Client
 
+DuckDB is [available in Arch's Extra package repository](https://archlinux.org/packages/extra/x86_64/duckdb/).
+To install it, run:
+
+```bash
+sudo pacman -S duckdb
+```
+
 The requirements for building the DuckDB CLI client on Arch, Manjaro, etc. are the following:
 
 ```bash
@@ -62,13 +69,6 @@ sudo pacman -S git gcc cmake ninja openssl
 git clone https://github.com/duckdb/duckdb
 cd duckdb
 GEN=ninja make
-```
-
-DuckDB is also [available in AUR](https://aur.archlinux.org/packages/duckdb).
-To install it, run:
-
-```bash
-yay -S duckdb
 ```
 
 ### Alpine Linux


### PR DESCRIPTION
Change installation instructions for DuckDB on Arch Linux to bring it in line with shift from AUR to Extra.