### PR TITLE
Fix Python doc generation scripts for duckdb 1.4.4

### DIFF
--- a/scripts/generate_python_docs.py
+++ b/scripts/generate_python_docs.py
@@ -69,7 +69,15 @@ def create_index_rst():
     classes = [
         {
             "name": name,
-            "rst_type": 'automethod' if not inspect.isclass(obj) else 'autoclass',
+            "rst_type": (
+                "autoclass"
+                if inspect.isclass(obj)
+                else (
+                    "autofunction"
+                    if inspect.isbuiltin(duckdb.CaseExpression)
+                    else "automethod"
+                )
+            ),
         }
         for name, obj in inspect.getmembers(duckdb)
         if inspect.isclass(obj) or inspect.isroutine(obj)
@@ -87,7 +95,7 @@ def create_index_rst():
             if cls['name'] == "DuckDBPyRelation":
                 f.write(".. include:: relation.rst\n")
             else:
-                f.write(f".. {cls['rst_type']}:: duckdb.{cls['name']}\n")
+                f.write(f".. {cls['rst_type']}:: {cls['name']}\n")
                 if cls['rst_type'] == 'autoclass':
                     f.write("   :members:\n")
                     f.write("   :show-inheritance:\n")

--- a/scripts/generate_python_relational_docs.py
+++ b/scripts/generate_python_relational_docs.py
@@ -176,12 +176,12 @@ def populate_member_details(relational_api_table, class_name, member_list, secti
             member_docs = inspect.getdoc(class_member_value).split("\n\n")
             if len(member_docs) >= 2:
                 member_signature = member_docs[0]
-                member_description = '\n'.join(member_docs[1:])
+                member_description = "\n".join(member_docs[1:])
             else:
                 member_description = member_docs[0]
 
-            if class_member_name in ['from_parquet', 'read_parquet']:
-                member_signature = '\n\n'.join(member_docs)
+            if class_member_name in ["from_parquet", "read_parquet"]:
+                member_signature = "\n\n".join(member_docs)
                 member_description = "Create a relation object from the Parquet files"
             number_of_duplicates = (
                 relational_api_table.filter(f"member_name = '{class_member_name}'")
@@ -201,7 +201,7 @@ def populate_member_details(relational_api_table, class_name, member_list, secti
                 f"```python\n{member_signature}\n```" if member_signature else None,
                 f"{member_description}{member_details.additional_description}",
                 (
-                    '\n'.join(
+                    "\n".join(
                         [
                             f"""- **{parameter.parameter_name}** : {', '.join(parameter.parameter_type)}{", default: "+parameter.parameter_default if parameter.parameter_default else ''}
                             \n\t{parameter.parameter_description}"""
@@ -234,7 +234,7 @@ def populate_member_details(relational_api_table, class_name, member_list, secti
                     else None
                 ),
                 (
-                    ', '.join(
+                    ", ".join(
                         f"[`{alias}`](#{alias})" for alias in member_details.aliases
                     )
                     if member_details.aliases
@@ -294,9 +294,9 @@ def generate_from_db(relational_api_table):
             )
             .string_agg(
                 "detailed_section",
-                sep='\n\n----\n\n',
-                groups='section, section_id',
-                projected_columns='section, section_id',
+                sep="\n\n----\n\n",
+                groups="section, section_id",
+                projected_columns="section, section_id",
             )
             .order("section_id")
         )
@@ -306,12 +306,12 @@ def generate_from_db(relational_api_table):
             f.write(SECTION_MAP.get(section[0]).get("description"))
             toc_section = (
                 relational_api_table.filter(f"section_id={section[1]}")
-                .select('section', "section_id", 'member_toc_line')
+                .select("section", "section_id", "member_toc_line")
                 .string_agg(
-                    'member_toc_line',
-                    sep='\n',
-                    groups='section, section_id',
-                    projected_columns='section, section_id',
+                    "member_toc_line",
+                    sep="\n",
+                    groups="section, section_id",
+                    projected_columns="section, section_id",
                 )
             ).fetchone()
             f.write("\n\n")
@@ -352,7 +352,7 @@ def generate_python_relational_api_md():
             member[0]
             for member in inspect.getmembers(duckdb.DuckDBPyConnection)
             if inspect.getdoc(member[1])
-            and '-> duckdb.duckdb.DuckDBPyRelation' in inspect.getdoc(member[1])
+            and "-> _duckdb.DuckDBPyRelation" in inspect.getdoc(member[1])
         ],
     )
 

--- a/scripts/generate_python_relational_docs_details.py
+++ b/scripts/generate_python_relational_docs_details.py
@@ -1361,7 +1361,7 @@ rel.apply(
         parameters=[
             PythonRelAPIParamDetails(
                 parameter_name="other_rel",
-                parameter_type=["duckdb.duckdb.DuckDBPyRelation"],
+                parameter_type=["_duckdb.DuckDBPyRelation"],
                 parameter_description="Another relation to perform a cross product with.",
             )
         ],
@@ -1382,7 +1382,7 @@ The relation query is executed twice, therefore generating different ids and tim
         parameters=[
             PythonRelAPIParamDetails(
                 parameter_name="other_rel",
-                parameter_type=["duckdb.duckdb.DuckDBPyRelation"],
+                parameter_type=["_duckdb.DuckDBPyRelation"],
                 parameter_description="The relation to subtract from the current relation (set difference).",
             )
         ],
@@ -1521,7 +1521,7 @@ therefore generating different ids and timestamps:
         parameters=[
             PythonRelAPIParamDetails(
                 parameter_name="other_rel",
-                parameter_type=["duckdb.duckdb.DuckDBPyRelation"],
+                parameter_type=["_duckdb.DuckDBPyRelation"],
                 parameter_description="The relation to intersect with the current relation (set intersection).",
             )
         ],
@@ -1612,7 +1612,7 @@ ON ((unnamed_relation_41bc15e744037078.id = unnamed_relation_307e245965aa2c2b.id
         parameters=[
             PythonRelAPIParamDetails(
                 parameter_name="other_rel",
-                parameter_type=["duckdb.duckdb.DuckDBPyRelation"],
+                parameter_type=["_duckdb.DuckDBPyRelation"],
                 parameter_description="The relation to join with the current relation.",
             ),
             PythonRelAPIParamDetails(
@@ -1780,7 +1780,7 @@ rel.map(multiply_by_2, schema={"id": int, "text": str})
         parameters=[
             PythonRelAPIParamDetails(
                 parameter_name="union_rel",
-                parameter_type=["duckdb.duckdb.DuckDBPyRelation"],
+                parameter_type=["_duckdb.DuckDBPyRelation"],
                 parameter_description="The relation to union with the current relation (set union).",
             )
         ],
@@ -3969,6 +3969,32 @@ created_timestamp: [[2025-04-10 09:24:51.259000Z,2025-04-10 09:25:51.259000Z,202
                 parameter_type=["int"],
                 parameter_default="1000000",
                 parameter_description="The batch size for fetching the data.",
+            )
+        ],
+    ),
+    "fetch_record_batch": PythonRelAPIDetails(
+        additional_description="\n\n> Deprecated `fetch_record_batch()` is deprecated since 1.4.0. Use [`record_batch()`](#record_batch) instead.",
+        example="pa_reader = rel.fetch_record_batch(rows_per_batch=1)\n\npa_reader.read_next_batch()",
+        result="""
+pyarrow.RecordBatch
+id: string
+description: string
+value: int64
+created_timestamp: timestamp[us, tz=Europe/Amsterdam]
+----
+id: ["908cf67c-a086-4b94-9017-2089a83e4a6c"]
+description: ["value is uneven"]
+value: [1]
+created_timestamp: [2025-04-10 09:52:55.249000Z]
+""",
+        use_default_example=True,
+        aliases=["record_batch"],
+        parameters=[
+            PythonRelAPIParamDetails(
+                parameter_name="rows_per_batch",
+                parameter_type=["int"],
+                parameter_default="1000000",
+                parameter_description="The number of rows per batch.",
             )
         ],
     ),

--- a/scripts/generate_python_relational_docs_methods.py
+++ b/scripts/generate_python_relational_docs_methods.py
@@ -95,6 +95,7 @@ OUTPUT_MEMBER_LIST = [
     "create_view",
     "df",
     "execute",
+    "fetch_record_batch",
     "fetch_arrow_reader",
     "fetch_arrow_table",
     "fetch_df_chunk",
@@ -118,20 +119,20 @@ OUTPUT_MEMBER_LIST = [
 ]
 
 CREATION_MEMBER_LIST = [
-    'from_arrow',
-    'from_csv_auto',
-    'from_df',
-    'from_parquet',
-    'from_query',
-    'query',
-    'read_csv',
-    'read_json',
-    'read_parquet',
-    'sql',
-    'table',
-    'table_function',
-    'values',
-    'view',
+    "from_arrow",
+    "from_csv_auto",
+    "from_df",
+    "from_parquet",
+    "from_query",
+    "query",
+    "read_csv",
+    "read_json",
+    "read_parquet",
+    "sql",
+    "table",
+    "table_function",
+    "values",
+    "view",
 ]
 
 PY_RELATION_MEMBERS = (


### PR DESCRIPTION
## Summary
- Add `fetch_record_batch` to `OUTPUT_MEMBER_LIST` and details (exists since 1.4.0, deprecated)
- Fix `duckdb.duckdb.DuckDBPyRelation` → `_duckdb.DuckDBPyRelation` in parameter descriptions and runtime docstring check
- Fix `autofunction`/`automethod` detection in `generate_python_docs.py`
- Fix Sphinx autodoc directive to not prefix with `duckdb` module
- Normalize quote style (single → double quotes)

## Test plan
- Verified scripts run without warnings against duckdb 1.4.4
- All members in 1.4.4's `DuckDBPyRelation` are accounted for