### PR TITLE
Updated Rest Catalog documentation based on recent changes

### DIFF
--- a/docs/preview/core_extensions/iceberg/iceberg_rest_catalogs.md
+++ b/docs/preview/core_extensions/iceberg/iceberg_rest_catalogs.md
@@ -298,7 +298,7 @@ ATTACH 'gs://biglake-public-nyc-taxi-iceberg' AS biglake_public (
 );
 
 -- Query the data
-SELECT COUNT(*) FROM biglake_public.public_data.nyc_taxicab;
+SELECT count(*) FROM biglake_public.public_data.nyc_taxicab;
 ```
 
 > Note: Google Cloud access tokens expire after 1 hour. For long-running sessions, you'll need to refresh the token periodically.


### PR DESCRIPTION
- Introduced `EXTRA_HTTP_HEADERS` parameter for additional HTTP headers in REST catalog requests.
- Updated limitations section to clarify supported storage backends.
- Added Biglake example with public dataset