### PR TITLE
Warn users against the use of parametrized queries in .sql

### DIFF
--- a/docs/stable/clients/python/known_issues.md
+++ b/docs/stable/clients/python/known_issues.md
@@ -80,6 +80,25 @@ Alternatively, you can instruct `pip` to compile the package from source as foll
 python3 -m pip install duckdb --no-binary duckdb
 ```
 
+### Parameterized Queries in Relational API
+
+Passing query parameters to the [`sql()`]({% link docs/stable/clients/python/relational_api.md %}#sql), [`query()`]({% link docs/stable/clients/python/relational_api.md %}#query), or [`from_query()`]({% link docs/stable/clients/python/relational_api.md %}#from_query) methods has significant performance overhead.
+There is currently no relation type in core that supports prepared statements, so parameterized queries are immediately materialized into an intermediate representation. This causes at least 5x processing overhead and nearly 2x memory usage compared to the non-parameterized path.
+
+Instead, use [`execute()`]({% link docs/stable/clients/python/dbapi.md %}#prepared-statements) for the parameterized query, then feed the result into the relational API via a [replacement scan]({% link docs/stable/clients/python/relational_api.md %}#sql):
+
+```python
+import duckdb
+
+conn = duckdb.connect()
+
+# Use execute() for the parameterized query
+df = conn.execute("SELECT * FROM my_table WHERE x = ?", [42]).df()
+
+# Use a replacement scan to continue with the relational API
+conn.sql("SELECT * FROM df WHERE y > 0").order("y").show()
+```
+
 ## Known Issues
 
 Unfortunately there are some issues that are either beyond our control or are very elusive / hard to track down.

--- a/docs/stable/clients/python/relational_api.md
+++ b/docs/stable/clients/python/relational_api.md
@@ -414,19 +414,21 @@ from_query(self: _duckdb.DuckDBPyConnection, query: object, *, alias: str = '', 
 
 Run a SQL query. If it is a SELECT statement, create a relation object from the given SQL query, otherwise run the query as-is.
 
+> **Warning.** Passing `params` to this method is [discouraged]({% link docs/stable/clients/python/known_issues.md %}#parameterized-queries-in-relational-api) due to significant performance overhead. Use [`execute()`]({% link docs/stable/clients/python/dbapi.md %}#prepared-statements) for parameterized queries instead.
+
 **Aliases**: [`query`](#query), [`sql`](#sql)
 
 ##### Parameters
 
 - **query** : object
-                            
+
 	The SQL query or subquery to be executed and converted into a relation.
 - **alias** : str, default: ''
-                            
+
 	Optional alias name to assign to the resulting relation.
 - **params** : object
-                            
-	Optional query parameters to be used in the SQL query.
+
+	Optional query parameters. **Discouraged** due to [significant performance overhead]({% link docs/stable/clients/python/known_issues.md %}#parameterized-queries-in-relational-api). Use [`execute()`]({% link docs/stable/clients/python/dbapi.md %}#prepared-statements) for parameterized queries instead.
 
 ##### Example
 
@@ -465,19 +467,21 @@ query(self: _duckdb.DuckDBPyConnection, query: object, *, alias: str = '', param
 
 Run a SQL query. If it is a SELECT statement, create a relation object from the given SQL query, otherwise run the query as-is.
 
+> **Warning.** Passing `params` to this method is [discouraged]({% link docs/stable/clients/python/known_issues.md %}#parameterized-queries-in-relational-api) due to significant performance overhead. Use [`execute()`]({% link docs/stable/clients/python/dbapi.md %}#prepared-statements) for parameterized queries instead.
+
 **Aliases**: [`from_query`](#from_query), [`sql`](#sql)
 
 ##### Parameters
 
 - **query** : object
-                            
+
 	The SQL query or subquery to be executed and converted into a relation.
 - **alias** : str, default: ''
-                            
+
 	Optional alias name to assign to the resulting relation.
 - **params** : object
-                            
-	Optional query parameters to be used in the SQL query.
+
+	Optional query parameters. **Discouraged** due to [significant performance overhead]({% link docs/stable/clients/python/known_issues.md %}#parameterized-queries-in-relational-api). Use [`execute()`]({% link docs/stable/clients/python/dbapi.md %}#prepared-statements) for parameterized queries instead.
 
 ##### Example
 
@@ -863,19 +867,21 @@ sql(self: _duckdb.DuckDBPyConnection, query: object, *, alias: str = '', params:
 
 Run a SQL query. If it is a SELECT statement, create a relation object from the given SQL query, otherwise run the query as-is.
 
+> **Warning.** Passing `params` to this method is [discouraged]({% link docs/stable/clients/python/known_issues.md %}#parameterized-queries-in-relational-api) due to significant performance overhead. Use [`execute()`]({% link docs/stable/clients/python/dbapi.md %}#prepared-statements) for parameterized queries instead.
+
 **Aliases**: [`from_query`](#from_query), [`query`](#query)
 
 ##### Parameters
 
 - **query** : object
-                            
+
 	The SQL query or subquery to be executed and converted into a relation.
 - **alias** : str, default: ''
-                            
+
 	Optional alias name to assign to the resulting relation.
 - **params** : object
-                            
-	Optional query parameters to be used in the SQL query.
+
+	Optional query parameters. **Discouraged** due to [significant performance overhead]({% link docs/stable/clients/python/known_issues.md %}#parameterized-queries-in-relational-api). Use [`execute()`]({% link docs/stable/clients/python/dbapi.md %}#prepared-statements) for parameterized queries instead.
 
 ##### Example
 

--- a/scripts/generate_python_relational_docs_details.py
+++ b/scripts/generate_python_relational_docs_details.py
@@ -439,6 +439,9 @@ rel.show()
         ],
     ),
     "from_query": PythonRelAPIDetails(
+        additional_description="""
+
+> **Warning.** Passing `params` to this method is [discouraged]({% link docs/stable/clients/python/known_issues.md %}#parameterized-queries-in-relational-api) due to significant performance overhead. Use [`execute()`]({% link docs/stable/clients/python/dbapi.md %}#prepared-statements) for parameterized queries instead.""",
         example="""
 import duckdb
 
@@ -473,11 +476,14 @@ rel.show()
             PythonRelAPIParamDetails(
                 parameter_name="params",
                 parameter_type=["object"],
-                parameter_description="Optional query parameters to be used in the SQL query.",
+                parameter_description="Optional query parameters. **Discouraged** due to [significant performance overhead]({% link docs/stable/clients/python/known_issues.md %}#parameterized-queries-in-relational-api). Use [`execute()`]({% link docs/stable/clients/python/dbapi.md %}#prepared-statements) for parameterized queries instead.",
             ),
         ],
     ),
     "query": PythonRelAPIDetails(
+        additional_description="""
+
+> **Warning.** Passing `params` to this method is [discouraged]({% link docs/stable/clients/python/known_issues.md %}#parameterized-queries-in-relational-api) due to significant performance overhead. Use [`execute()`]({% link docs/stable/clients/python/dbapi.md %}#prepared-statements) for parameterized queries instead.""",
         example="""
 import duckdb
 
@@ -512,7 +518,7 @@ rel.show()
             PythonRelAPIParamDetails(
                 parameter_name="params",
                 parameter_type=["object"],
-                parameter_description="Optional query parameters to be used in the SQL query.",
+                parameter_description="Optional query parameters. **Discouraged** due to [significant performance overhead]({% link docs/stable/clients/python/known_issues.md %}#parameterized-queries-in-relational-api). Use [`execute()`]({% link docs/stable/clients/python/dbapi.md %}#prepared-statements) for parameterized queries instead.",
             ),
         ],
     ),
@@ -970,6 +976,9 @@ rel.show()
         ],
     ),
     "sql": PythonRelAPIDetails(
+        additional_description="""
+
+> **Warning.** Passing `params` to this method is [discouraged]({% link docs/stable/clients/python/known_issues.md %}#parameterized-queries-in-relational-api) due to significant performance overhead. Use [`execute()`]({% link docs/stable/clients/python/dbapi.md %}#prepared-statements) for parameterized queries instead.""",
         example="""
 import duckdb
 
@@ -1004,7 +1013,7 @@ rel.show()
             PythonRelAPIParamDetails(
                 parameter_name="params",
                 parameter_type=["object"],
-                parameter_description="Optional query parameters to be used in the SQL query.",
+                parameter_description="Optional query parameters. **Discouraged** due to [significant performance overhead]({% link docs/stable/clients/python/known_issues.md %}#parameterized-queries-in-relational-api). Use [`execute()`]({% link docs/stable/clients/python/dbapi.md %}#prepared-statements) for parameterized queries instead.",
             ),
         ],
     ),


### PR DESCRIPTION
Related to https://github.com/duckdb/duckdb-python/issues/238#issuecomment-3884098644

The performance of .sql with parameterized queries is so poor that we should discourage users from using it, and point them towards `.execute()` + replacement scan instead.