### PR TITLE
Apply the deprecation of `UNION` in `USING KEY` CTEs to Docs

### DIFF
--- a/docs/preview/sql/query_syntax/with.md
+++ b/docs/preview/sql/query_syntax/with.md
@@ -387,7 +387,7 @@ This will overwrite the old payload `4` with the new payload `3`.
 WITH RECURSIVE tbl(a, b) USING KEY (a) AS (
     SELECT a, b
     FROM (VALUES (1, 3), (2, 4)) t(a, b)
-        UNION
+        UNION ALL
     SELECT a + 1, b
     FROM tbl
     WHERE a < 3
@@ -409,7 +409,7 @@ You can use the `VALUES` clause for the initial (anchor) part of the CTE:
 ```sql
 WITH RECURSIVE tbl(a, b) USING KEY (a) AS (
     VALUES (1, 3), (2, 4)
-        UNION
+        UNION ALL
     SELECT a + 1, b
     FROM tbl
     WHERE a < 3
@@ -439,7 +439,7 @@ INSERT INTO edges VALUES
 WITH RECURSIVE connected_components(id, comp) USING KEY (id) AS (
     SELECT n.id, n.id AS comp
     FROM nodes AS n
-        UNION (
+        UNION ALL (
     SELECT DISTINCT ON (previous_iter.id) previous_iter.id, initial_iter.comp
     FROM 
         recurring.connected_components AS previous_iter,


### PR DESCRIPTION
In #6458, I forgot to also switch the `USING KEY` examples in docs to using recursive `UNION ALL`s. Showing the deprecated recursive `UNION`s immediately after the big bold deprecation warning feels out of place to me.