### PR TITLE
Update .prompt command to show current database

### DIFF
--- a/docs/preview/clients/cli/overview.md
+++ b/docs/preview/clients/cli/overview.md
@@ -204,8 +204,14 @@ As an example, a file in the same directory as the DuckDB CLI named `prompt.sql`
 Note that the duck head is built with Unicode characters and does not work in all terminal environments (e.g., in Windows, unless running with WSL and using the Windows Terminal).
 
 ```text
-.prompt '⚫◗ '
+.prompt "{color:yellow1}{sql:select current_database()} ⚫◗ "
 ```
+
+Or a simpler version without colours:
+```sql
+.prompt "{sql:select current_database()} ⚫◗ "
+```
+
 
 To invoke that file on initialization, use this command:
 


### PR DESCRIPTION
Noticed that with the `.prompt` command you now lose the useful information showing the current active database. Thought it would nice to add that in. Also played around with the colors and I think `yellow1` is closest to DuckDB's color. 
```
.prompt "{color:yellow1}{sql:select current_database()} ⚫◗ "
```

<img width="113" height="30" alt="afbeelding" src="https://github.com/user-attachments/assets/b3c09de5-600f-4479-b44c-efbcc94139e6" />
