### PR TITLE
Fix struct_update code example to use the struct_update function

### DIFF
--- a/docs/stable/sql/functions/struct.md
+++ b/docs/stable/sql/functions/struct.md
@@ -126,5 +126,5 @@ title: Struct Functions
 <div class="nostroke_table"></div>
 
 | **Description** | Add or update field(s) of an existing `STRUCT`. |
-| **Example** | `struct_insert({'a': 1, 'b': 2}, b := 3, c := 4)` |
+| **Example** | `struct_update({'a': 1, 'b': 2}, b := 3, c := 4)` |
 | **Result** | `{'a': 1, 'b': 3, 'c': 4}` |


### PR DESCRIPTION
Updating the code example.

Previously this accidentally invoked struct_insert in the example.

I checked the guidelines but did not see this documentation being auto generated. <https://github.com/duckdb/duckdb-web/blob/a787d0830d5d74221b8ad68cbfdddbefb860d8cc/CONTRIBUTING.md#generated-sql-function-lists>
Sorry if I missed anything.