### PR TITLE
docs: fix version annotation for enable_profiling() table functions

### DIFF
--- a/docs/current/dev/profiling.md
+++ b/docs/current/dev/profiling.md
@@ -57,7 +57,7 @@ For more information, see the [“Profiling”]({% link docs/current/configurati
 
 ## Table Functions
 
-> These table functions were introduced in DuckDB v1.4.2.
+> These table functions were introduced in DuckDB v1.5.0.
 
 DuckDB provides table functions to enable and disable profiling, consolidating multiple settings into a single call.
 


### PR DESCRIPTION
## Summary

The profiling docs stated that the `enable_profiling()` and `disable_profiling()` table functions were introduced in **v1.4.2**. This is incorrect.

Verified against the [`duckdb/duckdb`](https://github.com/duckdb/duckdb) source repo:
* `enable_profiling.cpp` does **not** exist in the `v1.4.4` tag
* The function was added in the v1.5.0 release cycle via duckdb/duckdb#20151 ([Profiling] Add enable_profiling() Table Function by @maiadegraaf)

Updated the version annotation from `v1.4.2` → `v1.5.0`.

## Test plan

- [x] Confirmed `enable_profiling.cpp` is absent from the `v1.4.4` tag in duckdb/duckdb
- [x] Confirmed `enable_profiling.cpp` is present in the `v1.5.0` tag in duckdb/duckdb
- [x] Confirmed the addition in the v1.5.0 release notes: duckdb/duckdb#20151

🤖 Generated with [Claude Code](https://claude.com/claude-code)