### PR TITLE
ODBC extension: add a warning about lazy eval

### DIFF
--- a/docs/current/core_extensions/odbc/functions.md
+++ b/docs/current/core_extensions/odbc/functions.md
@@ -148,6 +148,13 @@ odbc_copy(conn_string VARCHAR, [, <optional named parameters>]) -> TABLE
 
 Copies rows from a DuckDB accessible file or table into the remote DB.
 
+> Warning Using `odbc_copy` from [Python Relational API](../../clients/python/relational_api)
+> 
+> `odbc_copy` is a table function that [returns](#returns-5) one row for each 2048 copied rows.
+> When it is used from Python with `duckdb.sql()` the [Lazy Evaluation](../../clients/python/relational_api#lazy-evaluation)
+> is taking place. Thus no rows will be copied until [a method that triggers execution](../../clients/python/relational_api#output)
+> is called on the resulting relation and all result rows are consumed.
+
 #### Parameters:
 
  - `conn_handle_or_string` (`BIGINT` or `VARCHAR`), one of:

--- a/docs/current/core_extensions/odbc/functions.md
+++ b/docs/current/core_extensions/odbc/functions.md
@@ -148,11 +148,11 @@ odbc_copy(conn_string VARCHAR, [, <optional named parameters>]) -> TABLE
 
 Copies rows from a DuckDB accessible file or table into the remote DB.
 
-> Warning Using `odbc_copy` from [Python Relational API](../../clients/python/relational_api)
-> 
+> Warning Using `odbc_copy` from [Python Relational API]({% link docs/current/clients/python/relational_api.md %}).
+>
 > `odbc_copy` is a table function that [returns](#returns-5) one row for each 2048 copied rows.
-> When it is used from Python with `duckdb.sql()` the [Lazy Evaluation](../../clients/python/relational_api#lazy-evaluation)
-> is taking place. Thus no rows will be copied until [a method that triggers execution](../../clients/python/relational_api#output)
+> When it is used from Python with `duckdb.sql()` the [Lazy Evaluation]({% link docs/current/clients/python/relational_api.md %}#lazy-evaluation)
+> is taking place. Thus no rows will be copied until [a method that triggers execution]({% link docs/current/clients/python/relational_api.md %}#output)
 > is called on the resulting relation and all result rows are consumed.
 
 #### Parameters:


### PR DESCRIPTION
This PR adds a warning to `odbc_copy` about its usage with Python Relational API.