### PR TITLE
Add DST transition documentation for TIMESTAMPTZ

### DIFF
--- a/docs/current/sql/functions/timestamptz.md
+++ b/docs/current/sql/functions/timestamptz.md
@@ -489,3 +489,4 @@ Example:
 SET timezone = 'Europe/Amsterdam';
 
 SELECT TIMESTAMPTZ '2025-03-29 02:30:00+01' + INTERVAL '1 day';
+```


### PR DESCRIPTION
Fixes #20845

This PR adds documentation describing how DuckDB handles daylight saving
time (DST) transitions when adding calendar intervals to `TIMESTAMPTZ`
values.

During DST transitions, certain local timestamps may not exist. DuckDB
follows PostgreSQL behavior and adjusts the resulting timestamp forward
to the next valid time.

An example demonstrating this behavior has been added to the
`timestamptz` documentation.
