### PR TITLE
update search index to process all blog posts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,9 @@ scripts/lint.sh
 # Auto-fix lint issues
 scripts/lint.sh -f
 
+# Run black manually (always use --skip-string-normalization)
+black --skip-string-normalization <file>
+
 # Run DuckDB queries (use the CLI, not Python)
 duckdb -c "SELECT 42"
 

--- a/scripts/generate_search_index.py
+++ b/scripts/generate_search_index.py
@@ -287,6 +287,119 @@ def collect_chunks(docs_dir, version):
 
 
 # ---------------------------------------------------------------------------
+# Blog post processing
+# ---------------------------------------------------------------------------
+
+
+def blog_url_from_filename(filename):
+    """Derive the Jekyll blog URL from a post filename.
+
+    e.g. 2024-06-03-announcing-duckdb-110.md -> /2024/06/03/announcing-duckdb-110
+    """
+    name = filename.removesuffix(".md")
+    match = re.match(r"(\d{4})-(\d{2})-(\d{2})-(.+)", name)
+    if not match:
+        return None
+    year, month, day, slug = match.groups()
+    return f"/{year}/{month}/{day}/{slug}"
+
+
+def process_blog_post(filepath):
+    """Parse a blog post and return chunks (split by H2)."""
+    with open(filepath, "r") as f:
+        post = frontmatter.load(f)
+
+    title = post.get("title", "")
+    if not title:
+        return []
+
+    filename = os.path.basename(filepath)
+    url = blog_url_from_filename(filename)
+    if not url:
+        return []
+
+    body = post.content
+    breadcrumb = "Blog"
+    slug = url.lstrip("/")
+
+    chunks = []
+    seen_anchors = {}
+
+    # Split on ## headings
+    parts = re.split(r"^(##)\s+(.+)$", body, flags=re.MULTILINE)
+
+    intro = parts[0].strip()
+
+    # No H2 headings — single chunk for the whole post
+    if len(parts) == 1:
+        chunks.append(
+            {
+                "chunk_id": f"blog/{slug}",
+                "page_title": title,
+                "section": None,
+                "breadcrumb": breadcrumb,
+                "url": url,
+                "version": "blog",
+                "text": body.strip(),
+            }
+        )
+        return chunks
+
+    # Intro chunk
+    if intro:
+        chunks.append(
+            {
+                "chunk_id": f"blog/{slug}",
+                "page_title": title,
+                "section": None,
+                "breadcrumb": breadcrumb,
+                "url": url,
+                "version": "blog",
+                "text": intro,
+            }
+        )
+
+    # H2 sections
+    i = 1
+    while i < len(parts):
+        _marker = parts[i]
+        heading = parts[i + 1].strip()
+        content = parts[i + 2].strip() if i + 2 < len(parts) else ""
+        i += 3
+
+        anchor = make_unique_anchor(slugify(heading), seen_anchors)
+        text = f"## {heading}\n\n{content}" if content else f"## {heading}"
+
+        chunks.append(
+            {
+                "chunk_id": f"blog/{slug}#{anchor}",
+                "page_title": title,
+                "section": heading,
+                "breadcrumb": breadcrumb,
+                "url": f"{url}#{anchor}",
+                "version": "blog",
+                "text": text,
+            }
+        )
+
+    return chunks
+
+
+def collect_blog_chunks(posts_dir):
+    """Collect chunks from all blog posts."""
+    chunks = []
+    for fname in sorted(os.listdir(posts_dir)):
+        if not fname.endswith(".md"):
+            continue
+        filepath = os.path.join(posts_dir, fname)
+        try:
+            chunks.extend(process_blog_post(filepath))
+        except Exception as e:
+            print(f"  Warning: failed to process blog post {fname}: {e}")
+    return chunks
+
+
+# ---------------------------------------------------------------------------
 # DuckDB index building
 # ---------------------------------------------------------------------------
 
@@ -426,6 +539,16 @@ def main():
         chunks = collect_chunks(docs_dir, version)
         print(f"  {len(chunks)} chunks from {version}")
         all_chunks.extend(chunks)
+
+    # Blog posts
+    posts_dir = "_posts"
+    if os.path.isdir(posts_dir):
+        print("Processing blog posts...")
+        blog_chunks = collect_blog_chunks(posts_dir)
+        print(f"  {len(blog_chunks)} chunks from blog")
+        all_chunks.extend(blog_chunks)
+    else:
+        print("Skipping blog: _posts/ not found")
 
     if not all_chunks:
         print("No chunks found — nothing to build")


### PR DESCRIPTION
## Summary

* Index blog posts (`_posts/*.md`) in the DuckDB search index alongside docs
* Blog posts are chunked by H2 sections, matching the strategy used for conceptual doc pages
* Adds 760 chunks from 127 blog posts

## Querying blog posts

```sql
LOAD fts;

-- Full-text search across blog posts only
SELECT chunk_id, page_title, section, url, round(score, 2) AS score
FROM (
    SELECT *,
           fts_main_docs_chunks.match_bm25(chunk_id, 'parquet performance') AS score
    FROM docs_chunks
    WHERE version = 'blog'
)
WHERE score IS NOT NULL
ORDER BY score DESC
LIMIT 5;

-- Search across everything (docs + blog)
SELECT chunk_id, page_title, version, round(score, 2) AS score
FROM (
    SELECT *,
           fts_main_docs_chunks.match_bm25(chunk_id, 'window functions') AS score
    FROM docs_chunks
)
WHERE score IS NOT NULL
ORDER BY score DESC
LIMIT 10;
```

## Test plan

* [x] `python scripts/generate_search_index.py --validate` passes
* [x] Blog-specific FTS queries return relevant results
* [x] `scripts/lint.sh` passes