### PR TITLE
docs: add BananaPi F3 (RISC-V) to DuckDB Everywhere

### DIFF
--- a/_everywhere/bananapi-f3.md
+++ b/_everywhere/bananapi-f3.md
@@ -7,7 +7,7 @@ thumb: "/images/everywhere/thumbs/bananapi-f3.jpg"
 image: "/images/everywhere/thumbs/bananapi-f3.jpg"
 excerpt: ""
 tags: ["Single-board computers"]
-thirdparty: false
+thirdparty: true
 ---
 
 DuckDB runs natively on the BananaPi F3, a $100 RISC-V single-board computer powered by the SpacemiT K1 SoC (8 cores @ 1.6 GHz, rv64gc, 16 GB RAM).


### PR DESCRIPTION
Add the BananaPi F3 to the DuckDB Everywhere page, using the thumbnail @szarnyasg created at `/images/everywhere/thumbs/bananapi-f3.jpg`.

The BananaPi F3 is a $100 RISC-V single-board computer (SpacemiT K1, 8 cores, 16 GB RAM). DuckDB builds and runs SQL queries natively on it, verified on real hardware.

Follow-up to the docs PR #6631 (build instructions) and as suggested in duckdb/duckdb#21496.