### PR TITLE
Generate Metric Documentation

### DIFF
--- a/_data/menu_docs_current.json
+++ b/_data/menu_docs_current.json
@@ -1731,6 +1731,10 @@
               "url": "release_cycle"
             },
             {
+              "page": "Metrics",
+              "url": "metrics"
+            },
+            {
               "page": "Profiling",
               "url": "profiling"
             },

--- a/docs/current/dev/metrics.md
+++ b/docs/current/dev/metrics.md
@@ -18,7 +18,7 @@ The table below describes each metric and which nodes they are available for.
 
 Other than `OPERATOR_TYPE`, all metrics can be turned on or off.
 
-# All Metrics
+## All Metrics
 
 | Name                                                                  | Group                                 | Description                                                                |
 |-----------------------------------------------------------------------|---------------------------------------|----------------------------------------------------------------------------|
@@ -58,7 +58,9 @@ Other than `OPERATOR_TYPE`, all metrics can be turned on or off.
 | [`OPERATOR_TYPE`](#operator_type)                                     | [operator](#operator-metrics)         | Type of the operator                                                       |
 
 
-# Metric Groups:
+
+## Metric Groups
+
 The metrics are organized into groups, which can be used to enable or disable related metrics together.
 The following is a list of the available metric groups:
 - `ALL`: All metrics
@@ -70,8 +72,11 @@ The following is a list of the available metric groups:
 - [`OPTIMIZER`](#optimizer-metrics)
 - [`PHASE_TIMING`](#phase_timing-metrics)
 
-## Core Metrics
+
+### Core Metrics
+
 core metrics
+
 
 #### `CPU_TIME`
 
@@ -83,8 +88,16 @@ core metrics
 | **Default** | ✅ |
 | **Query Node** | ✅ |
 | **Operator Node** | ✅ |
-| **[Cumulative](#cumulative_metrics)** | ✅ |
+| **[Cumulative](#cumulative-metrics)** | ✅ |
 | **Child** | OPERATOR_TIMING |
+
+**Note:**
+
+`CPU_TIME` measures the cumulative operator timings.
+It does not include time spent in other stages, like parsing, query planning, etc.
+Thus, for some queries, the `LATENCY` in the `QUERY_ROOT` can be greater than the `CPU_TIME`.
+
+
 
 #### `CUMULATIVE_CARDINALITY`
 
@@ -96,8 +109,9 @@ core metrics
 | **Default** | ✅ |
 | **Query Node** | ✅ |
 | **Operator Node** | ✅ |
-| **[Cumulative](#cumulative_metrics)** | ✅ |
+| **[Cumulative](#cumulative-metrics)** | ✅ |
 | **Child** | OPERATOR_CARDINALITY |
+
 
 #### `CUMULATIVE_ROWS_SCANNED`
 
@@ -109,8 +123,9 @@ core metrics
 | **Default** | ✅ |
 | **Query Node** | ✅ |
 | **Operator Node** | ✅ |
-| **[Cumulative](#cumulative_metrics)** | ✅ |
+| **[Cumulative](#cumulative-metrics)** | ✅ |
 | **Child** | OPERATOR_ROWS_SCANNED |
+
 
 #### `EXTRA_INFO`
 
@@ -122,6 +137,7 @@ core metrics
 | **Query Node** | ✅ |
 | **Operator Node** | ✅ |
 
+
 #### `LATENCY`
 
 <div class="nostroke_table"></div>
@@ -132,6 +148,7 @@ core metrics
 | **Default** | ✅ |
 | **Query Node** | ✅ |
 
+
 #### `QUERY_NAME`
 
 <div class="nostroke_table"></div>
@@ -140,6 +157,7 @@ core metrics
 | **Type** | string |
 | **Default** | ✅ |
 | **Query Node** | ✅ |
+
 
 #### `RESULT_SET_SIZE`
 
@@ -153,6 +171,7 @@ core metrics
 | **Operator Node** | ✅ |
 | **Child** | RESULT_SET_SIZE |
 
+
 #### `ROWS_RETURNED`
 
 <div class="nostroke_table"></div>
@@ -164,8 +183,11 @@ core metrics
 | **Query Node** | ✅ |
 | **Child** | OPERATOR_CARDINALITY |
 
-## Execution Metrics
+
+### Execution Metrics
+
 Metrics that are collected during query execution
+
 
 #### `BLOCKED_THREAD_TIME`
 
@@ -176,6 +198,7 @@ Metrics that are collected during query execution
 | **Unit** | seconds |
 | **Default** | ✅ |
 | **Query Node** | ✅ |
+
 
 #### `SYSTEM_PEAK_BUFFER_MEMORY`
 
@@ -188,6 +211,7 @@ Metrics that are collected during query execution
 | **Query Node** | ✅ |
 | **Operator Node** | ✅ |
 
+
 #### `SYSTEM_PEAK_TEMP_DIR_SIZE`
 
 <div class="nostroke_table"></div>
@@ -199,6 +223,7 @@ Metrics that are collected during query execution
 | **Query Node** | ✅ |
 | **Operator Node** | ✅ |
 
+
 #### `TOTAL_MEMORY_ALLOCATED`
 
 <div class="nostroke_table"></div>
@@ -209,8 +234,11 @@ Metrics that are collected during query execution
 | **Default** | ✅ |
 | **Query Node** | ✅ |
 
-## File Metrics
+
+### File Metrics
+
 metrics that are collected during file operations
+
 
 #### `ATTACH_LOAD_STORAGE_LATENCY`
 
@@ -222,6 +250,7 @@ metrics that are collected during file operations
 | **Default** | ✅ |
 | **Query Node** | ✅ |
 
+
 #### `ATTACH_REPLAY_WAL_LATENCY`
 
 <div class="nostroke_table"></div>
@@ -231,6 +260,7 @@ metrics that are collected during file operations
 | **Unit** | seconds |
 | **Default** | ✅ |
 | **Query Node** | ✅ |
+
 
 #### `CHECKPOINT_LATENCY`
 
@@ -242,6 +272,7 @@ metrics that are collected during file operations
 | **Default** | ✅ |
 | **Query Node** | ✅ |
 
+
 #### `COMMIT_LOCAL_STORAGE_LATENCY`
 
 <div class="nostroke_table"></div>
@@ -251,6 +282,7 @@ metrics that are collected during file operations
 | **Unit** | seconds |
 | **Default** | ✅ |
 | **Query Node** | ✅ |
+
 
 #### `TOTAL_BYTES_READ`
 
@@ -262,6 +294,7 @@ metrics that are collected during file operations
 | **Default** | ✅ |
 | **Query Node** | ✅ |
 
+
 #### `TOTAL_BYTES_WRITTEN`
 
 <div class="nostroke_table"></div>
@@ -271,6 +304,7 @@ metrics that are collected during file operations
 | **Unit** | bytes |
 | **Default** | ✅ |
 | **Query Node** | ✅ |
+
 
 #### `WAITING_TO_ATTACH_LATENCY`
 
@@ -282,6 +316,7 @@ metrics that are collected during file operations
 | **Default** | ✅ |
 | **Query Node** | ✅ |
 
+
 #### `WAL_REPLAY_ENTRY_COUNT`
 
 <div class="nostroke_table"></div>
@@ -291,6 +326,7 @@ metrics that are collected during file operations
 | **Unit** | absolute |
 | **Default** | ✅ |
 | **Query Node** | ✅ |
+
 
 #### `WRITE_TO_WAL_LATENCY`
 
@@ -302,8 +338,11 @@ metrics that are collected during file operations
 | **Default** | ✅ |
 | **Query Node** | ✅ |
 
-## Operator Metrics
+
+### Operator Metrics
+
 metrics that are collected for each operator
+
 
 #### `OPERATOR_CARDINALITY`
 
@@ -315,6 +354,7 @@ metrics that are collected for each operator
 | **Default** | ✅ |
 | **Operator Node** | ✅ |
 
+
 #### `OPERATOR_NAME`
 
 <div class="nostroke_table"></div>
@@ -323,6 +363,7 @@ metrics that are collected for each operator
 | **Type** | string |
 | **Default** | ✅ |
 | **Operator Node** | ✅ |
+
 
 #### `OPERATOR_ROWS_SCANNED`
 
@@ -334,6 +375,7 @@ metrics that are collected for each operator
 | **Default** | ✅ |
 | **Operator Node** | ✅ |
 
+
 #### `OPERATOR_TIMING`
 
 <div class="nostroke_table"></div>
@@ -344,6 +386,7 @@ metrics that are collected for each operator
 | **Default** | ✅ |
 | **Operator Node** | ✅ |
 
+
 #### `OPERATOR_TYPE`
 
 <div class="nostroke_table"></div>
@@ -353,8 +396,31 @@ metrics that are collected for each operator
 | **Default** | ✅ |
 | **Operator Node** | ✅ |
 
-## Phase_timing Metrics
+
+### Phase_timing Metrics
+
 This group contains metrics related to the planner and the physical planner. The planner is responsible for generating the logical plan, whereas the physical planner is responsible for generating the physical plan from the logical plan.
+
+
+#### `ALL_OPTIMIZERS`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Enables all optimizers |
+| **Type** | double |
+| **Query Node** | ✅ |
+
+
+#### `CUMULATIVE_OPTIMIZER_TIMING`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Time spent in all optimizers |
+| **Type** | double |
+| **Unit** | milliseconds |
+| **Query Node** | ✅ |
+| **[Cumulative](#cumulative-metrics)** | ✅ |
+
 
 #### `PHYSICAL_PLANNER`
 
@@ -365,6 +431,7 @@ This group contains metrics related to the planner and the physical planner. The
 | **Unit** | milliseconds |
 | **Query Node** | ✅ |
 
+
 #### `PHYSICAL_PLANNER_COLUMN_BINDING`
 
 <div class="nostroke_table"></div>
@@ -373,6 +440,7 @@ This group contains metrics related to the planner and the physical planner. The
 | **Type** | double |
 | **Unit** | milliseconds |
 | **Query Node** | ✅ |
+
 
 #### `PHYSICAL_PLANNER_CREATE_PLAN`
 
@@ -383,6 +451,7 @@ This group contains metrics related to the planner and the physical planner. The
 | **Unit** | milliseconds |
 | **Query Node** | ✅ |
 
+
 #### `PHYSICAL_PLANNER_RESOLVE_TYPES`
 
 <div class="nostroke_table"></div>
@@ -392,6 +461,7 @@ This group contains metrics related to the planner and the physical planner. The
 | **Unit** | milliseconds |
 | **Query Node** | ✅ |
 
+
 #### `PLANNER`
 
 <div class="nostroke_table"></div>
@@ -400,6 +470,7 @@ This group contains metrics related to the planner and the physical planner. The
 | **Type** | double |
 | **Unit** | milliseconds |
 | **Query Node** | ✅ |
+
 
 #### `PLANNER_BINDING`
 
@@ -411,7 +482,9 @@ This group contains metrics related to the planner and the physical planner. The
 | **Query Node** | ✅ |
 
 
-## Optimizer Metrics
+
+### Optimizer Metrics
+
 Optimizer metrics sit at the `QUERY_ROOT` level, and measure the time taken by each [optimizer]({% link docs/current/internals/overview.md %}#optimizer).
 These metrics are only available when the specific optimizer is enabled.
 The available optimizations can be queried using the [`duckdb_optimizers()`{:.language-sql .highlight} table function]({% link docs/current/sql/meta/duckdb_table_functions.md %}#duckdb_optimizers).
@@ -420,42 +493,131 @@ Each optimizer has a corresponding metric that follows the template: `OPTIMIZER_
 For example, the `OPTIMIZER_JOIN_ORDER` metric corresponds to the `JOIN_ORDER` optimizer.
 
 Additionally, the following metrics are available to support the optimizer metrics:
-
-#### `ALL_OPTIMIZERS`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Enables all optimizers |
-| **Type** | double |
-| **Query Node** | ✅ |
-
-#### `CUMULATIVE_OPTIMIZER_TIMING`
-
-<div class="nostroke_table"></div>
-
-| **Description** | Time spent in all optimizers |
-| **Type** | double |
-| **Unit** | milliseconds |
-| **Query Node** | ✅ |
+- [`ALL_OPTIMIZERS`](#all_optimizers)
+- [`CUMULATIVE_OPTIMIZER_TIMING`](#cumulative_optimizer_timing)
 
 
-# Cumulative Metrics
+## Cumulative Metrics
 
 DuckDB also supports several cumulative metrics that are available in all nodes.
 In the `QUERY_ROOT` node, these metrics represent the sum of the corresponding metrics across all operators in the query.
 The `OPERATOR` nodes represent the sum of the operator's specific metric and those of all its children recursively.
 
 These cumulative metrics can be enabled independently, even if the underlying specific metrics are disabled.
-The table below shows the cumulative metrics.
-It also depicts the metric based on which DuckDB calculates the cumulative metric.
 
-| Metric                    | Unit     | Metric calculated cumulatively |
-|---------------------------|----------|--------------------------------|
-| `CPU_TIME`                | seconds  | `OPERATOR_TIMING`              |
-| `CUMULATIVE_CARDINALITY`  | absolute | `OPERATOR_CARDINALITY`         |
-| `CUMULATIVE_ROWS_SCANNED` | absolute | `OPERATOR_ROWS_SCANNED`        |
+The following is a list of the available cumulative metrics:
+- [`CPU_TIME`](#cpu_time)
+- [`CUMULATIVE_CARDINALITY`](#cumulative_cardinality)
+- [`CUMULATIVE_ROWS_SCANNED`](#cumulative_rows_scanned)
+- [`CUMULATIVE_OPTIMIZER_TIMING`](#cumulative_optimizer_timing)
 
-`CPU_TIME` measures the cumulative operator timings.
-It does not include time spent in other stages, like parsing, query planning, etc.
-Thus, for some queries, the `LATENCY` in the `QUERY_ROOT` can be greater than the `CPU_TIME`.
 
+## Examples
+
+The following examples demonstrate how to enable custom profiling and set the output format to `json`.
+In the first example, we enable profiling and set the output to a file.
+We only enable `EXTRA_INFO`, `OPERATOR_CARDINALITY`, and `OPERATOR_TIMING`.
+
+```sql
+CREATE TABLE students (name VARCHAR, sid INTEGER);
+CREATE TABLE exams (eid INTEGER, subject VARCHAR, sid INTEGER);
+INSERT INTO students VALUES ('Mark', 1), ('Joe', 2), ('Matthew', 3);
+INSERT INTO exams VALUES (10, 'Physics', 1), (20, 'Chemistry', 2), (30, 'Literature', 3);
+
+PRAGMA enable_profiling = 'json';
+PRAGMA profiling_output = '/path/to/file.json';
+
+PRAGMA configure_profiling = '{"CPU_TIME": "false", "EXTRA_INFO": "true", "OPERATOR_CARDINALITY": "true", "OPERATOR_TIMING": "true"}';
+
+SELECT name
+FROM students
+JOIN exams USING (sid)
+WHERE name LIKE 'Ma%';
+```
+
+The file's content after executing the query:
+
+```json
+{
+    "extra_info": {},
+    "query_name": "SELECT name\nFROM students\nJOIN exams USING (sid)\nWHERE name LIKE 'Ma%';",
+    "children": [
+        {
+            "operator_timing": 0.000001,
+            "operator_cardinality": 2,
+            "operator_type": "PROJECTION",
+            "extra_info": {
+                "Projections": "name",
+                "Estimated Cardinality": "1"
+            },
+            "children": [
+                {
+                    "extra_info": {
+                        "Join Type": "INNER",
+                        "Conditions": "sid = sid",
+                        "Build Min": "1",
+                        "Build Max": "3",
+                        "Estimated Cardinality": "1"
+                    },
+                    "operator_cardinality": 2,
+                    "operator_type": "HASH_JOIN",
+                    "operator_timing": 0.00023899999999999998,
+                    "children": [
+...
+```
+
+The second example adds detailed metrics to the output.
+
+```sql
+PRAGMA profiling_mode = 'detailed';
+
+SELECT name
+FROM students
+JOIN exams USING (sid)
+WHERE name LIKE 'Ma%';
+```
+
+The contents of the outputted file:
+
+```json
+{
+  "all_optimizers": 0.001413,
+  "cumulative_optimizer_timing": 0.0014120000000000003,
+  "planner": 0.000873,
+  "planner_binding": 0.000869,
+  "physical_planner": 0.000236,
+  "physical_planner_column_binding": 0.000005,
+  "physical_planner_resolve_types": 0.000001,
+  "physical_planner_create_plan": 0.000226,
+  "optimizer_expression_rewriter": 0.000029,
+  "optimizer_filter_pullup": 0.000002,
+  "optimizer_filter_pushdown": 0.000102,
+...
+  "optimizer_column_lifetime": 0.000009999999999999999,
+  "rows_returned": 2,
+  "latency": 0.003708,
+  "cumulative_rows_scanned": 6,
+  "cumulative_cardinality": 11,
+  "extra_info": {},
+  "cpu_time": 0.000095,
+  "optimizer_build_side_probe_side": 0.000017,
+  "result_set_size": 32,
+  "blocked_thread_time": 0.0,
+  "query_name": "SELECT name\nFROM students\nJOIN exams USING (sid)\nWHERE name LIKE 'Ma%';",
+  "children": [
+    {
+      "operator_timing": 0.000001,
+      "operator_rows_scanned": 0,
+      "cumulative_rows_scanned": 6,
+      "operator_cardinality": 2,
+      "operator_type": "PROJECTION",
+      "cumulative_cardinality": 11,
+      "extra_info": {
+        "Projections": "name",
+        "Estimated Cardinality": "1"
+      },
+      "result_set_size": 32,
+      "cpu_time": 0.000095,
+      "children": [
+...
+```

--- a/docs/current/dev/metrics.md
+++ b/docs/current/dev/metrics.md
@@ -1,9 +1,11 @@
-
 ---
 layout: docu
-title: Metrics
 redirect_from:
-  - /dev/metrics
+- /dev/metrics
+- /docs/dev/metrics
+- /docs/preview/dev/metrics
+- /docs/stable/dev/metrics
+title: Metrics
 ---
 
 DuckDB provides a set of metrics that can be used to monitor the performance and health of the database.
@@ -17,78 +19,50 @@ The table below describes each metric and which nodes they are available for.
 Other than `OPERATOR_TYPE`, all metrics can be turned on or off.
 
 # All Metrics
-| Name                                                                              | Group                                 | Description                                                                |
-|-----------------------------------------------------------------------------------|---------------------------------------|----------------------------------------------------------------------------|
-| [`CPU_TIME`](#CPU_TIME)                                                           | [core](#core-metrics)                 | CPU time spent on the query                                                |
-| [`CUMULATIVE_CARDINALITY`](#CUMULATIVE_CARDINALITY)                               | [core](#core-metrics)                 | Cumulative cardinality of the query                                        |
-| [`CUMULATIVE_ROWS_SCANNED`](#CUMULATIVE_ROWS_SCANNED)                             | [core](#core-metrics)                 | Cumulative number of rows scanned by the query                             |
-| [`EXTRA_INFO`](#EXTRA_INFO)                                                       | [core](#core-metrics)                 | Unique operator metrics                                                    |
-| [`LATENCY`](#LATENCY)                                                             | [core](#core-metrics)                 | Time spent executing the entire query                                      |
-| [`QUERY_NAME`](#QUERY_NAME)                                                       | [core](#core-metrics)                 | The SQL string of the query                                                |
-| [`RESULT_SET_SIZE`](#RESULT_SET_SIZE)                                             | [core](#core-metrics)                 | The size of the result                                                     |
-| [`ROWS_RETURNED`](#ROWS_RETURNED)                                                 | [core](#core-metrics)                 | The number of rows returned by the query                                   |
-| [`BLOCKED_THREAD_TIME`](#BLOCKED_THREAD_TIME)                                     | [execution](#execution-metrics)       | Time spent waiting for a thread to become available                        |
-| [`SYSTEM_PEAK_BUFFER_MEMORY`](#SYSTEM_PEAK_BUFFER_MEMORY)                         | [execution](#execution-metrics)       | Peak memory usage of the system                                            |
-| [`SYSTEM_PEAK_TEMP_DIR_SIZE`](#SYSTEM_PEAK_TEMP_DIR_SIZE)                         | [execution](#execution-metrics)       | Peak size of the temporary directory                                       |
-| [`TOTAL_MEMORY_ALLOCATED`](#TOTAL_MEMORY_ALLOCATED)                               | [execution](#execution-metrics)       | The total memory allocated by the buffer manager.                          |
-| [`ATTACH_LOAD_STORAGE_LATENCY`](#ATTACH_LOAD_STORAGE_LATENCY)                     | [file](#file-metrics)                 | Time spent loading from storage.                                           |
-| [`ATTACH_REPLAY_WAL_LATENCY`](#ATTACH_REPLAY_WAL_LATENCY)                         | [file](#file-metrics)                 | Time spent replaying the WAL file.                                         |
-| [`CHECKPOINT_LATENCY`](#CHECKPOINT_LATENCY)                                       | [file](#file-metrics)                 | Time spent running checkpoints                                             |
-| [`COMMIT_LOCAL_STORAGE_LATENCY`](#COMMIT_LOCAL_STORAGE_LATENCY)                   | [file](#file-metrics)                 | Time spent committing the transaction-local storage.                       |
-| [`TOTAL_BYTES_READ`](#TOTAL_BYTES_READ)                                           | [file](#file-metrics)                 | The total bytes read by the file system.                                   |
-| [`TOTAL_BYTES_WRITTEN`](#TOTAL_BYTES_WRITTEN)                                     | [file](#file-metrics)                 | The total bytes written by the file system.                                |
-| [`WAITING_TO_ATTACH_LATENCY`](#WAITING_TO_ATTACH_LATENCY)                         | [file](#file-metrics)                 | Time spent waiting to ATTACH a file.                                       |
-| [`WAL_REPLAY_ENTRY_COUNT`](#WAL_REPLAY_ENTRY_COUNT)                               | [file](#file-metrics)                 | The total number of entries to replay in the WAL.                          |
-| [`WRITE_TO_WAL_LATENCY`](#WRITE_TO_WAL_LATENCY)                                   | [file](#file-metrics)                 | Time spent writing to the WAL.                                             |
-| [`ALL_OPTIMIZERS`](#ALL_OPTIMIZERS)                                               | [phase_timing](#phase_timing-metrics) | Enables all optimizers                                                     |
-| [`CUMULATIVE_OPTIMIZER_TIMING`](#CUMULATIVE_OPTIMIZER_TIMING)                     | [phase_timing](#phase_timing-metrics) | Time spent in all optimizers                                               |
-| [`PHYSICAL_PLANNER`](#PHYSICAL_PLANNER)                                           | [phase_timing](#phase_timing-metrics) | The time spent generating the physical plan                                |
-| [`PHYSICAL_PLANNER_COLUMN_BINDING`](#PHYSICAL_PLANNER_COLUMN_BINDING)             | [phase_timing](#phase_timing-metrics) | The time spent binding the columns in the logical plan to physical columns |
-| [`PHYSICAL_PLANNER_CREATE_PLAN`](#PHYSICAL_PLANNER_CREATE_PLAN)                   | [phase_timing](#phase_timing-metrics) | The time spent creating the physical plan                                  |
-| [`PHYSICAL_PLANNER_RESOLVE_TYPES`](#PHYSICAL_PLANNER_RESOLVE_TYPES)               | [phase_timing](#phase_timing-metrics) | The time spent resolving the types in the logical plan to physical types   |
-| [`PLANNER`](#PLANNER)                                                             | [phase_timing](#phase_timing-metrics) | The time to generate the logical plan from the parsed SQL nodes.           |
-| [`PLANNER_BINDING`](#PLANNER_BINDING)                                             | [phase_timing](#phase_timing-metrics) | The time taken to bind the logical plan.                                   |
-| [`OPERATOR_CARDINALITY`](#OPERATOR_CARDINALITY)                                   | [operator](#operator-metrics)         | Cardinality of the operator                                                |
-| [`OPERATOR_NAME`](#OPERATOR_NAME)                                                 | [operator](#operator-metrics)         | Name of the operator                                                       |
-| [`OPERATOR_ROWS_SCANNED`](#OPERATOR_ROWS_SCANNED)                                 | [operator](#operator-metrics)         | Number of rows scanned by the operator                                     |
-| [`OPERATOR_TIMING`](#OPERATOR_TIMING)                                             | [operator](#operator-metrics)         | Time spent in the operator                                                 |
-| [`OPERATOR_TYPE`](#OPERATOR_TYPE)                                                 | [operator](#operator-metrics)         | Type of the operator                                                       |
-| [`OPTIMIZER_EXPRESSION_REWRITER`](#OPTIMIZER_EXPRESSION_REWRITER)                 | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_EXPRESSION_REWRITER                                |
-| [`OPTIMIZER_FILTER_PULLUP`](#OPTIMIZER_FILTER_PULLUP)                             | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_FILTER_PULLUP                                      |
-| [`OPTIMIZER_FILTER_PUSHDOWN`](#OPTIMIZER_FILTER_PUSHDOWN)                         | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_FILTER_PUSHDOWN                                    |
-| [`OPTIMIZER_EMPTY_RESULT_PULLUP`](#OPTIMIZER_EMPTY_RESULT_PULLUP)                 | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_EMPTY_RESULT_PULLUP                                |
-| [`OPTIMIZER_CTE_FILTER_PUSHER`](#OPTIMIZER_CTE_FILTER_PUSHER)                     | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_CTE_FILTER_PUSHER                                  |
-| [`OPTIMIZER_REGEX_RANGE`](#OPTIMIZER_REGEX_RANGE)                                 | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_REGEX_RANGE                                        |
-| [`OPTIMIZER_IN_CLAUSE`](#OPTIMIZER_IN_CLAUSE)                                     | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_IN_CLAUSE                                          |
-| [`OPTIMIZER_JOIN_ORDER`](#OPTIMIZER_JOIN_ORDER)                                   | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_JOIN_ORDER                                         |
-| [`OPTIMIZER_DELIMINATOR`](#OPTIMIZER_DELIMINATOR)                                 | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_DELIMINATOR                                        |
-| [`OPTIMIZER_UNNEST_REWRITER`](#OPTIMIZER_UNNEST_REWRITER)                         | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_UNNEST_REWRITER                                    |
-| [`OPTIMIZER_UNUSED_COLUMNS`](#OPTIMIZER_UNUSED_COLUMNS)                           | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_UNUSED_COLUMNS                                     |
-| [`OPTIMIZER_STATISTICS_PROPAGATION`](#OPTIMIZER_STATISTICS_PROPAGATION)           | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_STATISTICS_PROPAGATION                             |
-| [`OPTIMIZER_COMMON_SUBEXPRESSIONS`](#OPTIMIZER_COMMON_SUBEXPRESSIONS)             | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_COMMON_SUBEXPRESSIONS                              |
-| [`OPTIMIZER_COMMON_AGGREGATE`](#OPTIMIZER_COMMON_AGGREGATE)                       | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_COMMON_AGGREGATE                                   |
-| [`OPTIMIZER_COLUMN_LIFETIME`](#OPTIMIZER_COLUMN_LIFETIME)                         | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_COLUMN_LIFETIME                                    |
-| [`OPTIMIZER_BUILD_SIDE_PROBE_SIDE`](#OPTIMIZER_BUILD_SIDE_PROBE_SIDE)             | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_BUILD_SIDE_PROBE_SIDE                              |
-| [`OPTIMIZER_LIMIT_PUSHDOWN`](#OPTIMIZER_LIMIT_PUSHDOWN)                           | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_LIMIT_PUSHDOWN                                     |
-| [`OPTIMIZER_TOP_N`](#OPTIMIZER_TOP_N)                                             | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_TOP_N                                              |
-| [`OPTIMIZER_COMPRESSED_MATERIALIZATION`](#OPTIMIZER_COMPRESSED_MATERIALIZATION)   | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_COMPRESSED_MATERIALIZATION                         |
-| [`OPTIMIZER_DUPLICATE_GROUPS`](#OPTIMIZER_DUPLICATE_GROUPS)                       | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_DUPLICATE_GROUPS                                   |
-| [`OPTIMIZER_REORDER_FILTER`](#OPTIMIZER_REORDER_FILTER)                           | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_REORDER_FILTER                                     |
-| [`OPTIMIZER_SAMPLING_PUSHDOWN`](#OPTIMIZER_SAMPLING_PUSHDOWN)                     | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_SAMPLING_PUSHDOWN                                  |
-| [`OPTIMIZER_JOIN_FILTER_PUSHDOWN`](#OPTIMIZER_JOIN_FILTER_PUSHDOWN)               | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_JOIN_FILTER_PUSHDOWN                               |
-| [`OPTIMIZER_EXTENSION`](#OPTIMIZER_EXTENSION)                                     | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_EXTENSION                                          |
-| [`OPTIMIZER_MATERIALIZED_CTE`](#OPTIMIZER_MATERIALIZED_CTE)                       | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_MATERIALIZED_CTE                                   |
-| [`OPTIMIZER_AGGREGATE_FUNCTION_REWRITER`](#OPTIMIZER_AGGREGATE_FUNCTION_REWRITER) | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_AGGREGATE_FUNCTION_REWRITER                        |
-| [`OPTIMIZER_LATE_MATERIALIZATION`](#OPTIMIZER_LATE_MATERIALIZATION)               | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_LATE_MATERIALIZATION                               |
-| [`OPTIMIZER_CTE_INLINING`](#OPTIMIZER_CTE_INLINING)                               | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_CTE_INLINING                                       |
-| [`OPTIMIZER_ROW_GROUP_PRUNER`](#OPTIMIZER_ROW_GROUP_PRUNER)                       | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_ROW_GROUP_PRUNER                                   |
-| [`OPTIMIZER_TOP_N_WINDOW_ELIMINATION`](#OPTIMIZER_TOP_N_WINDOW_ELIMINATION)       | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_TOP_N_WINDOW_ELIMINATION                           |
-| [`OPTIMIZER_COMMON_SUBPLAN`](#OPTIMIZER_COMMON_SUBPLAN)                           | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_COMMON_SUBPLAN                                     |
-| [`OPTIMIZER_JOIN_ELIMINATION`](#OPTIMIZER_JOIN_ELIMINATION)                       | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_JOIN_ELIMINATION                                   |
-| [`OPTIMIZER_WINDOW_SELF_JOIN`](#OPTIMIZER_WINDOW_SELF_JOIN)                       | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_WINDOW_SELF_JOIN                                   |
-| [`OPTIMIZER_PROJECTION_PULLUP`](#OPTIMIZER_PROJECTION_PULLUP)                     | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_PROJECTION_PULLUP                                  |
+
+| Name                                                                  | Group                                 | Description                                                                |
+|-----------------------------------------------------------------------|---------------------------------------|----------------------------------------------------------------------------|
+| [`CPU_TIME`](#cpu_time)                                               | [core](#core-metrics)                 | CPU time spent on the query                                                |
+| [`CUMULATIVE_CARDINALITY`](#cumulative_cardinality)                   | [core](#core-metrics)                 | Cumulative cardinality of the query                                        |
+| [`CUMULATIVE_ROWS_SCANNED`](#cumulative_rows_scanned)                 | [core](#core-metrics)                 | Cumulative number of rows scanned by the query                             |
+| [`EXTRA_INFO`](#extra_info)                                           | [core](#core-metrics)                 | Unique operator metrics                                                    |
+| [`LATENCY`](#latency)                                                 | [core](#core-metrics)                 | Time spent executing the entire query                                      |
+| [`QUERY_NAME`](#query_name)                                           | [core](#core-metrics)                 | The SQL string of the query                                                |
+| [`RESULT_SET_SIZE`](#result_set_size)                                 | [core](#core-metrics)                 | The size of the result                                                     |
+| [`ROWS_RETURNED`](#rows_returned)                                     | [core](#core-metrics)                 | The number of rows returned by the query                                   |
+| [`BLOCKED_THREAD_TIME`](#blocked_thread_time)                         | [execution](#execution-metrics)       | Time spent waiting for a thread to become available                        |
+| [`SYSTEM_PEAK_BUFFER_MEMORY`](#system_peak_buffer_memory)             | [execution](#execution-metrics)       | Peak memory usage of the system                                            |
+| [`SYSTEM_PEAK_TEMP_DIR_SIZE`](#system_peak_temp_dir_size)             | [execution](#execution-metrics)       | Peak size of the temporary directory                                       |
+| [`TOTAL_MEMORY_ALLOCATED`](#total_memory_allocated)                   | [execution](#execution-metrics)       | The total memory allocated by the buffer manager.                          |
+| [`ATTACH_LOAD_STORAGE_LATENCY`](#attach_load_storage_latency)         | [file](#file-metrics)                 | Time spent loading from storage.                                           |
+| [`ATTACH_REPLAY_WAL_LATENCY`](#attach_replay_wal_latency)             | [file](#file-metrics)                 | Time spent replaying the WAL file.                                         |
+| [`CHECKPOINT_LATENCY`](#checkpoint_latency)                           | [file](#file-metrics)                 | Time spent running checkpoints                                             |
+| [`COMMIT_LOCAL_STORAGE_LATENCY`](#commit_local_storage_latency)       | [file](#file-metrics)                 | Time spent committing the transaction-local storage.                       |
+| [`TOTAL_BYTES_READ`](#total_bytes_read)                               | [file](#file-metrics)                 | The total bytes read by the file system.                                   |
+| [`TOTAL_BYTES_WRITTEN`](#total_bytes_written)                         | [file](#file-metrics)                 | The total bytes written by the file system.                                |
+| [`WAITING_TO_ATTACH_LATENCY`](#waiting_to_attach_latency)             | [file](#file-metrics)                 | Time spent waiting to ATTACH a file.                                       |
+| [`WAL_REPLAY_ENTRY_COUNT`](#wal_replay_entry_count)                   | [file](#file-metrics)                 | The total number of entries to replay in the WAL.                          |
+| [`WRITE_TO_WAL_LATENCY`](#write_to_wal_latency)                       | [file](#file-metrics)                 | Time spent writing to the WAL.                                             |
+| [`ALL_OPTIMIZERS`](#all_optimizers)                                   | [phase_timing](#phase_timing-metrics) | Enables all optimizers                                                     |
+| [`CUMULATIVE_OPTIMIZER_TIMING`](#cumulative_optimizer_timing)         | [phase_timing](#phase_timing-metrics) | Time spent in all optimizers                                               |
+| [`PHYSICAL_PLANNER`](#physical_planner)                               | [phase_timing](#phase_timing-metrics) | The time spent generating the physical plan                                |
+| [`PHYSICAL_PLANNER_COLUMN_BINDING`](#physical_planner_column_binding) | [phase_timing](#phase_timing-metrics) | The time spent binding the columns in the logical plan to physical columns |
+| [`PHYSICAL_PLANNER_CREATE_PLAN`](#physical_planner_create_plan)       | [phase_timing](#phase_timing-metrics) | The time spent creating the physical plan                                  |
+| [`PHYSICAL_PLANNER_RESOLVE_TYPES`](#physical_planner_resolve_types)   | [phase_timing](#phase_timing-metrics) | The time spent resolving the types in the logical plan to physical types   |
+| [`PLANNER`](#planner)                                                 | [phase_timing](#phase_timing-metrics) | The time to generate the logical plan from the parsed SQL nodes.           |
+| [`PLANNER_BINDING`](#planner_binding)                                 | [phase_timing](#phase_timing-metrics) | The time taken to bind the logical plan.                                   |
+| [`OPERATOR_CARDINALITY`](#operator_cardinality)                       | [operator](#operator-metrics)         | Cardinality of the operator                                                |
+| [`OPERATOR_NAME`](#operator_name)                                     | [operator](#operator-metrics)         | Name of the operator                                                       |
+| [`OPERATOR_ROWS_SCANNED`](#operator_rows_scanned)                     | [operator](#operator-metrics)         | Number of rows scanned by the operator                                     |
+| [`OPERATOR_TIMING`](#operator_timing)                                 | [operator](#operator-metrics)         | Time spent in the operator                                                 |
+| [`OPERATOR_TYPE`](#operator_type)                                     | [operator](#operator-metrics)         | Type of the operator                                                       |
 
 
+# Metric Groups:
+The metrics are organized into groups, which can be used to enable or disable related metrics together.
+The following is a list of the available metric groups:
+- `ALL`: All metrics
+- `DEFAULT`: The default set of metrics
 - [`CORE`](#core-metrics)
 - [`EXECUTION`](#execution-metrics)
 - [`FILE`](#file-metrics)
@@ -96,7 +70,7 @@ Other than `OPERATOR_TYPE`, all metrics can be turned on or off.
 - [`OPTIMIZER`](#optimizer-metrics)
 - [`PHASE_TIMING`](#phase_timing-metrics)
 
-### Core Metrics
+## Core Metrics
 core metrics
 
 #### `CPU_TIME`
@@ -106,10 +80,10 @@ core metrics
 | **Description** | CPU time spent on the query |
 | **Type** | double |
 | **Unit** | seconds |
-| **Default** | '✅' |
-| **Query Node** | '✅' |
-| **Operator Node** | '✅' |
-| **[Cumulative](#cumulative_metrics)** | '✅' |
+| **Default** | ✅ |
+| **Query Node** | ✅ |
+| **Operator Node** | ✅ |
+| **[Cumulative](#cumulative_metrics)** | ✅ |
 | **Child** | OPERATOR_TIMING |
 
 #### `CUMULATIVE_CARDINALITY`
@@ -119,10 +93,10 @@ core metrics
 | **Description** | Cumulative cardinality of the query |
 | **Type** | uint64 |
 | **Unit** | absolute |
-| **Default** | '✅' |
-| **Query Node** | '✅' |
-| **Operator Node** | '✅' |
-| **[Cumulative](#cumulative_metrics)** | '✅' |
+| **Default** | ✅ |
+| **Query Node** | ✅ |
+| **Operator Node** | ✅ |
+| **[Cumulative](#cumulative_metrics)** | ✅ |
 | **Child** | OPERATOR_CARDINALITY |
 
 #### `CUMULATIVE_ROWS_SCANNED`
@@ -132,10 +106,10 @@ core metrics
 | **Description** | Cumulative number of rows scanned by the query |
 | **Type** | uint64 |
 | **Unit** | absolute |
-| **Default** | '✅' |
-| **Query Node** | '✅' |
-| **Operator Node** | '✅' |
-| **[Cumulative](#cumulative_metrics)** | '✅' |
+| **Default** | ✅ |
+| **Query Node** | ✅ |
+| **Operator Node** | ✅ |
+| **[Cumulative](#cumulative_metrics)** | ✅ |
 | **Child** | OPERATOR_ROWS_SCANNED |
 
 #### `EXTRA_INFO`
@@ -144,9 +118,9 @@ core metrics
 
 | **Description** | Unique operator metrics |
 | **Type** | Value::MAP |
-| **Default** | '✅' |
-| **Query Node** | '✅' |
-| **Operator Node** | '✅' |
+| **Default** | ✅ |
+| **Query Node** | ✅ |
+| **Operator Node** | ✅ |
 
 #### `LATENCY`
 
@@ -155,8 +129,8 @@ core metrics
 | **Description** | Time spent executing the entire query |
 | **Type** | double |
 | **Unit** | seconds |
-| **Default** | '✅' |
-| **Query Node** | '✅' |
+| **Default** | ✅ |
+| **Query Node** | ✅ |
 
 #### `QUERY_NAME`
 
@@ -164,8 +138,8 @@ core metrics
 
 | **Description** | The SQL string of the query |
 | **Type** | string |
-| **Default** | '✅' |
-| **Query Node** | '✅' |
+| **Default** | ✅ |
+| **Query Node** | ✅ |
 
 #### `RESULT_SET_SIZE`
 
@@ -174,9 +148,9 @@ core metrics
 | **Description** | The size of the result |
 | **Type** | uint64 |
 | **Unit** | bytes |
-| **Default** | '✅' |
-| **Query Node** | '✅' |
-| **Operator Node** | '✅' |
+| **Default** | ✅ |
+| **Query Node** | ✅ |
+| **Operator Node** | ✅ |
 | **Child** | RESULT_SET_SIZE |
 
 #### `ROWS_RETURNED`
@@ -186,11 +160,11 @@ core metrics
 | **Description** | The number of rows returned by the query |
 | **Type** | uint64 |
 | **Unit** | absolute |
-| **Default** | '✅' |
-| **Query Node** | '✅' |
+| **Default** | ✅ |
+| **Query Node** | ✅ |
 | **Child** | OPERATOR_CARDINALITY |
 
-### Execution Metrics
+## Execution Metrics
 Metrics that are collected during query execution
 
 #### `BLOCKED_THREAD_TIME`
@@ -200,8 +174,8 @@ Metrics that are collected during query execution
 | **Description** | Time spent waiting for a thread to become available |
 | **Type** | double |
 | **Unit** | seconds |
-| **Default** | '✅' |
-| **Query Node** | '✅' |
+| **Default** | ✅ |
+| **Query Node** | ✅ |
 
 #### `SYSTEM_PEAK_BUFFER_MEMORY`
 
@@ -210,9 +184,9 @@ Metrics that are collected during query execution
 | **Description** | Peak memory usage of the system |
 | **Type** | uint64 |
 | **Unit** | bytes |
-| **Default** | '✅' |
-| **Query Node** | '✅' |
-| **Operator Node** | '✅' |
+| **Default** | ✅ |
+| **Query Node** | ✅ |
+| **Operator Node** | ✅ |
 
 #### `SYSTEM_PEAK_TEMP_DIR_SIZE`
 
@@ -221,9 +195,9 @@ Metrics that are collected during query execution
 | **Description** | Peak size of the temporary directory |
 | **Type** | uint64 |
 | **Unit** | bytes |
-| **Default** | '✅' |
-| **Query Node** | '✅' |
-| **Operator Node** | '✅' |
+| **Default** | ✅ |
+| **Query Node** | ✅ |
+| **Operator Node** | ✅ |
 
 #### `TOTAL_MEMORY_ALLOCATED`
 
@@ -232,10 +206,10 @@ Metrics that are collected during query execution
 | **Description** | The total memory allocated by the buffer manager. |
 | **Type** | uint64 |
 | **Unit** | bytes |
-| **Default** | '✅' |
-| **Query Node** | '✅' |
+| **Default** | ✅ |
+| **Query Node** | ✅ |
 
-### File Metrics
+## File Metrics
 metrics that are collected during file operations
 
 #### `ATTACH_LOAD_STORAGE_LATENCY`
@@ -245,8 +219,8 @@ metrics that are collected during file operations
 | **Description** | Time spent loading from storage. |
 | **Type** | double |
 | **Unit** | seconds |
-| **Default** | '✅' |
-| **Query Node** | '✅' |
+| **Default** | ✅ |
+| **Query Node** | ✅ |
 
 #### `ATTACH_REPLAY_WAL_LATENCY`
 
@@ -255,8 +229,8 @@ metrics that are collected during file operations
 | **Description** | Time spent replaying the WAL file. |
 | **Type** | double |
 | **Unit** | seconds |
-| **Default** | '✅' |
-| **Query Node** | '✅' |
+| **Default** | ✅ |
+| **Query Node** | ✅ |
 
 #### `CHECKPOINT_LATENCY`
 
@@ -265,8 +239,8 @@ metrics that are collected during file operations
 | **Description** | Time spent running checkpoints |
 | **Type** | double |
 | **Unit** | seconds |
-| **Default** | '✅' |
-| **Query Node** | '✅' |
+| **Default** | ✅ |
+| **Query Node** | ✅ |
 
 #### `COMMIT_LOCAL_STORAGE_LATENCY`
 
@@ -275,8 +249,8 @@ metrics that are collected during file operations
 | **Description** | Time spent committing the transaction-local storage. |
 | **Type** | double |
 | **Unit** | seconds |
-| **Default** | '✅' |
-| **Query Node** | '✅' |
+| **Default** | ✅ |
+| **Query Node** | ✅ |
 
 #### `TOTAL_BYTES_READ`
 
@@ -285,8 +259,8 @@ metrics that are collected during file operations
 | **Description** | The total bytes read by the file system. |
 | **Type** | uint64 |
 | **Unit** | bytes |
-| **Default** | '✅' |
-| **Query Node** | '✅' |
+| **Default** | ✅ |
+| **Query Node** | ✅ |
 
 #### `TOTAL_BYTES_WRITTEN`
 
@@ -295,8 +269,8 @@ metrics that are collected during file operations
 | **Description** | The total bytes written by the file system. |
 | **Type** | uint64 |
 | **Unit** | bytes |
-| **Default** | '✅' |
-| **Query Node** | '✅' |
+| **Default** | ✅ |
+| **Query Node** | ✅ |
 
 #### `WAITING_TO_ATTACH_LATENCY`
 
@@ -305,8 +279,8 @@ metrics that are collected during file operations
 | **Description** | Time spent waiting to ATTACH a file. |
 | **Type** | double |
 | **Unit** | seconds |
-| **Default** | '✅' |
-| **Query Node** | '✅' |
+| **Default** | ✅ |
+| **Query Node** | ✅ |
 
 #### `WAL_REPLAY_ENTRY_COUNT`
 
@@ -315,8 +289,8 @@ metrics that are collected during file operations
 | **Description** | The total number of entries to replay in the WAL. |
 | **Type** | uint64 |
 | **Unit** | absolute |
-| **Default** | '✅' |
-| **Query Node** | '✅' |
+| **Default** | ✅ |
+| **Query Node** | ✅ |
 
 #### `WRITE_TO_WAL_LATENCY`
 
@@ -325,10 +299,10 @@ metrics that are collected during file operations
 | **Description** | Time spent writing to the WAL. |
 | **Type** | double |
 | **Unit** | seconds |
-| **Default** | '✅' |
-| **Query Node** | '✅' |
+| **Default** | ✅ |
+| **Query Node** | ✅ |
 
-### Operator Metrics
+## Operator Metrics
 metrics that are collected for each operator
 
 #### `OPERATOR_CARDINALITY`
@@ -338,8 +312,8 @@ metrics that are collected for each operator
 | **Description** | Cardinality of the operator |
 | **Type** | uint64 |
 | **Unit** | absolute |
-| **Default** | '✅' |
-| **Operator Node** | '✅' |
+| **Default** | ✅ |
+| **Operator Node** | ✅ |
 
 #### `OPERATOR_NAME`
 
@@ -347,8 +321,8 @@ metrics that are collected for each operator
 
 | **Description** | Name of the operator |
 | **Type** | string |
-| **Default** | '✅' |
-| **Operator Node** | '✅' |
+| **Default** | ✅ |
+| **Operator Node** | ✅ |
 
 #### `OPERATOR_ROWS_SCANNED`
 
@@ -357,8 +331,8 @@ metrics that are collected for each operator
 | **Description** | Number of rows scanned by the operator |
 | **Type** | uint64 |
 | **Unit** | absolute |
-| **Default** | '✅' |
-| **Operator Node** | '✅' |
+| **Default** | ✅ |
+| **Operator Node** | ✅ |
 
 #### `OPERATOR_TIMING`
 
@@ -367,8 +341,8 @@ metrics that are collected for each operator
 | **Description** | Time spent in the operator |
 | **Type** | double |
 | **Unit** | seconds |
-| **Default** | '✅' |
-| **Operator Node** | '✅' |
+| **Default** | ✅ |
+| **Operator Node** | ✅ |
 
 #### `OPERATOR_TYPE`
 
@@ -376,10 +350,10 @@ metrics that are collected for each operator
 
 | **Description** | Type of the operator |
 | **Type** | uint8 |
-| **Default** | '✅' |
-| **Operator Node** | '✅' |
+| **Default** | ✅ |
+| **Operator Node** | ✅ |
 
-### Phase_timing Metrics
+## Phase_timing Metrics
 This group contains metrics related to the planner and the physical planner. The planner is responsible for generating the logical plan, whereas the physical planner is responsible for generating the physical plan from the logical plan.
 
 #### `PHYSICAL_PLANNER`
@@ -389,7 +363,7 @@ This group contains metrics related to the planner and the physical planner. The
 | **Description** | The time spent generating the physical plan |
 | **Type** | double |
 | **Unit** | milliseconds |
-| **Query Node** | '✅' |
+| **Query Node** | ✅ |
 
 #### `PHYSICAL_PLANNER_COLUMN_BINDING`
 
@@ -398,7 +372,7 @@ This group contains metrics related to the planner and the physical planner. The
 | **Description** | The time spent binding the columns in the logical plan to physical columns |
 | **Type** | double |
 | **Unit** | milliseconds |
-| **Query Node** | '✅' |
+| **Query Node** | ✅ |
 
 #### `PHYSICAL_PLANNER_CREATE_PLAN`
 
@@ -407,7 +381,7 @@ This group contains metrics related to the planner and the physical planner. The
 | **Description** | The time spent creating the physical plan |
 | **Type** | double |
 | **Unit** | milliseconds |
-| **Query Node** | '✅' |
+| **Query Node** | ✅ |
 
 #### `PHYSICAL_PLANNER_RESOLVE_TYPES`
 
@@ -416,7 +390,7 @@ This group contains metrics related to the planner and the physical planner. The
 | **Description** | The time spent resolving the types in the logical plan to physical types |
 | **Type** | double |
 | **Unit** | milliseconds |
-| **Query Node** | '✅' |
+| **Query Node** | ✅ |
 
 #### `PLANNER`
 
@@ -425,7 +399,7 @@ This group contains metrics related to the planner and the physical planner. The
 | **Description** | The time to generate the logical plan from the parsed SQL nodes. |
 | **Type** | double |
 | **Unit** | milliseconds |
-| **Query Node** | '✅' |
+| **Query Node** | ✅ |
 
 #### `PLANNER_BINDING`
 
@@ -434,10 +408,10 @@ This group contains metrics related to the planner and the physical planner. The
 | **Description** | The time taken to bind the logical plan. |
 | **Type** | double |
 | **Unit** | milliseconds |
-| **Query Node** | '✅' |
+| **Query Node** | ✅ |
 
 
-### Optimizer Metrics
+## Optimizer Metrics
 Optimizer metrics sit at the `QUERY_ROOT` level, and measure the time taken by each [optimizer]({% link docs/current/internals/overview.md %}#optimizer).
 These metrics are only available when the specific optimizer is enabled.
 The available optimizations can be queried using the [`duckdb_optimizers()`{:.language-sql .highlight} table function]({% link docs/current/sql/meta/duckdb_table_functions.md %}#duckdb_optimizers).
@@ -453,7 +427,7 @@ Additionally, the following metrics are available to support the optimizer metri
 
 | **Description** | Enables all optimizers |
 | **Type** | double |
-| **Query Node** | '✅' |
+| **Query Node** | ✅ |
 
 #### `CUMULATIVE_OPTIMIZER_TIMING`
 
@@ -462,10 +436,10 @@ Additionally, the following metrics are available to support the optimizer metri
 | **Description** | Time spent in all optimizers |
 | **Type** | double |
 | **Unit** | milliseconds |
-| **Query Node** | '✅' |
+| **Query Node** | ✅ |
 
 
-## Cumulative Metrics
+# Cumulative Metrics
 
 DuckDB also supports several cumulative metrics that are available in all nodes.
 In the `QUERY_ROOT` node, these metrics represent the sum of the corresponding metrics across all operators in the query.

--- a/docs/current/dev/metrics.md
+++ b/docs/current/dev/metrics.md
@@ -1,0 +1,487 @@
+
+---
+layout: docu
+title: Metrics
+redirect_from:
+  - /dev/metrics
+---
+
+DuckDB provides a set of metrics that can be used to monitor the performance and health of the database.
+
+The query tree has two types of nodes: the `QUERY_ROOT` and `OPERATOR` nodes.
+The `QUERY_ROOT` refers exclusively to the top-level node, and the metrics it contains are measured over the entire query.
+The `OPERATOR` nodes refer to the individual operators in the query plan.
+Some metrics are only available for `QUERY_ROOT` nodes, while others are only for `OPERATOR` nodes.
+The table below describes each metric and which nodes they are available for.
+
+Other than `OPERATOR_TYPE`, all metrics can be turned on or off.
+
+# All Metrics
+| Name                                                                              | Group                                 | Description                                                                |
+|-----------------------------------------------------------------------------------|---------------------------------------|----------------------------------------------------------------------------|
+| [`CPU_TIME`](#CPU_TIME)                                                           | [core](#core-metrics)                 | CPU time spent on the query                                                |
+| [`CUMULATIVE_CARDINALITY`](#CUMULATIVE_CARDINALITY)                               | [core](#core-metrics)                 | Cumulative cardinality of the query                                        |
+| [`CUMULATIVE_ROWS_SCANNED`](#CUMULATIVE_ROWS_SCANNED)                             | [core](#core-metrics)                 | Cumulative number of rows scanned by the query                             |
+| [`EXTRA_INFO`](#EXTRA_INFO)                                                       | [core](#core-metrics)                 | Unique operator metrics                                                    |
+| [`LATENCY`](#LATENCY)                                                             | [core](#core-metrics)                 | Time spent executing the entire query                                      |
+| [`QUERY_NAME`](#QUERY_NAME)                                                       | [core](#core-metrics)                 | The SQL string of the query                                                |
+| [`RESULT_SET_SIZE`](#RESULT_SET_SIZE)                                             | [core](#core-metrics)                 | The size of the result                                                     |
+| [`ROWS_RETURNED`](#ROWS_RETURNED)                                                 | [core](#core-metrics)                 | The number of rows returned by the query                                   |
+| [`BLOCKED_THREAD_TIME`](#BLOCKED_THREAD_TIME)                                     | [execution](#execution-metrics)       | Time spent waiting for a thread to become available                        |
+| [`SYSTEM_PEAK_BUFFER_MEMORY`](#SYSTEM_PEAK_BUFFER_MEMORY)                         | [execution](#execution-metrics)       | Peak memory usage of the system                                            |
+| [`SYSTEM_PEAK_TEMP_DIR_SIZE`](#SYSTEM_PEAK_TEMP_DIR_SIZE)                         | [execution](#execution-metrics)       | Peak size of the temporary directory                                       |
+| [`TOTAL_MEMORY_ALLOCATED`](#TOTAL_MEMORY_ALLOCATED)                               | [execution](#execution-metrics)       | The total memory allocated by the buffer manager.                          |
+| [`ATTACH_LOAD_STORAGE_LATENCY`](#ATTACH_LOAD_STORAGE_LATENCY)                     | [file](#file-metrics)                 | Time spent loading from storage.                                           |
+| [`ATTACH_REPLAY_WAL_LATENCY`](#ATTACH_REPLAY_WAL_LATENCY)                         | [file](#file-metrics)                 | Time spent replaying the WAL file.                                         |
+| [`CHECKPOINT_LATENCY`](#CHECKPOINT_LATENCY)                                       | [file](#file-metrics)                 | Time spent running checkpoints                                             |
+| [`COMMIT_LOCAL_STORAGE_LATENCY`](#COMMIT_LOCAL_STORAGE_LATENCY)                   | [file](#file-metrics)                 | Time spent committing the transaction-local storage.                       |
+| [`TOTAL_BYTES_READ`](#TOTAL_BYTES_READ)                                           | [file](#file-metrics)                 | The total bytes read by the file system.                                   |
+| [`TOTAL_BYTES_WRITTEN`](#TOTAL_BYTES_WRITTEN)                                     | [file](#file-metrics)                 | The total bytes written by the file system.                                |
+| [`WAITING_TO_ATTACH_LATENCY`](#WAITING_TO_ATTACH_LATENCY)                         | [file](#file-metrics)                 | Time spent waiting to ATTACH a file.                                       |
+| [`WAL_REPLAY_ENTRY_COUNT`](#WAL_REPLAY_ENTRY_COUNT)                               | [file](#file-metrics)                 | The total number of entries to replay in the WAL.                          |
+| [`WRITE_TO_WAL_LATENCY`](#WRITE_TO_WAL_LATENCY)                                   | [file](#file-metrics)                 | Time spent writing to the WAL.                                             |
+| [`ALL_OPTIMIZERS`](#ALL_OPTIMIZERS)                                               | [phase_timing](#phase_timing-metrics) | Enables all optimizers                                                     |
+| [`CUMULATIVE_OPTIMIZER_TIMING`](#CUMULATIVE_OPTIMIZER_TIMING)                     | [phase_timing](#phase_timing-metrics) | Time spent in all optimizers                                               |
+| [`PHYSICAL_PLANNER`](#PHYSICAL_PLANNER)                                           | [phase_timing](#phase_timing-metrics) | The time spent generating the physical plan                                |
+| [`PHYSICAL_PLANNER_COLUMN_BINDING`](#PHYSICAL_PLANNER_COLUMN_BINDING)             | [phase_timing](#phase_timing-metrics) | The time spent binding the columns in the logical plan to physical columns |
+| [`PHYSICAL_PLANNER_CREATE_PLAN`](#PHYSICAL_PLANNER_CREATE_PLAN)                   | [phase_timing](#phase_timing-metrics) | The time spent creating the physical plan                                  |
+| [`PHYSICAL_PLANNER_RESOLVE_TYPES`](#PHYSICAL_PLANNER_RESOLVE_TYPES)               | [phase_timing](#phase_timing-metrics) | The time spent resolving the types in the logical plan to physical types   |
+| [`PLANNER`](#PLANNER)                                                             | [phase_timing](#phase_timing-metrics) | The time to generate the logical plan from the parsed SQL nodes.           |
+| [`PLANNER_BINDING`](#PLANNER_BINDING)                                             | [phase_timing](#phase_timing-metrics) | The time taken to bind the logical plan.                                   |
+| [`OPERATOR_CARDINALITY`](#OPERATOR_CARDINALITY)                                   | [operator](#operator-metrics)         | Cardinality of the operator                                                |
+| [`OPERATOR_NAME`](#OPERATOR_NAME)                                                 | [operator](#operator-metrics)         | Name of the operator                                                       |
+| [`OPERATOR_ROWS_SCANNED`](#OPERATOR_ROWS_SCANNED)                                 | [operator](#operator-metrics)         | Number of rows scanned by the operator                                     |
+| [`OPERATOR_TIMING`](#OPERATOR_TIMING)                                             | [operator](#operator-metrics)         | Time spent in the operator                                                 |
+| [`OPERATOR_TYPE`](#OPERATOR_TYPE)                                                 | [operator](#operator-metrics)         | Type of the operator                                                       |
+| [`OPTIMIZER_EXPRESSION_REWRITER`](#OPTIMIZER_EXPRESSION_REWRITER)                 | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_EXPRESSION_REWRITER                                |
+| [`OPTIMIZER_FILTER_PULLUP`](#OPTIMIZER_FILTER_PULLUP)                             | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_FILTER_PULLUP                                      |
+| [`OPTIMIZER_FILTER_PUSHDOWN`](#OPTIMIZER_FILTER_PUSHDOWN)                         | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_FILTER_PUSHDOWN                                    |
+| [`OPTIMIZER_EMPTY_RESULT_PULLUP`](#OPTIMIZER_EMPTY_RESULT_PULLUP)                 | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_EMPTY_RESULT_PULLUP                                |
+| [`OPTIMIZER_CTE_FILTER_PUSHER`](#OPTIMIZER_CTE_FILTER_PUSHER)                     | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_CTE_FILTER_PUSHER                                  |
+| [`OPTIMIZER_REGEX_RANGE`](#OPTIMIZER_REGEX_RANGE)                                 | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_REGEX_RANGE                                        |
+| [`OPTIMIZER_IN_CLAUSE`](#OPTIMIZER_IN_CLAUSE)                                     | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_IN_CLAUSE                                          |
+| [`OPTIMIZER_JOIN_ORDER`](#OPTIMIZER_JOIN_ORDER)                                   | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_JOIN_ORDER                                         |
+| [`OPTIMIZER_DELIMINATOR`](#OPTIMIZER_DELIMINATOR)                                 | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_DELIMINATOR                                        |
+| [`OPTIMIZER_UNNEST_REWRITER`](#OPTIMIZER_UNNEST_REWRITER)                         | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_UNNEST_REWRITER                                    |
+| [`OPTIMIZER_UNUSED_COLUMNS`](#OPTIMIZER_UNUSED_COLUMNS)                           | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_UNUSED_COLUMNS                                     |
+| [`OPTIMIZER_STATISTICS_PROPAGATION`](#OPTIMIZER_STATISTICS_PROPAGATION)           | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_STATISTICS_PROPAGATION                             |
+| [`OPTIMIZER_COMMON_SUBEXPRESSIONS`](#OPTIMIZER_COMMON_SUBEXPRESSIONS)             | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_COMMON_SUBEXPRESSIONS                              |
+| [`OPTIMIZER_COMMON_AGGREGATE`](#OPTIMIZER_COMMON_AGGREGATE)                       | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_COMMON_AGGREGATE                                   |
+| [`OPTIMIZER_COLUMN_LIFETIME`](#OPTIMIZER_COLUMN_LIFETIME)                         | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_COLUMN_LIFETIME                                    |
+| [`OPTIMIZER_BUILD_SIDE_PROBE_SIDE`](#OPTIMIZER_BUILD_SIDE_PROBE_SIDE)             | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_BUILD_SIDE_PROBE_SIDE                              |
+| [`OPTIMIZER_LIMIT_PUSHDOWN`](#OPTIMIZER_LIMIT_PUSHDOWN)                           | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_LIMIT_PUSHDOWN                                     |
+| [`OPTIMIZER_TOP_N`](#OPTIMIZER_TOP_N)                                             | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_TOP_N                                              |
+| [`OPTIMIZER_COMPRESSED_MATERIALIZATION`](#OPTIMIZER_COMPRESSED_MATERIALIZATION)   | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_COMPRESSED_MATERIALIZATION                         |
+| [`OPTIMIZER_DUPLICATE_GROUPS`](#OPTIMIZER_DUPLICATE_GROUPS)                       | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_DUPLICATE_GROUPS                                   |
+| [`OPTIMIZER_REORDER_FILTER`](#OPTIMIZER_REORDER_FILTER)                           | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_REORDER_FILTER                                     |
+| [`OPTIMIZER_SAMPLING_PUSHDOWN`](#OPTIMIZER_SAMPLING_PUSHDOWN)                     | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_SAMPLING_PUSHDOWN                                  |
+| [`OPTIMIZER_JOIN_FILTER_PUSHDOWN`](#OPTIMIZER_JOIN_FILTER_PUSHDOWN)               | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_JOIN_FILTER_PUSHDOWN                               |
+| [`OPTIMIZER_EXTENSION`](#OPTIMIZER_EXTENSION)                                     | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_EXTENSION                                          |
+| [`OPTIMIZER_MATERIALIZED_CTE`](#OPTIMIZER_MATERIALIZED_CTE)                       | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_MATERIALIZED_CTE                                   |
+| [`OPTIMIZER_AGGREGATE_FUNCTION_REWRITER`](#OPTIMIZER_AGGREGATE_FUNCTION_REWRITER) | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_AGGREGATE_FUNCTION_REWRITER                        |
+| [`OPTIMIZER_LATE_MATERIALIZATION`](#OPTIMIZER_LATE_MATERIALIZATION)               | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_LATE_MATERIALIZATION                               |
+| [`OPTIMIZER_CTE_INLINING`](#OPTIMIZER_CTE_INLINING)                               | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_CTE_INLINING                                       |
+| [`OPTIMIZER_ROW_GROUP_PRUNER`](#OPTIMIZER_ROW_GROUP_PRUNER)                       | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_ROW_GROUP_PRUNER                                   |
+| [`OPTIMIZER_TOP_N_WINDOW_ELIMINATION`](#OPTIMIZER_TOP_N_WINDOW_ELIMINATION)       | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_TOP_N_WINDOW_ELIMINATION                           |
+| [`OPTIMIZER_COMMON_SUBPLAN`](#OPTIMIZER_COMMON_SUBPLAN)                           | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_COMMON_SUBPLAN                                     |
+| [`OPTIMIZER_JOIN_ELIMINATION`](#OPTIMIZER_JOIN_ELIMINATION)                       | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_JOIN_ELIMINATION                                   |
+| [`OPTIMIZER_WINDOW_SELF_JOIN`](#OPTIMIZER_WINDOW_SELF_JOIN)                       | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_WINDOW_SELF_JOIN                                   |
+| [`OPTIMIZER_PROJECTION_PULLUP`](#OPTIMIZER_PROJECTION_PULLUP)                     | [optimizer](#optimizer-metrics)       | Time spent in OPTIMIZER_PROJECTION_PULLUP                                  |
+
+
+- [`CORE`](#core-metrics)
+- [`EXECUTION`](#execution-metrics)
+- [`FILE`](#file-metrics)
+- [`OPERATOR`](#operator-metrics)
+- [`OPTIMIZER`](#optimizer-metrics)
+- [`PHASE_TIMING`](#phase_timing-metrics)
+
+### Core Metrics
+core metrics
+
+#### `CPU_TIME`
+
+<div class="nostroke_table"></div>
+
+| **Description** | CPU time spent on the query |
+| **Type** | double |
+| **Unit** | seconds |
+| **Default** | '✅' |
+| **Query Node** | '✅' |
+| **Operator Node** | '✅' |
+| **[Cumulative](#cumulative_metrics)** | '✅' |
+| **Child** | OPERATOR_TIMING |
+
+#### `CUMULATIVE_CARDINALITY`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Cumulative cardinality of the query |
+| **Type** | uint64 |
+| **Unit** | absolute |
+| **Default** | '✅' |
+| **Query Node** | '✅' |
+| **Operator Node** | '✅' |
+| **[Cumulative](#cumulative_metrics)** | '✅' |
+| **Child** | OPERATOR_CARDINALITY |
+
+#### `CUMULATIVE_ROWS_SCANNED`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Cumulative number of rows scanned by the query |
+| **Type** | uint64 |
+| **Unit** | absolute |
+| **Default** | '✅' |
+| **Query Node** | '✅' |
+| **Operator Node** | '✅' |
+| **[Cumulative](#cumulative_metrics)** | '✅' |
+| **Child** | OPERATOR_ROWS_SCANNED |
+
+#### `EXTRA_INFO`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Unique operator metrics |
+| **Type** | Value::MAP |
+| **Default** | '✅' |
+| **Query Node** | '✅' |
+| **Operator Node** | '✅' |
+
+#### `LATENCY`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Time spent executing the entire query |
+| **Type** | double |
+| **Unit** | seconds |
+| **Default** | '✅' |
+| **Query Node** | '✅' |
+
+#### `QUERY_NAME`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The SQL string of the query |
+| **Type** | string |
+| **Default** | '✅' |
+| **Query Node** | '✅' |
+
+#### `RESULT_SET_SIZE`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The size of the result |
+| **Type** | uint64 |
+| **Unit** | bytes |
+| **Default** | '✅' |
+| **Query Node** | '✅' |
+| **Operator Node** | '✅' |
+| **Child** | RESULT_SET_SIZE |
+
+#### `ROWS_RETURNED`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The number of rows returned by the query |
+| **Type** | uint64 |
+| **Unit** | absolute |
+| **Default** | '✅' |
+| **Query Node** | '✅' |
+| **Child** | OPERATOR_CARDINALITY |
+
+### Execution Metrics
+Metrics that are collected during query execution
+
+#### `BLOCKED_THREAD_TIME`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Time spent waiting for a thread to become available |
+| **Type** | double |
+| **Unit** | seconds |
+| **Default** | '✅' |
+| **Query Node** | '✅' |
+
+#### `SYSTEM_PEAK_BUFFER_MEMORY`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Peak memory usage of the system |
+| **Type** | uint64 |
+| **Unit** | bytes |
+| **Default** | '✅' |
+| **Query Node** | '✅' |
+| **Operator Node** | '✅' |
+
+#### `SYSTEM_PEAK_TEMP_DIR_SIZE`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Peak size of the temporary directory |
+| **Type** | uint64 |
+| **Unit** | bytes |
+| **Default** | '✅' |
+| **Query Node** | '✅' |
+| **Operator Node** | '✅' |
+
+#### `TOTAL_MEMORY_ALLOCATED`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The total memory allocated by the buffer manager. |
+| **Type** | uint64 |
+| **Unit** | bytes |
+| **Default** | '✅' |
+| **Query Node** | '✅' |
+
+### File Metrics
+metrics that are collected during file operations
+
+#### `ATTACH_LOAD_STORAGE_LATENCY`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Time spent loading from storage. |
+| **Type** | double |
+| **Unit** | seconds |
+| **Default** | '✅' |
+| **Query Node** | '✅' |
+
+#### `ATTACH_REPLAY_WAL_LATENCY`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Time spent replaying the WAL file. |
+| **Type** | double |
+| **Unit** | seconds |
+| **Default** | '✅' |
+| **Query Node** | '✅' |
+
+#### `CHECKPOINT_LATENCY`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Time spent running checkpoints |
+| **Type** | double |
+| **Unit** | seconds |
+| **Default** | '✅' |
+| **Query Node** | '✅' |
+
+#### `COMMIT_LOCAL_STORAGE_LATENCY`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Time spent committing the transaction-local storage. |
+| **Type** | double |
+| **Unit** | seconds |
+| **Default** | '✅' |
+| **Query Node** | '✅' |
+
+#### `TOTAL_BYTES_READ`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The total bytes read by the file system. |
+| **Type** | uint64 |
+| **Unit** | bytes |
+| **Default** | '✅' |
+| **Query Node** | '✅' |
+
+#### `TOTAL_BYTES_WRITTEN`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The total bytes written by the file system. |
+| **Type** | uint64 |
+| **Unit** | bytes |
+| **Default** | '✅' |
+| **Query Node** | '✅' |
+
+#### `WAITING_TO_ATTACH_LATENCY`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Time spent waiting to ATTACH a file. |
+| **Type** | double |
+| **Unit** | seconds |
+| **Default** | '✅' |
+| **Query Node** | '✅' |
+
+#### `WAL_REPLAY_ENTRY_COUNT`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The total number of entries to replay in the WAL. |
+| **Type** | uint64 |
+| **Unit** | absolute |
+| **Default** | '✅' |
+| **Query Node** | '✅' |
+
+#### `WRITE_TO_WAL_LATENCY`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Time spent writing to the WAL. |
+| **Type** | double |
+| **Unit** | seconds |
+| **Default** | '✅' |
+| **Query Node** | '✅' |
+
+### Operator Metrics
+metrics that are collected for each operator
+
+#### `OPERATOR_CARDINALITY`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Cardinality of the operator |
+| **Type** | uint64 |
+| **Unit** | absolute |
+| **Default** | '✅' |
+| **Operator Node** | '✅' |
+
+#### `OPERATOR_NAME`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Name of the operator |
+| **Type** | string |
+| **Default** | '✅' |
+| **Operator Node** | '✅' |
+
+#### `OPERATOR_ROWS_SCANNED`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Number of rows scanned by the operator |
+| **Type** | uint64 |
+| **Unit** | absolute |
+| **Default** | '✅' |
+| **Operator Node** | '✅' |
+
+#### `OPERATOR_TIMING`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Time spent in the operator |
+| **Type** | double |
+| **Unit** | seconds |
+| **Default** | '✅' |
+| **Operator Node** | '✅' |
+
+#### `OPERATOR_TYPE`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Type of the operator |
+| **Type** | uint8 |
+| **Default** | '✅' |
+| **Operator Node** | '✅' |
+
+### Phase_timing Metrics
+This group contains metrics related to the planner and the physical planner. The planner is responsible for generating the logical plan, whereas the physical planner is responsible for generating the physical plan from the logical plan.
+
+#### `PHYSICAL_PLANNER`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The time spent generating the physical plan |
+| **Type** | double |
+| **Unit** | milliseconds |
+| **Query Node** | '✅' |
+
+#### `PHYSICAL_PLANNER_COLUMN_BINDING`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The time spent binding the columns in the logical plan to physical columns |
+| **Type** | double |
+| **Unit** | milliseconds |
+| **Query Node** | '✅' |
+
+#### `PHYSICAL_PLANNER_CREATE_PLAN`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The time spent creating the physical plan |
+| **Type** | double |
+| **Unit** | milliseconds |
+| **Query Node** | '✅' |
+
+#### `PHYSICAL_PLANNER_RESOLVE_TYPES`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The time spent resolving the types in the logical plan to physical types |
+| **Type** | double |
+| **Unit** | milliseconds |
+| **Query Node** | '✅' |
+
+#### `PLANNER`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The time to generate the logical plan from the parsed SQL nodes. |
+| **Type** | double |
+| **Unit** | milliseconds |
+| **Query Node** | '✅' |
+
+#### `PLANNER_BINDING`
+
+<div class="nostroke_table"></div>
+
+| **Description** | The time taken to bind the logical plan. |
+| **Type** | double |
+| **Unit** | milliseconds |
+| **Query Node** | '✅' |
+
+
+### Optimizer Metrics
+Optimizer metrics sit at the `QUERY_ROOT` level, and measure the time taken by each [optimizer]({% link docs/current/internals/overview.md %}#optimizer).
+These metrics are only available when the specific optimizer is enabled.
+The available optimizations can be queried using the [`duckdb_optimizers()`{:.language-sql .highlight} table function]({% link docs/current/sql/meta/duckdb_table_functions.md %}#duckdb_optimizers).
+
+Each optimizer has a corresponding metric that follows the template: `OPTIMIZER_⟨OPTIMIZER_NAME⟩`{:.language-sql .highlight}.
+For example, the `OPTIMIZER_JOIN_ORDER` metric corresponds to the `JOIN_ORDER` optimizer.
+
+Additionally, the following metrics are available to support the optimizer metrics:
+
+#### `ALL_OPTIMIZERS`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Enables all optimizers |
+| **Type** | double |
+| **Query Node** | '✅' |
+
+#### `CUMULATIVE_OPTIMIZER_TIMING`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Time spent in all optimizers |
+| **Type** | double |
+| **Unit** | milliseconds |
+| **Query Node** | '✅' |
+
+
+## Cumulative Metrics
+
+DuckDB also supports several cumulative metrics that are available in all nodes.
+In the `QUERY_ROOT` node, these metrics represent the sum of the corresponding metrics across all operators in the query.
+The `OPERATOR` nodes represent the sum of the operator's specific metric and those of all its children recursively.
+
+These cumulative metrics can be enabled independently, even if the underlying specific metrics are disabled.
+The table below shows the cumulative metrics.
+It also depicts the metric based on which DuckDB calculates the cumulative metric.
+
+| Metric                    | Unit     | Metric calculated cumulatively |
+|---------------------------|----------|--------------------------------|
+| `CPU_TIME`                | seconds  | `OPERATOR_TIMING`              |
+| `CUMULATIVE_CARDINALITY`  | absolute | `OPERATOR_CARDINALITY`         |
+| `CUMULATIVE_ROWS_SCANNED` | absolute | `OPERATOR_ROWS_SCANNED`        |
+
+`CPU_TIME` measures the cumulative operator timings.
+It does not include time spent in other stages, like parsing, query planning, etc.
+Thus, for some queries, the `LATENCY` in the `QUERY_ROOT` can be greater than the `CPU_TIME`.
+

--- a/docs/current/dev/profiling.md
+++ b/docs/current/dev/profiling.md
@@ -49,14 +49,14 @@ The following pragmas are available and can be set using either `PRAGMA` or `SET
 They can also be reset using `RESET`, followed by the setting name.
 For more information, see the [“Profiling”]({% link docs/current/configuration/pragmas.md %}#profiling) section of the pragmas page.
 
-| Setting                                                                                                                                                                            | Description                                     | Default                                                  | Options                                                                                                                 |
-|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------|----------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|
-| [`enable_profiling`]({% link docs/current/configuration/pragmas.md %}#enable_profiling), [`enable_profile`]({% link docs/current/configuration/pragmas.md %}#enable_profiling)     | Turn on profiling                               | `query_tree`                                             | `query_tree`, `json`, `query_tree_optimizer`, `no_output`                                                               |
-| [`profiling_coverage`]({% link docs/current/configuration/pragmas.md %}#profiling_coverage)                                                                                        | Set the operators to profile                    | `SELECT`                                                 | `SELECT`, `ALL`                                                                                                         |
-| [`profiling_output`]({% link docs/current/configuration/pragmas.md %}#profiling_output)                                                                                            | Set a profiling output file                     | Console                                                  | A filepath                                                                                                              |
-| [`profiling_mode`]({% link docs/current/configuration/pragmas.md %}#profiling_mode)                                                                                                | Toggle additional optimizer and planner metrics | `standard`                                               | `standard`, `detailed`                                                                                                  |
-| [`custom_profiling_settings`]({% link docs/current/configuration/pragmas.md %}#custom_profiling_metrics)                                                                           | Enable or disable specific metrics              | All metrics except those activated by detailed profiling | A JSON object that matches the following: `{"METRIC_NAME": "boolean", ...}`. See the [metrics](#metrics) section below. |
-| [`disable_profiling`]({% link docs/current/configuration/pragmas.md %}#disable_profiling), [`disable_profile`]({% link docs/current/configuration/pragmas.md %}#disable_profiling) | Turn off profiling                              |                                                          |                                                                                                                         |
+| Setting                                                                                                                                                                            | Description                                     | Default                                                  | Options                                                                                                                                                            |
+|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------|----------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [`enable_profiling`]({% link docs/current/configuration/pragmas.md %}#enable_profiling), [`enable_profile`]({% link docs/current/configuration/pragmas.md %}#enable_profiling)     | Turn on profiling                               | `query_tree`                                             | `query_tree`, `json`, `query_tree_optimizer`, `no_output`                                                                                                          |
+| [`profiling_coverage`]({% link docs/current/configuration/pragmas.md %}#profiling_coverage)                                                                                        | Set the operators to profile                    | `SELECT`                                                 | `SELECT`, `ALL`                                                                                                                                                    |
+| [`profiling_output`]({% link docs/current/configuration/pragmas.md %}#profiling_output)                                                                                            | Set a profiling output file                     | Console                                                  | A filepath                                                                                                                                                         |
+| [`profiling_mode`]({% link docs/current/configuration/pragmas.md %}#profiling_mode)                                                                                                | Toggle additional optimizer and planner metrics | `standard`                                               | `standard`, `detailed`                                                                                                                                             |
+| [`configure_profiling`]({% link docs/current/configuration/pragmas.md %}#custom_profiling_metrics)                                                                                 | Enable or disable specific metrics              | All metrics except those activated by detailed profiling | A JSON object that matches the following: `{"METRIC_NAME": "boolean", ...}`. ([List of all available metrics]({% link docs/current/dev/metrics.md %}#all_metrics)) |
+| [`disable_profiling`]({% link docs/current/configuration/pragmas.md %}#disable_profiling), [`disable_profile`]({% link docs/current/configuration/pragmas.md %}#disable_profiling) | Turn off profiling                              |                                                          |                                                                                                                                                                    |
 
 ## Table Functions
 
@@ -102,194 +102,13 @@ CALL disable_profiling();
 
 ## Metrics
 
-The query tree has two types of nodes: the `QUERY_ROOT` and `OPERATOR` nodes.
-The `QUERY_ROOT` refers exclusively to the top-level node, and the metrics it contains are measured over the entire query.
-The `OPERATOR` nodes refer to the individual operators in the query plan.
-Some metrics are only available for `QUERY_ROOT` nodes, while others are only for `OPERATOR` nodes.
-The table below describes each metric and which nodes they are available for.
-
-Other than `QUERY_NAME` and `OPERATOR_TYPE`, it is possible to turn all metrics on or off.
-
-| Metric                  | Return type |   Unit   | Query | Operator | Description                                                                                                                   |
-|-------------------------|-------------|----------|:-----:|:--------:|-------------------------------------------------------------------------------------------------------------------------------|
-| `BLOCKED_THREAD_TIME`   | `double`    | seconds  |   ✅  |          | The total time threads are blocked                                                                                           |
-| `EXTRA_INFO`            | `string`    |          |   ✅  |    ✅    | Unique operator metrics                                                                                                      |
-| `LATENCY`               | `double`    | seconds  |   ✅  |          | The total elapsed query execution time                                                                                       |
-| `OPERATOR_CARDINALITY`  | `uint64`    | absolute |       |    ✅    | The cardinality of each operator, i.e., the number of rows it returns to its parent. Operator equivalent of `ROWS_RETURNED`  |
-| `OPERATOR_ROWS_SCANNED` | `uint64`    | absolute |       |    ✅    | The total rows scanned by each operator                                                                                      |
-| `OPERATOR_TIMING`       | `double`    | seconds  |       |    ✅    | The time taken by each operator. Operator equivalent of `LATENCY`                                                            |
-| `OPERATOR_TYPE`         | `string`    |          |       |    ✅    | The name of each operator                                                                                                    |
-| `QUERY_NAME`            | `string`    |          |   ✅  |          | The query string                                                                                                             |
-| `RESULT_SET_SIZE`       | `uint64`    |  bytes   |   ✅  |    ✅    | The size of the result                                                                                                       |
-| `ROWS_RETURNED`         | `uint64`    | absolute |   ✅  |          | The number of rows returned by the query                                                                                     |
-
-### Cumulative Metrics
-
-DuckDB also supports several cumulative metrics that are available in all nodes.
-In the `QUERY_ROOT` node, these metrics represent the sum of the corresponding metrics across all operators in the query.
-The `OPERATOR` nodes represent the sum of the operator's specific metric and those of all its children recursively.
-
-These cumulative metrics can be enabled independently, even if the underlying specific metrics are disabled.
-The table below shows the cumulative metrics.
-It also depicts the metric based on which DuckDB calculates the cumulative metric.
-
-| Metric                    | Unit     | Metric calculated cumulatively |
-|---------------------------|----------|--------------------------------|
-| `CPU_TIME`                | seconds  | `OPERATOR_TIMING`              |
-| `CUMULATIVE_CARDINALITY`  | absolute | `OPERATOR_CARDINALITY`         |
-| `CUMULATIVE_ROWS_SCANNED` | absolute | `OPERATOR_ROWS_SCANNED`        |
-
-`CPU_TIME` measures the cumulative operator timings.
-It does not include time spent in other stages, like parsing, query planning, etc.
-Thus, for some queries, the `LATENCY` in the `QUERY_ROOT` can be greater than the `CPU_TIME`.
+DuckDB supports a wide range of metrics that can be enabled or disabled independently. To learn more and to see the full list of available metrics, refer to the [metrics documentation]({% link docs/current/dev/metrics.md %}#all_metrics).
 
 ## Detailed Profiling
 
 When the `profiling_mode` is set to `detailed`, an extra set of metrics are enabled, which are only available in the `QUERY_ROOT` node.
-These include [`OPTIMIZER`](#optimizer-metrics), [`PLANNER`](#planner-metrics), and [`PHYSICAL_PLANNER`](#physical-planner-metrics) metrics.
-They are measured in seconds and returned as a `double`.
+These include all the metrics in the [Phase timing]({% link docs/current/dev/metrics.md %}#phase_timing_metrics) metric group.
 It is possible to toggle each of these additional metrics individually.
-
-### Optimizer Metrics
-
-At the `QUERY_ROOT` node, there are metrics that measure the time taken by each [optimizer]({% link docs/current/internals/overview.md %}#optimizer).
-These metrics are only available when the specific optimizer is enabled.
-The available optimizations can be queried using the [`duckdb_optimizers()`{:.language-sql .highlight} table function]({% link docs/current/sql/meta/duckdb_table_functions.md %}#duckdb_optimizers).
-
-Each optimizer has a corresponding metric that follows the template: `OPTIMIZER_⟨OPTIMIZER_NAME⟩`{:.language-sql .highlight}.
-For example, the `OPTIMIZER_JOIN_ORDER` metric corresponds to the `JOIN_ORDER` optimizer.
-
-Additionally, the following metrics are available to support the optimizer metrics:
-
-* `ALL_OPTIMIZERS`: Enables all optimizer metrics and measures the time the optimizer parent node takes.
-* `CUMULATIVE_OPTIMIZER_TIMING`: The cumulative sum of all optimizer metrics. It is usable without turning on all optimizer metrics.
-
-### Planner Metrics
-
-The planner is responsible for generating the logical plan. Currently, DuckDB measures two metrics in the planner:
-
-* `PLANNER`: The time to generate the logical plan from the parsed SQL nodes.
-* `PLANNER_BINDING`: The time taken to bind the logical plan.
-
-### Physical Planner Metrics
-
-The physical planner is responsible for generating the physical plan from the logical plan.
-The following are the metrics supported in the physical planner:
-
-* `PHYSICAL_PLANNER`: The time spent generating the physical plan.
-* `PHYSICAL_PLANNER_COLUMN_BINDING`: The time spent binding the columns in the logical plan to physical columns.
-* `PHYSICAL_PLANNER_RESOLVE_TYPES`: The time spent resolving the types in the logical plan to physical types.
-* `PHYSICAL_PLANNER_CREATE_PLAN`: The time spent creating the physical plan.
-
-## Custom Metrics Examples
-
-The following examples demonstrate how to enable custom profiling and set the output format to `json`.
-In the first example, we enable profiling and set the output to a file.
-We only enable `EXTRA_INFO`, `OPERATOR_CARDINALITY`, and `OPERATOR_TIMING`.
-
-```sql
-CREATE TABLE students (name VARCHAR, sid INTEGER);
-CREATE TABLE exams (eid INTEGER, subject VARCHAR, sid INTEGER);
-INSERT INTO students VALUES ('Mark', 1), ('Joe', 2), ('Matthew', 3);
-INSERT INTO exams VALUES (10, 'Physics', 1), (20, 'Chemistry', 2), (30, 'Literature', 3);
-
-PRAGMA enable_profiling = 'json';
-PRAGMA profiling_output = '/path/to/file.json';
-
-PRAGMA custom_profiling_settings = '{"CPU_TIME": "false", "EXTRA_INFO": "true", "OPERATOR_CARDINALITY": "true", "OPERATOR_TIMING": "true"}';
-
-SELECT name
-FROM students
-JOIN exams USING (sid)
-WHERE name LIKE 'Ma%';
-```
-
-The file's content after executing the query:
-
-```json
-{
-    "extra_info": {},
-    "query_name": "SELECT name\nFROM students\nJOIN exams USING (sid)\nWHERE name LIKE 'Ma%';",
-    "children": [
-        {
-            "operator_timing": 0.000001,
-            "operator_cardinality": 2,
-            "operator_type": "PROJECTION",
-            "extra_info": {
-                "Projections": "name",
-                "Estimated Cardinality": "1"
-            },
-            "children": [
-                {
-                    "extra_info": {
-                        "Join Type": "INNER",
-                        "Conditions": "sid = sid",
-                        "Build Min": "1",
-                        "Build Max": "3",
-                        "Estimated Cardinality": "1"
-                    },
-                    "operator_cardinality": 2,
-                    "operator_type": "HASH_JOIN",
-                    "operator_timing": 0.00023899999999999998,
-                    "children": [
-...
-```
-
-The second example adds detailed metrics to the output.
-
-```sql
-PRAGMA profiling_mode = 'detailed';
-
-SELECT name
-FROM students
-JOIN exams USING (sid)
-WHERE name LIKE 'Ma%';
-```
-
-The contents of the outputted file:
-
-```json
-{
-  "all_optimizers": 0.001413,
-  "cumulative_optimizer_timing": 0.0014120000000000003,
-  "planner": 0.000873,
-  "planner_binding": 0.000869,
-  "physical_planner": 0.000236,
-  "physical_planner_column_binding": 0.000005,
-  "physical_planner_resolve_types": 0.000001,
-  "physical_planner_create_plan": 0.000226,
-  "optimizer_expression_rewriter": 0.000029,
-  "optimizer_filter_pullup": 0.000002,
-  "optimizer_filter_pushdown": 0.000102,
-...
-  "optimizer_column_lifetime": 0.000009999999999999999,
-  "rows_returned": 2,
-  "latency": 0.003708,
-  "cumulative_rows_scanned": 6,
-  "cumulative_cardinality": 11,
-  "extra_info": {},
-  "cpu_time": 0.000095,
-  "optimizer_build_side_probe_side": 0.000017,
-  "result_set_size": 32,
-  "blocked_thread_time": 0.0,
-  "query_name": "SELECT name\nFROM students\nJOIN exams USING (sid)\nWHERE name LIKE 'Ma%';",
-  "children": [
-    {
-      "operator_timing": 0.000001,
-      "operator_rows_scanned": 0,
-      "cumulative_rows_scanned": 6,
-      "operator_cardinality": 2,
-      "operator_type": "PROJECTION",
-      "cumulative_cardinality": 11,
-      "extra_info": {
-        "Projections": "name",
-        "Estimated Cardinality": "1"
-      },
-      "result_set_size": 32,
-      "cpu_time": 0.000095,
-      "children": [
-...
-```
 
 ## Query Graphs
 

--- a/scripts/generate_profiling_docs.py
+++ b/scripts/generate_profiling_docs.py
@@ -14,7 +14,7 @@ METRICS_DOC_TEMPLATE = REPO_ROOT / "scripts" / "metrics.md.template"
 METRICS_MARKER = "<!-- METRICS_TABLE -->"
 END_METRICS_MARKER = "<!-- END_METRICS_TABLE -->"
 GROUPS_MARKER = "<!-- GROUPS -->"
-END_GROUPS_MARKER = "<!-- END_GROUPS_TABLE -->"
+END_GROUPS_MARKER = "<!-- END_GROUPS -->"
 OPTIMIZER_MARKER = "<!-- OPTIMIZER_METRICS -->"
 END_OPTIMIZER_MARKER = "<!-- END_OPTIMIZER_METRICS -->"
 CUMULATIVE_MARKER = "<!-- CUMULATIVE_METRICS -->"
@@ -36,10 +36,10 @@ def _write_individual_metric(f, metric):
     table = f"| **Description** | {metric.description} |\n"
     table += f"| **Type** | {metric.type} |\n"
     table += f"| **Unit** | {metric.unit} |\n" if metric.unit != "--" else ""
-    table += f"| **Default** | '✅' |\n" if metric.is_default else ''
-    table += f"| **Query Node** | '✅' |\n" if is_query_node else ''
-    table += f"| **Operator Node** | '✅' |\n" if is_operator_node else ''
-    table += f"| **[Cumulative](#cumulative_metrics)** | '✅' |\n" if metric.collection_method == "cumulative" else ''
+    table += f"| **Default** | ✅ |\n" if metric.is_default else ''
+    table += f"| **Query Node** | ✅ |\n" if is_query_node else ''
+    table += f"| **Operator Node** | ✅ |\n" if is_operator_node else ''
+    table += f"| **[Cumulative](#cumulative_metrics)** | ✅ |\n" if metric.collection_method == "cumulative" else ''
     table += f"| **Child** | {metric.child} |\n" if metric.child else ''
     f.write(table + "\n")
 
@@ -87,31 +87,28 @@ def main():
     optimizers = retrieve_optimizers(OPTIMIZER_HPP)
     metric_index = build_all_metrics(metrics_json, optimizers)
 
-    # Generate metrics table
-    metrics_table = []
-
-    for metric in metric_index.defs:
-        is_operator_node = metric.group == "operator"
-        is_query_node = metric.query_root
-
-        if metric.query_root is False and metric.group != "operator":
-            is_query_node = True
-            is_operator_node = True
-
-        metrics_table.append([
-            f"[`{metric.name}`](#{metric.name})",
-            f"[{metric.group}](#{metric.group}-metrics)",
-            metric.description
-        ])
 
     with IndentedFileWriter(METRICS_DOC_PATH) as f:
-        f.write(retrieve_template(METRICS_DOC_TEMPLATE, START_OF_FILE, METRICS_MARKER))
+        f.write(retrieve_template(METRICS_DOC_TEMPLATE, START_OF_FILE, METRICS_MARKER).lstrip('\n'))
+
+        # Generate metrics table
+        metrics_table = []
+
+        for metric in metric_index.defs:
+            if metric.group == "optimizer":
+                continue
+            metrics_table.append([
+                f"[`{metric.name}`](#{metric.name.lower().replace(' ', '_')})",
+                f"[{metric.group}](#{metric.group}-metrics)",
+                metric.description
+            ])
 
         metric_table_headers = ["Name", "Group", "Description"]
+        f.write("\n")
         f.write(tabulate(metrics_table, headers=metric_table_headers, tablefmt="github"))
         f.write("\n\n")
 
-        f.write(retrieve_template(METRICS_DOC_TEMPLATE, METRICS_MARKER, END_METRICS_MARKER))
+        f.write(retrieve_template(METRICS_DOC_TEMPLATE, GROUPS_MARKER, END_GROUPS_MARKER))
         for group in metric_index.group_names:
             if group not in ("all", "default"):
                 f.write(f"- [`{group.upper()}`](#{group}-metrics)\n")
@@ -121,12 +118,12 @@ def main():
         cumulative_metrics = []
 
         for group in metric_index.group_names:
-            if group == "all" or group == "default" or group == "optimizer":
+            if group in ("all", "default", "optimizer"):
                 continue
 
             group_metrics = [m for m in metric_index.defs if m.group == group]
 
-            f.write(f"### {group.capitalize()} Metrics\n")
+            f.write(f"## {group.capitalize()} Metrics\n")
             f.write(metric_index.group_description(group) + "\n\n")
 
             for metric in group_metrics:

--- a/scripts/generate_profiling_docs.py
+++ b/scripts/generate_profiling_docs.py
@@ -22,6 +22,16 @@ END_CUMALATIVE_MARKER = "<!-- END_CUMULATIVE_METRICS -->"
 EXAMPLES_MARKER = "<!-- EXAMPLES -->"
 END_EXAMPLES_MARKER = "<!-- END_EXAMPLES -->"
 
+CPU_TIME_NOTE = f"""`CPU_TIME` measures the cumulative operator timings.
+It does not include time spent in other stages, like parsing, query planning, etc.
+Thus, for some queries, the `LATENCY` in the `QUERY_ROOT` can be greater than the `CPU_TIME`.
+"""
+
+
+def _write_heading(f, heading):
+    f.write(f"\n{heading}\n\n")
+
+
 def _write_individual_metric(f, metric):
     is_operator_node = metric.group == "operator"
     is_query_node = metric.query_root
@@ -30,7 +40,7 @@ def _write_individual_metric(f, metric):
         is_query_node = True
         is_operator_node = True
 
-    f.write(f"#### `{metric.name}`\n\n")
+    _write_heading(f, f"#### `{metric.name}`")
     f.write("<div class=\"nostroke_table\"></div>\n\n")
 
     table = f"| **Description** | {metric.description} |\n"
@@ -39,9 +49,16 @@ def _write_individual_metric(f, metric):
     table += f"| **Default** | ✅ |\n" if metric.is_default else ''
     table += f"| **Query Node** | ✅ |\n" if is_query_node else ''
     table += f"| **Operator Node** | ✅ |\n" if is_operator_node else ''
-    table += f"| **[Cumulative](#cumulative_metrics)** | ✅ |\n" if metric.collection_method == "cumulative" else ''
+    table += (
+        f"| **[Cumulative](#cumulative-metrics)** | ✅ |\n"
+        if metric.collection_method and "cumulative" in metric.collection_method.lower()
+        else ''
+    )
     table += f"| **Child** | {metric.child} |\n" if metric.child else ''
     f.write(table + "\n")
+
+    if metric.name == "CPU_TIME":
+        f.write(f"**Note:**\n\n{CPU_TIME_NOTE}\n\n")
 
 
 def _write_section_from_template(f, metrics, section):
@@ -59,7 +76,7 @@ def main():
         "--duckdb-path",
         required=True,
         type=str,
-        help="Path to the DuckDB repository (used to read metric definitions and optimizer types)"
+        help="Path to the DuckDB repository (used to read metric definitions and optimizer types)",
     )
 
     args = parser.parse_args()
@@ -68,7 +85,12 @@ def main():
     sys.path.append(str(metrics_package_path))
 
     try:
-        from metrics.inputs import load_metrics_json, retrieve_optimizers, retrieve_template, START_OF_FILE
+        from metrics.inputs import (
+            load_metrics_json,
+            retrieve_optimizers,
+            retrieve_template,
+            START_OF_FILE,
+        )
         from metrics.model import build_all_metrics
         from metrics.paths import (
             METRICS_JSON,
@@ -76,10 +98,14 @@ def main():
         )
         from metrics.writer import IndentedFileWriter
     except ImportError as e:
-        print(f"Error: Could not find profiling metric tools in {metrics_package_path / 'metrics'}.")
+        print(
+            f"Error: Could not find profiling metric tools in {metrics_package_path / 'metrics'}."
+        )
         print(f"DuckDB path provided: {args.duckdb_path}")
         print(f"Resolved base path: {base_path}")
-        print("Please ensure the DuckDB path is correct and points to a DuckDB repository with the required scripts in scripts/metrics.")
+        print(
+            "Please ensure the DuckDB path is correct and points to a DuckDB repository with the required scripts in scripts/metrics."
+        )
         print(f"Original error: {e}")
         sys.exit(1)
 
@@ -87,9 +113,12 @@ def main():
     optimizers = retrieve_optimizers(OPTIMIZER_HPP)
     metric_index = build_all_metrics(metrics_json, optimizers)
 
-
     with IndentedFileWriter(METRICS_DOC_PATH) as f:
-        f.write(retrieve_template(METRICS_DOC_TEMPLATE, START_OF_FILE, METRICS_MARKER).lstrip('\n'))
+        f.write(
+            retrieve_template(
+                METRICS_DOC_TEMPLATE, START_OF_FILE, METRICS_MARKER
+            ).lstrip('\n')
+        )
 
         # Generate metrics table
         metrics_table = []
@@ -97,18 +126,23 @@ def main():
         for metric in metric_index.defs:
             if metric.group == "optimizer":
                 continue
-            metrics_table.append([
-                f"[`{metric.name}`](#{metric.name.lower().replace(' ', '_')})",
-                f"[{metric.group}](#{metric.group}-metrics)",
-                metric.description
-            ])
+            metrics_table.append(
+                [
+                    f"[`{metric.name}`](#{metric.name.lower().replace(' ', '_')})",
+                    f"[{metric.group}](#{metric.group}-metrics)",
+                    metric.description,
+                ]
+            )
 
         metric_table_headers = ["Name", "Group", "Description"]
-        f.write("\n")
-        f.write(tabulate(metrics_table, headers=metric_table_headers, tablefmt="github"))
+        f.write(
+            tabulate(metrics_table, headers=metric_table_headers, tablefmt="github")
+        )
         f.write("\n\n")
 
-        f.write(retrieve_template(METRICS_DOC_TEMPLATE, GROUPS_MARKER, END_GROUPS_MARKER))
+        f.write(
+            retrieve_template(METRICS_DOC_TEMPLATE, GROUPS_MARKER, END_GROUPS_MARKER)
+        )
         for group in metric_index.group_names:
             if group not in ("all", "default"):
                 f.write(f"- [`{group.upper()}`](#{group}-metrics)\n")
@@ -123,26 +157,45 @@ def main():
 
             group_metrics = [m for m in metric_index.defs if m.group == group]
 
-            f.write(f"## {group.capitalize()} Metrics\n")
+            _write_heading(f, f"### {group.capitalize()} Metrics")
             f.write(metric_index.group_description(group) + "\n\n")
 
             for metric in group_metrics:
-                if metric.collection_method == "cumulative":
+                if (
+                    metric.collection_method
+                    and "cumulative" in metric.collection_method.lower()
+                ):
                     cumulative_metrics.append(metric)
 
                 if "optimizer" in metric.name.lower():
                     optimizers.append(metric)
-                else:
-                    _write_individual_metric(f, metric)
+
+                _write_individual_metric(f, metric)
 
         # write optimizer metrics
-        f.write(retrieve_template(METRICS_DOC_TEMPLATE, OPTIMIZER_MARKER, END_OPTIMIZER_MARKER))
+        f.write(
+            retrieve_template(
+                METRICS_DOC_TEMPLATE, OPTIMIZER_MARKER, END_OPTIMIZER_MARKER
+            )
+        )
         for metric in optimizers:
-            _write_individual_metric(f, metric)
+            f.write(f"- [`{metric.name}`](#{metric.name.lower().replace(' ', '_')})\n")
 
         # write cumulative metrics
-        f.write(retrieve_template(METRICS_DOC_TEMPLATE, CUMULATIVE_MARKER, END_CUMALATIVE_MARKER))
+        f.write(
+            retrieve_template(
+                METRICS_DOC_TEMPLATE, CUMULATIVE_MARKER, END_CUMALATIVE_MARKER
+            )
+        )
+        for metric in cumulative_metrics:
+            f.write(f"- [`{metric.name}`](#{metric.name.lower().replace(' ', '_')})\n")
 
+        # write examples
+        f.write(
+            retrieve_template(
+                METRICS_DOC_TEMPLATE, EXAMPLES_MARKER, END_EXAMPLES_MARKER
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/generate_profiling_docs.py
+++ b/scripts/generate_profiling_docs.py
@@ -1,0 +1,152 @@
+import argparse
+import os
+import sys
+from pathlib import Path
+
+from jinja2.optimizer import Optimizer
+from tabulate import tabulate
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+METRIC_TOOLS_PATH = Path("scripts") / "metrics"
+METRICS_DOC_PATH = REPO_ROOT / "docs" / "current" / "dev" / "metrics.md"
+METRICS_DOC_TEMPLATE = REPO_ROOT / "scripts" / "metrics.md.template"
+
+METRICS_MARKER = "<!-- METRICS_TABLE -->"
+END_METRICS_MARKER = "<!-- END_METRICS_TABLE -->"
+GROUPS_MARKER = "<!-- GROUPS -->"
+END_GROUPS_MARKER = "<!-- END_GROUPS_TABLE -->"
+OPTIMIZER_MARKER = "<!-- OPTIMIZER_METRICS -->"
+END_OPTIMIZER_MARKER = "<!-- END_OPTIMIZER_METRICS -->"
+CUMULATIVE_MARKER = "<!-- CUMULATIVE_METRICS -->"
+END_CUMALATIVE_MARKER = "<!-- END_CUMULATIVE_METRICS -->"
+EXAMPLES_MARKER = "<!-- EXAMPLES -->"
+END_EXAMPLES_MARKER = "<!-- END_EXAMPLES -->"
+
+def _write_individual_metric(f, metric):
+    is_operator_node = metric.group == "operator"
+    is_query_node = metric.query_root
+
+    if metric.query_root is False and metric.group != "operator":
+        is_query_node = True
+        is_operator_node = True
+
+    f.write(f"#### `{metric.name}`\n\n")
+    f.write("<div class=\"nostroke_table\"></div>\n\n")
+
+    table = f"| **Description** | {metric.description} |\n"
+    table += f"| **Type** | {metric.type} |\n"
+    table += f"| **Unit** | {metric.unit} |\n" if metric.unit != "--" else ""
+    table += f"| **Default** | '✅' |\n" if metric.is_default else ''
+    table += f"| **Query Node** | '✅' |\n" if is_query_node else ''
+    table += f"| **Operator Node** | '✅' |\n" if is_operator_node else ''
+    table += f"| **[Cumulative](#cumulative_metrics)** | '✅' |\n" if metric.collection_method == "cumulative" else ''
+    table += f"| **Child** | {metric.child} |\n" if metric.child else ''
+    f.write(table + "\n")
+
+
+def _write_section_from_template(f, metrics, section):
+    f.write(section)
+    for metric in metrics:
+        _write_individual_metric(f, metric)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate documentation for DuckDB profiling metrics based on the definitions in duckdb/src/common/enums/metric_type.json"
+    )
+
+    parser.add_argument(
+        "--duckdb-path",
+        required=True,
+        type=str,
+        help="Path to the DuckDB repository (used to read metric definitions and optimizer types)"
+    )
+
+    args = parser.parse_args()
+    base_path = REPO_ROOT / args.duckdb_path
+    metrics_package_path = base_path / "scripts"
+    sys.path.append(str(metrics_package_path))
+
+    try:
+        from metrics.inputs import load_metrics_json, retrieve_optimizers, retrieve_template, START_OF_FILE
+        from metrics.model import build_all_metrics
+        from metrics.paths import (
+            METRICS_JSON,
+            OPTIMIZER_HPP,
+        )
+        from metrics.writer import IndentedFileWriter
+    except ImportError as e:
+        print(f"Error: Could not find profiling metric tools in {metrics_package_path / 'metrics'}.")
+        print(f"DuckDB path provided: {args.duckdb_path}")
+        print(f"Resolved base path: {base_path}")
+        print("Please ensure the DuckDB path is correct and points to a DuckDB repository with the required scripts in scripts/metrics.")
+        print(f"Original error: {e}")
+        sys.exit(1)
+
+    metrics_json = load_metrics_json(METRICS_JSON)
+    optimizers = retrieve_optimizers(OPTIMIZER_HPP)
+    metric_index = build_all_metrics(metrics_json, optimizers)
+
+    # Generate metrics table
+    metrics_table = []
+
+    for metric in metric_index.defs:
+        is_operator_node = metric.group == "operator"
+        is_query_node = metric.query_root
+
+        if metric.query_root is False and metric.group != "operator":
+            is_query_node = True
+            is_operator_node = True
+
+        metrics_table.append([
+            f"[`{metric.name}`](#{metric.name})",
+            f"[{metric.group}](#{metric.group}-metrics)",
+            metric.description
+        ])
+
+    with IndentedFileWriter(METRICS_DOC_PATH) as f:
+        f.write(retrieve_template(METRICS_DOC_TEMPLATE, START_OF_FILE, METRICS_MARKER))
+
+        metric_table_headers = ["Name", "Group", "Description"]
+        f.write(tabulate(metrics_table, headers=metric_table_headers, tablefmt="github"))
+        f.write("\n\n")
+
+        f.write(retrieve_template(METRICS_DOC_TEMPLATE, METRICS_MARKER, END_METRICS_MARKER))
+        for group in metric_index.group_names:
+            if group not in ("all", "default"):
+                f.write(f"- [`{group.upper()}`](#{group}-metrics)\n")
+
+        f.write("\n")
+        optimizers = []
+        cumulative_metrics = []
+
+        for group in metric_index.group_names:
+            if group == "all" or group == "default" or group == "optimizer":
+                continue
+
+            group_metrics = [m for m in metric_index.defs if m.group == group]
+
+            f.write(f"### {group.capitalize()} Metrics\n")
+            f.write(metric_index.group_description(group) + "\n\n")
+
+            for metric in group_metrics:
+                if metric.collection_method == "cumulative":
+                    cumulative_metrics.append(metric)
+
+                if "optimizer" in metric.name.lower():
+                    optimizers.append(metric)
+                else:
+                    _write_individual_metric(f, metric)
+
+        # write optimizer metrics
+        f.write(retrieve_template(METRICS_DOC_TEMPLATE, OPTIMIZER_MARKER, END_OPTIMIZER_MARKER))
+        for metric in optimizers:
+            _write_individual_metric(f, metric)
+
+        # write cumulative metrics
+        f.write(retrieve_template(METRICS_DOC_TEMPLATE, CUMULATIVE_MARKER, END_CUMALATIVE_MARKER))
+
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/metrics.md.template
+++ b/scripts/metrics.md.template
@@ -1,0 +1,180 @@
+// !!!!!!!
+// WARNING: this file is used for doc generation by scripts/generate_profiling_docs.py after modifying the code below, rerun
+//          the script to apply changes to the generated files
+// !!!!!!!
+
+// DUCKDB_START_OF_FILE
+---
+layout: docu
+title: Metrics
+redirect_from:
+  - /dev/metrics
+---
+
+DuckDB provides a set of metrics that can be used to monitor the performance and health of the database.
+
+The query tree has two types of nodes: the `QUERY_ROOT` and `OPERATOR` nodes.
+The `QUERY_ROOT` refers exclusively to the top-level node, and the metrics it contains are measured over the entire query.
+The `OPERATOR` nodes refer to the individual operators in the query plan.
+Some metrics are only available for `QUERY_ROOT` nodes, while others are only for `OPERATOR` nodes.
+The table below describes each metric and which nodes they are available for.
+
+Other than `OPERATOR_TYPE`, all metrics can be turned on or off.
+
+# All Metrics
+<!-- METRICS_TABLE -->
+<!-- END_METRICS_TABLE -->
+
+## Metric Groups:
+The metrics are organized into groups, which can be used to enable or disable related metrics together.
+The following is a list of the available metric groups:
+- `ALL`: All metrics
+- `DEFAULT`: The default set of metrics
+<!-- GROUPS -->
+<!-- END_GROUPS -->
+
+<!-- OPTIMIZER_METRICS -->
+### Optimizer Metrics
+Optimizer metrics sit at the `QUERY_ROOT` level, and measure the time taken by each [optimizer]({% link docs/current/internals/overview.md %}#optimizer).
+These metrics are only available when the specific optimizer is enabled.
+The available optimizations can be queried using the [`duckdb_optimizers()`{:.language-sql .highlight} table function]({% link docs/current/sql/meta/duckdb_table_functions.md %}#duckdb_optimizers).
+
+Each optimizer has a corresponding metric that follows the template: `OPTIMIZER_⟨OPTIMIZER_NAME⟩`{:.language-sql .highlight}.
+For example, the `OPTIMIZER_JOIN_ORDER` metric corresponds to the `JOIN_ORDER` optimizer.
+
+Additionally, the following metrics are available to support the optimizer metrics:
+
+<!-- END_OPTIMIZER_METRICS -->
+<!-- CUMULATIVE_METRICS -->
+## Cumulative Metrics
+
+DuckDB also supports several cumulative metrics that are available in all nodes.
+In the `QUERY_ROOT` node, these metrics represent the sum of the corresponding metrics across all operators in the query.
+The `OPERATOR` nodes represent the sum of the operator's specific metric and those of all its children recursively.
+
+These cumulative metrics can be enabled independently, even if the underlying specific metrics are disabled.
+The table below shows the cumulative metrics.
+It also depicts the metric based on which DuckDB calculates the cumulative metric.
+
+| Metric                    | Unit     | Metric calculated cumulatively |
+|---------------------------|----------|--------------------------------|
+| `CPU_TIME`                | seconds  | `OPERATOR_TIMING`              |
+| `CUMULATIVE_CARDINALITY`  | absolute | `OPERATOR_CARDINALITY`         |
+| `CUMULATIVE_ROWS_SCANNED` | absolute | `OPERATOR_ROWS_SCANNED`        |
+
+`CPU_TIME` measures the cumulative operator timings.
+It does not include time spent in other stages, like parsing, query planning, etc.
+Thus, for some queries, the `LATENCY` in the `QUERY_ROOT` can be greater than the `CPU_TIME`.
+
+<!-- END_CUMULATIVE_METRICS -->
+<!-- EXAMPLES -->
+## Examples
+
+The following examples demonstrate how to enable custom profiling and set the output format to `json`.
+In the first example, we enable profiling and set the output to a file.
+We only enable `EXTRA_INFO`, `OPERATOR_CARDINALITY`, and `OPERATOR_TIMING`.
+
+```sql
+CREATE TABLE students (name VARCHAR, sid INTEGER);
+CREATE TABLE exams (eid INTEGER, subject VARCHAR, sid INTEGER);
+INSERT INTO students VALUES ('Mark', 1), ('Joe', 2), ('Matthew', 3);
+INSERT INTO exams VALUES (10, 'Physics', 1), (20, 'Chemistry', 2), (30, 'Literature', 3);
+
+PRAGMA enable_profiling = 'json';
+PRAGMA profiling_output = '/path/to/file.json';
+
+PRAGMA configure_profiling = '{"CPU_TIME": "false", "EXTRA_INFO": "true", "OPERATOR_CARDINALITY": "true", "OPERATOR_TIMING": "true"}';
+
+SELECT name
+FROM students
+JOIN exams USING (sid)
+WHERE name LIKE 'Ma%';
+```
+
+The file's content after executing the query:
+
+```json
+{
+    "extra_info": {},
+    "query_name": "SELECT name\nFROM students\nJOIN exams USING (sid)\nWHERE name LIKE 'Ma%';",
+    "children": [
+        {
+            "operator_timing": 0.000001,
+            "operator_cardinality": 2,
+            "operator_type": "PROJECTION",
+            "extra_info": {
+                "Projections": "name",
+                "Estimated Cardinality": "1"
+            },
+            "children": [
+                {
+                    "extra_info": {
+                        "Join Type": "INNER",
+                        "Conditions": "sid = sid",
+                        "Build Min": "1",
+                        "Build Max": "3",
+                        "Estimated Cardinality": "1"
+                    },
+                    "operator_cardinality": 2,
+                    "operator_type": "HASH_JOIN",
+                    "operator_timing": 0.00023899999999999998,
+                    "children": [
+...
+```
+
+The second example adds detailed metrics to the output.
+
+```sql
+PRAGMA profiling_mode = 'detailed';
+
+SELECT name
+FROM students
+JOIN exams USING (sid)
+WHERE name LIKE 'Ma%';
+```
+
+The contents of the outputted file:
+
+```json
+{
+  "all_optimizers": 0.001413,
+  "cumulative_optimizer_timing": 0.0014120000000000003,
+  "planner": 0.000873,
+  "planner_binding": 0.000869,
+  "physical_planner": 0.000236,
+  "physical_planner_column_binding": 0.000005,
+  "physical_planner_resolve_types": 0.000001,
+  "physical_planner_create_plan": 0.000226,
+  "optimizer_expression_rewriter": 0.000029,
+  "optimizer_filter_pullup": 0.000002,
+  "optimizer_filter_pushdown": 0.000102,
+...
+  "optimizer_column_lifetime": 0.000009999999999999999,
+  "rows_returned": 2,
+  "latency": 0.003708,
+  "cumulative_rows_scanned": 6,
+  "cumulative_cardinality": 11,
+  "extra_info": {},
+  "cpu_time": 0.000095,
+  "optimizer_build_side_probe_side": 0.000017,
+  "result_set_size": 32,
+  "blocked_thread_time": 0.0,
+  "query_name": "SELECT name\nFROM students\nJOIN exams USING (sid)\nWHERE name LIKE 'Ma%';",
+  "children": [
+    {
+      "operator_timing": 0.000001,
+      "operator_rows_scanned": 0,
+      "cumulative_rows_scanned": 6,
+      "operator_cardinality": 2,
+      "operator_type": "PROJECTION",
+      "cumulative_cardinality": 11,
+      "extra_info": {
+        "Projections": "name",
+        "Estimated Cardinality": "1"
+      },
+      "result_set_size": 32,
+      "cpu_time": 0.000095,
+      "children": [
+...
+```
+<!-- END_EXAMPLES -->

--- a/scripts/metrics.md.template
+++ b/scripts/metrics.md.template
@@ -23,12 +23,15 @@ The table below describes each metric and which nodes they are available for.
 
 Other than `OPERATOR_TYPE`, all metrics can be turned on or off.
 
-# All Metrics
+## All Metrics
+
 <!-- METRICS_TABLE -->
 <!-- END_METRICS_TABLE -->
 
 <!-- GROUPS -->
-# Metric Groups:
+
+## Metric Groups
+
 The metrics are organized into groups, which can be used to enable or disable related metrics together.
 The following is a list of the available metric groups:
 - `ALL`: All metrics
@@ -36,7 +39,9 @@ The following is a list of the available metric groups:
 <!-- END_GROUPS -->
 
 <!-- OPTIMIZER_METRICS -->
-## Optimizer Metrics
+
+### Optimizer Metrics
+
 Optimizer metrics sit at the `QUERY_ROOT` level, and measure the time taken by each [optimizer]({% link docs/current/internals/overview.md %}#optimizer).
 These metrics are only available when the specific optimizer is enabled.
 The available optimizations can be queried using the [`duckdb_optimizers()`{:.language-sql .highlight} table function]({% link docs/current/sql/meta/duckdb_table_functions.md %}#duckdb_optimizers).
@@ -45,32 +50,26 @@ Each optimizer has a corresponding metric that follows the template: `OPTIMIZER_
 For example, the `OPTIMIZER_JOIN_ORDER` metric corresponds to the `JOIN_ORDER` optimizer.
 
 Additionally, the following metrics are available to support the optimizer metrics:
-
 <!-- END_OPTIMIZER_METRICS -->
+
 <!-- CUMULATIVE_METRICS -->
-# Cumulative Metrics
+
+## Cumulative Metrics
 
 DuckDB also supports several cumulative metrics that are available in all nodes.
 In the `QUERY_ROOT` node, these metrics represent the sum of the corresponding metrics across all operators in the query.
 The `OPERATOR` nodes represent the sum of the operator's specific metric and those of all its children recursively.
 
 These cumulative metrics can be enabled independently, even if the underlying specific metrics are disabled.
-The table below shows the cumulative metrics.
-It also depicts the metric based on which DuckDB calculates the cumulative metric.
 
-| Metric                    | Unit     | Metric calculated cumulatively |
-|---------------------------|----------|--------------------------------|
-| `CPU_TIME`                | seconds  | `OPERATOR_TIMING`              |
-| `CUMULATIVE_CARDINALITY`  | absolute | `OPERATOR_CARDINALITY`         |
-| `CUMULATIVE_ROWS_SCANNED` | absolute | `OPERATOR_ROWS_SCANNED`        |
-
-`CPU_TIME` measures the cumulative operator timings.
-It does not include time spent in other stages, like parsing, query planning, etc.
-Thus, for some queries, the `LATENCY` in the `QUERY_ROOT` can be greater than the `CPU_TIME`.
-
+The following is a list of the available cumulative metrics:
 <!-- END_CUMULATIVE_METRICS -->
+
+
+
 <!-- EXAMPLES -->
-# Examples
+
+## Examples
 
 The following examples demonstrate how to enable custom profiling and set the output format to `json`.
 In the first example, we enable profiling and set the output to a file.

--- a/scripts/metrics.md.template
+++ b/scripts/metrics.md.template
@@ -2,13 +2,15 @@
 // WARNING: this file is used for doc generation by scripts/generate_profiling_docs.py after modifying the code below, rerun
 //          the script to apply changes to the generated files
 // !!!!!!!
-
 // DUCKDB_START_OF_FILE
 ---
 layout: docu
-title: Metrics
 redirect_from:
-  - /dev/metrics
+- /dev/metrics
+- /docs/dev/metrics
+- /docs/preview/dev/metrics
+- /docs/stable/dev/metrics
+title: Metrics
 ---
 
 DuckDB provides a set of metrics that can be used to monitor the performance and health of the database.
@@ -25,16 +27,16 @@ Other than `OPERATOR_TYPE`, all metrics can be turned on or off.
 <!-- METRICS_TABLE -->
 <!-- END_METRICS_TABLE -->
 
-## Metric Groups:
+<!-- GROUPS -->
+# Metric Groups:
 The metrics are organized into groups, which can be used to enable or disable related metrics together.
 The following is a list of the available metric groups:
 - `ALL`: All metrics
 - `DEFAULT`: The default set of metrics
-<!-- GROUPS -->
 <!-- END_GROUPS -->
 
 <!-- OPTIMIZER_METRICS -->
-### Optimizer Metrics
+## Optimizer Metrics
 Optimizer metrics sit at the `QUERY_ROOT` level, and measure the time taken by each [optimizer]({% link docs/current/internals/overview.md %}#optimizer).
 These metrics are only available when the specific optimizer is enabled.
 The available optimizations can be queried using the [`duckdb_optimizers()`{:.language-sql .highlight} table function]({% link docs/current/sql/meta/duckdb_table_functions.md %}#duckdb_optimizers).
@@ -46,7 +48,7 @@ Additionally, the following metrics are available to support the optimizer metri
 
 <!-- END_OPTIMIZER_METRICS -->
 <!-- CUMULATIVE_METRICS -->
-## Cumulative Metrics
+# Cumulative Metrics
 
 DuckDB also supports several cumulative metrics that are available in all nodes.
 In the `QUERY_ROOT` node, these metrics represent the sum of the corresponding metrics across all operators in the query.
@@ -68,7 +70,7 @@ Thus, for some queries, the `LATENCY` in the `QUERY_ROOT` can be greater than th
 
 <!-- END_CUMULATIVE_METRICS -->
 <!-- EXAMPLES -->
-## Examples
+# Examples
 
 The following examples demonstrate how to enable custom profiling and set the output format to `json`.
 In the first example, we enable profiling and set the output to a file.


### PR DESCRIPTION
This PR adds generated documentation based on the [metric_type.json](https://github.com/duckdb/duckdb/blob/main/src/common/enums/metric_type.json) file in duckdb core. 

The generated file: [metrics.html](https://github.com/user-attachments/files/26540180/metrics.html)
