### PR TITLE
Add missing spatial functions

### DIFF
--- a/docs/current/core_extensions/spatial/functions.md
+++ b/docs/current/core_extensions/spatial/functions.md
@@ -97,6 +97,7 @@ title: Spatial Functions
 | [`ST_MakeBox2D`](#st_makebox2d) | Create a BOX2D from two POINT geometries |
 | [`ST_MakeEnvelope`](#st_makeenvelope) | Create a rectangular polygon from min/max coordinates |
 | [`ST_MakeLine`](#st_makeline) | Create a LINESTRING from a list of POINT geometries |
+| [`ST_MakePoint`](#st_makepoint) | Creates a GEOMETRY point from an pair of floating point numbers. |
 | [`ST_MakePolygon`](#st_makepolygon) | Create a POLYGON from a LINESTRING shell |
 | [`ST_MakeValid`](#st_makevalid) | Returns a valid representation of the geometry |
 | [`ST_MaximumInscribedCircle`](#st_maximuminscribedcircle) | Returns the maximum inscribed circle of the input geometry, optionally with a tolerance. |
@@ -1965,6 +1966,35 @@ Create a LINESTRING from a list of POINT geometries
 SELECT ST_MakeLine([ST_Point(0, 0), ST_Point(1, 1)]);
 ----
 LINESTRING(0 0, 1 1)
+```
+
+----
+
+### ST_MakePoint
+
+
+#### Signatures
+
+```sql
+POINT_2D ST_MakePoint (x DOUBLE, y DOUBLE)
+POINT_3D ST_MakePoint (x DOUBLE, y DOUBLE, z DOUBLE)
+POINT_4D ST_MakePoint (x DOUBLE, y DOUBLE, z DOUBLE, m DOUBLE)
+```
+
+#### Description
+
+Creates a GEOMETRY point from an pair of floating point numbers.
+
+For geodetic coordinate systems, x is typically the longitude value and y is the latitude value.
+
+Note that ST_Point is equivalent. ST_MakePoint is provided for PostGIS compatibility.
+
+#### Example
+
+```sql
+SELECT ST_AsText(ST_MakePoint(143.3, -24.2));
+----
+POINT (143.3 -24.2)
 ```
 
 ----

--- a/docs/current/core_extensions/spatial/functions.md
+++ b/docs/current/core_extensions/spatial/functions.md
@@ -89,6 +89,8 @@ title: Spatial Functions
 | [`ST_LineMerge`](#st_linemerge) | "Merges" the input line geometry, optionally taking direction into account. |
 | [`ST_LineString2DFromWKB`](#st_linestring2dfromwkb) | Deserialize a LINESTRING_2D from a WKB encoded blob |
 | [`ST_LineSubstring`](#st_linesubstring) | Returns a substring of a line between two fractions of total 2D length. |
+| [`ST_LocateAlong`](#st_locatealong) | Returns a point or multi-point, containing the point(s) at the geometry with the given measure |
+| [`ST_LocateBetween`](#st_locatebetween) | Returns a geometry or geometry collection created by filtering and interpolating vertices within a range of "M" values |
 | [`ST_M`](#st_m) | Returns the M coordinate of a point geometry |
 | [`ST_MMax`](#st_mmax) | Returns the maximum M coordinate of a geometry |
 | [`ST_MMin`](#st_mmin) | Returns the minimum M coordinate of a geometry |
@@ -1792,6 +1794,52 @@ GEOMETRY ST_LineSubstring (line GEOMETRY, start_fraction DOUBLE, end_fraction DO
 #### Description
 
 Returns a substring of a line between two fractions of total 2D length.
+
+----
+
+### ST_LocateAlong
+
+
+#### Signatures
+
+```sql
+GEOMETRY ST_LocateAlong (line GEOMETRY, measure DOUBLE, offset DOUBLE)
+GEOMETRY ST_LocateAlong (line GEOMETRY, measure DOUBLE)
+```
+
+#### Description
+
+Returns a point or multi-point, containing the point(s) at the geometry with the given measure
+
+For a LINESTRING, or MULTILINESTRING, the location is determined by interpolating between M values
+For a POINT and MULTIPOINT, the point is returned if the measure matches the M value of the vertex, otherwise an empty geometry is returned
+For a POLYGON, only the exterior ring is considered, and treated as a LINESTRING
+
+If offset is provided, the resulting point(s) is offset by the given amount perpendicular to the line direction.
+
+----
+
+### ST_LocateBetween
+
+
+#### Signatures
+
+```sql
+GEOMETRY ST_LocateBetween (line GEOMETRY, start_measure DOUBLE, end_measure DOUBLE, offset DOUBLE)
+GEOMETRY ST_LocateBetween (line GEOMETRY, start_measure DOUBLE, end_measure DOUBLE)
+```
+
+#### Description
+
+Returns a geometry or geometry collection created by filtering and interpolating vertices within a range of "M" values
+
+Creates a geometry or geometry collection, containing the parts formed by vertices that have an "M" value within the "start_measure" and "end_measure" range
+
+For LINESTRING or MULTILINESTRING, if a line segment would cross either the upper or lower bound, a vertex is added by interpolating the coordinates at the "intersection"
+For a POINT and MULTIPOINT, the point is added to the collection if its vertex has an "M" value within the range, otherwise it is skipped
+For a POLYGON, only the exterior ring is considered, and treated like a LINESTRING
+
+If offset is provided, the resulting vertices are offset by the given amount perpendicular to the line direction.
 
 ----
 

--- a/docs/current/core_extensions/spatial/functions.md
+++ b/docs/current/core_extensions/spatial/functions.md
@@ -85,6 +85,7 @@ title: Spatial Functions
 | [`ST_Length_Spheroid`](#st_length_spheroid) | Returns the length of the input geometry in meters, using an ellipsoidal model of the earth |
 | [`ST_LineInterpolatePoint`](#st_lineinterpolatepoint) | Returns a point interpolated along a line at a fraction of total 2D length. |
 | [`ST_LineInterpolatePoints`](#st_lineinterpolatepoints) | Returns a multi-point interpolated along a line at a fraction of total 2D length. |
+| [`ST_LineLocatePoint`](#st_linelocatepoint) | Returns the location on a line closest to a point as a fraction of the total 2D length of the line. |
 | [`ST_LineMerge`](#st_linemerge) | "Merges" the input line geometry, optionally taking direction into account. |
 | [`ST_LineString2DFromWKB`](#st_linestring2dfromwkb) | Deserialize a LINESTRING_2D from a WKB encoded blob |
 | [`ST_LineSubstring`](#st_linesubstring) | Returns a substring of a line between two fractions of total 2D length. |
@@ -1730,6 +1731,21 @@ Returns a multi-point interpolated along a line at a fraction of total 2D length
 
 if repeat is false, the result is a single point, (and equivalent to ST_LineInterpolatePoint),
 otherwise, the result is a multi-point with points repeated at the fraction interval.
+
+----
+
+### ST_LineLocatePoint
+
+
+#### Signature
+
+```sql
+DOUBLE ST_LineLocatePoint (line GEOMETRY, point GEOMETRY)
+```
+
+#### Description
+
+Returns the location on a line closest to a point as a fraction of the total 2D length of the line.
 
 ----
 

--- a/docs/current/core_extensions/spatial/functions.md
+++ b/docs/current/core_extensions/spatial/functions.md
@@ -94,6 +94,7 @@ title: Spatial Functions
 | [`ST_M`](#st_m) | Returns the M coordinate of a point geometry |
 | [`ST_MMax`](#st_mmax) | Returns the maximum M coordinate of a geometry |
 | [`ST_MMin`](#st_mmin) | Returns the minimum M coordinate of a geometry |
+| [`ST_MakeBox2D`](#st_makebox2d) | Create a BOX2D from two POINT geometries |
 | [`ST_MakeEnvelope`](#st_makeenvelope) | Create a rectangular polygon from min/max coordinates |
 | [`ST_MakeLine`](#st_makeline) | Create a LINESTRING from a list of POINT geometries |
 | [`ST_MakePolygon`](#st_makepolygon) | Create a POLYGON from a LINESTRING shell |
@@ -1902,6 +1903,29 @@ Returns the minimum M coordinate of a geometry
 
 ```sql
 SELECT ST_MMin(ST_Point(1, 2, 3, 4))
+```
+
+----
+
+### ST_MakeBox2D
+
+
+#### Signature
+
+```sql
+BOX_2D ST_MakeBox2D (point1 GEOMETRY, point2 GEOMETRY)
+```
+
+#### Description
+
+Create a BOX2D from two POINT geometries
+
+#### Example
+
+```sql
+SELECT ST_MakeBox2D(ST_Point(0, 0), ST_Point(1, 1));
+----
+BOX(0 0, 1 1)
 ```
 
 ----

--- a/docs/current/core_extensions/spatial/functions.md
+++ b/docs/current/core_extensions/spatial/functions.md
@@ -72,6 +72,7 @@ title: Spatial Functions
 | [`ST_HasM`](#st_hasm) | Check if the input geometry has M values. |
 | [`ST_HasZ`](#st_hasz) | Check if the input geometry has Z values. |
 | [`ST_Hilbert`](#st_hilbert) | Encodes the X and Y values as the hilbert curve index for a curve covering the given bounding box. |
+| [`ST_InterpolatePoint`](#st_interpolatepoint) | Computes the closest point on a LINESTRING to a given POINT and returns the interpolated M value of that point. |
 | [`ST_Intersection`](#st_intersection) | Returns the intersection of two geometries |
 | [`ST_Intersects`](#st_intersects) | Returns true if the geometries intersect |
 | [`ST_Intersects_Extent`](#st_intersects_extent) | Returns true if the extent of two geometries intersects |
@@ -1519,6 +1520,24 @@ Encodes the X and Y values as the hilbert curve index for a curve covering the g
 If a geometry is provided, the center of the approximate bounding box is used as the point to encode.
 If no bounding box is provided, the hilbert curve index is mapped to the full range of a single-presicion float.
 For the BOX_2D and BOX_2DF variants, the center of the box is used as the point to encode.
+
+----
+
+### ST_InterpolatePoint
+
+
+#### Signature
+
+```sql
+DOUBLE ST_InterpolatePoint (line GEOMETRY, point GEOMETRY)
+```
+
+#### Description
+
+Computes the closest point on a LINESTRING to a given POINT and returns the interpolated M value of that point.
+
+First argument must be a linestring and must have a M dimension. The second argument must be a point. 
+Neither argument can be empty.
 
 ----
 


### PR DESCRIPTION
This pull request adds in more of the functions documented in the spatial repo docs but not on the official spatial docs website.
https://github.com/duckdb/duckdb-spatial/blob/v1.5-variegata/docs/functions.md



Hope this helps.