### PR TITLE
docs: add Tigris to S3-compatible platforms and add import guide

### DIFF
--- a/_data/menu_docs_current.json
+++ b/_data/menu_docs_current.json
@@ -1371,6 +1371,10 @@
                 {
                   "page": "Fastly Object Storage Import",
                   "url": "fastly_object_storage_import"
+                },
+                {
+                  "page": "Tigris Import",
+                  "url": "tigris_import"
                 }
               ]
             },

--- a/_data/menu_docs_lts.json
+++ b/_data/menu_docs_lts.json
@@ -1349,6 +1349,10 @@
                 {
                   "page": "Fastly Object Storage Import",
                   "url": "fastly_object_storage_import"
+                },
+                {
+                  "page": "Tigris Import",
+                  "url": "tigris_import"
                 }
               ]
             },

--- a/docs/current/core_extensions/httpfs/s3api.md
+++ b/docs/current/core_extensions/httpfs/s3api.md
@@ -13,7 +13,7 @@ The `httpfs` extension supports reading/writing/[globbing](#globbing) files on o
 
 ## Platforms
 
-The `httpfs` filesystem is tested with [AWS S3](https://aws.amazon.com/s3/), [Minio](https://min.io/), [Google Cloud](https://cloud.google.com/storage/docs/interoperability) and [lakeFS](https://docs.lakefs.io/integrations/duckdb.html). Other services that implement the S3 API (such as [Cloudflare R2](https://www.cloudflare.com/en-gb/developer-platform/r2/)) should also work, but not all features may be supported.
+The `httpfs` filesystem is tested with [AWS S3](https://aws.amazon.com/s3/), [Minio](https://min.io/), [Google Cloud](https://cloud.google.com/storage/docs/interoperability) and [lakeFS](https://docs.lakefs.io/integrations/duckdb.html). Other services that implement the S3 API (such as [Cloudflare R2](https://www.cloudflare.com/en-gb/developer-platform/r2/) and [Tigris](https://www.tigrisdata.com/)) should also work, but not all features may be supported.
 
 The following table shows which parts of the S3 API are required for each `httpfs` feature.
 

--- a/docs/current/guides/network_cloud_storage/tigris_import.md
+++ b/docs/current/guides/network_cloud_storage/tigris_import.md
@@ -1,0 +1,38 @@
+---
+layout: docu
+title: Tigris Import
+---
+
+## Prerequisites
+
+For [Tigris](https://www.tigrisdata.com/), the [S3-compatible API](https://www.tigrisdata.com/docs/api/s3/) allows you to use DuckDB's S3 support to read and write from Tigris buckets.
+
+This requires the [`httpfs` extension]({% link docs/current/core_extensions/httpfs/overview.md %}), which can be installed using the `INSTALL` SQL command. This only needs to be run once.
+
+## Credentials and Configuration
+
+You will need to [generate an access key pair](https://www.tigrisdata.com/docs/iam/) and create an `S3` secret in DuckDB:
+
+```sql
+CREATE SECRET my_secret (
+    TYPE s3,
+    KEY_ID '⟨tid_xxxxxxxxxxxx⟩',
+    SECRET '⟨tsec_xxxxxxxxxxxxxxxxxxxxxxxx⟩',
+    REGION 'auto',
+    ENDPOINT 'fly.storage.tigris.dev'
+);
+```
+
+* A single endpoint (`fly.storage.tigris.dev`) serves all regions; requests are routed to the Tigris region nearest the caller. `REGION` is required for request signing but is not used for routing — set it to `auto`.
+* `URL_STYLE` does not need to be set. Tigris uses virtual-hosted-style URLs, which is DuckDB's default for `TYPE s3`.
+
+> Tip When DuckDB runs on a [Fly.io](https://fly.io/) Machine, requests to `fly.storage.tigris.dev` stay on Fly's internal network and are served from the same region as the Machine when possible.
+
+## Querying
+
+After setting up the Tigris credentials, you can query the data using DuckDB's built-in methods, such as `read_csv` or `read_parquet`:
+
+```sql
+SELECT * FROM 's3://⟨tigris-bucket-name⟩/⟨file⟩.csv';
+SELECT * FROM read_parquet('s3://⟨tigris-bucket-name⟩/⟨file⟩.parquet');
+```

--- a/docs/lts/core_extensions/httpfs/s3api.md
+++ b/docs/lts/core_extensions/httpfs/s3api.md
@@ -7,7 +7,7 @@ The `httpfs` extension supports reading/writing/[globbing](#globbing) files on o
 
 ## Platforms
 
-The `httpfs` filesystem is tested with [AWS S3](https://aws.amazon.com/s3/), [Minio](https://min.io/), [Google Cloud](https://cloud.google.com/storage/docs/interoperability) and [lakeFS](https://docs.lakefs.io/integrations/duckdb.html). Other services that implement the S3 API (such as [Cloudflare R2](https://www.cloudflare.com/en-gb/developer-platform/r2/)) should also work, but not all features may be supported.
+The `httpfs` filesystem is tested with [AWS S3](https://aws.amazon.com/s3/), [Minio](https://min.io/), [Google Cloud](https://cloud.google.com/storage/docs/interoperability) and [lakeFS](https://docs.lakefs.io/integrations/duckdb.html). Other services that implement the S3 API (such as [Cloudflare R2](https://www.cloudflare.com/en-gb/developer-platform/r2/) and [Tigris](https://www.tigrisdata.com/)) should also work, but not all features may be supported.
 
 The following table shows which parts of the S3 API are required for each `httpfs` feature.
 

--- a/docs/lts/guides/network_cloud_storage/tigris_import.md
+++ b/docs/lts/guides/network_cloud_storage/tigris_import.md
@@ -1,0 +1,38 @@
+---
+layout: docu
+title: Tigris Import
+---
+
+## Prerequisites
+
+For [Tigris](https://www.tigrisdata.com/), the [S3-compatible API](https://www.tigrisdata.com/docs/api/s3/) allows you to use DuckDB's S3 support to read and write from Tigris buckets.
+
+This requires the [`httpfs` extension]({% link docs/lts/core_extensions/httpfs/overview.md %}), which can be installed using the `INSTALL` SQL command. This only needs to be run once.
+
+## Credentials and Configuration
+
+You will need to [generate an access key pair](https://www.tigrisdata.com/docs/iam/) and create an `S3` secret in DuckDB:
+
+```sql
+CREATE SECRET my_secret (
+    TYPE s3,
+    KEY_ID '⟨tid_xxxxxxxxxxxx⟩',
+    SECRET '⟨tsec_xxxxxxxxxxxxxxxxxxxxxxxx⟩',
+    REGION 'auto',
+    ENDPOINT 'fly.storage.tigris.dev'
+);
+```
+
+* A single endpoint (`fly.storage.tigris.dev`) serves all regions; requests are routed to the Tigris region nearest the caller. `REGION` is required for request signing but is not used for routing — set it to `auto`.
+* `URL_STYLE` does not need to be set. Tigris uses virtual-hosted-style URLs, which is DuckDB's default for `TYPE s3`.
+
+> Tip When DuckDB runs on a [Fly.io](https://fly.io/) Machine, requests to `fly.storage.tigris.dev` stay on Fly's internal network and are served from the same region as the Machine when possible.
+
+## Querying
+
+After setting up the Tigris credentials, you can query the data using DuckDB's built-in methods, such as `read_csv` or `read_parquet`:
+
+```sql
+SELECT * FROM 's3://⟨tigris-bucket-name⟩/⟨file⟩.csv';
+SELECT * FROM read_parquet('s3://⟨tigris-bucket-name⟩/⟨file⟩.parquet');
+```


### PR DESCRIPTION
Hi! We recently [wrote a blog](https://www.tigrisdata.com/blog/fifty-agents-one-bucket/) about DuckDB and I thought I'd shoot over some more info.

Small docs addition for Tigris, an S3-compatible object storage service.

Two changes, mirroring how Cloudflare R2 and Fastly Object Storage are already documented:

1. **`core_extensions/httpfs/s3api.md`** — adds Tigris next to the existing Cloudflare R2 reference in the "other services that implement the S3 API should also work" sentence. One word in a parenthetical, applied to both `current` and `lts`.

2. **`guides/network_cloud_storage/tigris_import.md`** — new page following the structure of `fastly_object_storage_import.md` and `cloudflare_r2_import.md`. Includes the `CREATE SECRET` snippet plus three notes I thought were worth calling out:
   - Why `REGION 'auto'` (single global endpoint, edge-routed — the value is required for SigV4 signing but not used for routing)
   - `URL_STYLE` does not need to be set (Tigris uses virtual-hosted-style, unlike Fastly which needs `path`)
   - A tip about Fly.io Machine colocation, since Tigris runs on Fly infrastructure

Menu entries added to `menu_docs_current.json` and `menu_docs_lts.json` alongside the existing Fastly entry.

Happy to fold the content into the existing `s3_import.md` under the "GCS and Cloudflare R2" section instead if you'd rather not add another per-vendor page — let me know what you prefer.

Thanks for taking a look!