### PR TITLE
Add sticky_header_table as table option

### DIFF
--- a/_layouts/docu.html
+++ b/_layouts/docu.html
@@ -183,7 +183,7 @@ Page URL: <https://duckdb.org{{ page.url }}>
 				</div>
 				
 				<div class="bottomline">
-					<div>© 2026 DuckDB Foundation, Amsterdam NL</div>
+					<div>© {{ "now" | date: "%Y" }} DuckDB Foundation, Amsterdam NL</div>
 					<div>
 						<a href="/code_of_conduct.html">Code of Conduct</a>
 						<a href="/trademark_guidelines.html">Trademark Use</a>

--- a/_sass/layout/_responsive.scss
+++ b/_sass/layout/_responsive.scss
@@ -795,7 +795,12 @@
 			margin-bottom: 0.8em;
 		}
 	}
-	
+
+	body.documentation .bottomline {
+		flex-direction: column-reverse;
+		gap: 24px;
+	}
+
 	body.documentation{
 		#duckdb_logo{
 			width: 38px;

--- a/_sass/pages/_docs-content.scss
+++ b/_sass/pages/_docs-content.scss
@@ -464,6 +464,24 @@ body.layout_default.blog_typography {
         }
     }
 
+    .sticky_header_table + table {
+        @media (min-width: 768px) {
+            display: table;
+            overflow: visible;
+
+            thead tr {
+                border-bottom: 0;
+            }
+
+            thead th {
+                position: sticky;
+                top: 69px;
+                z-index: 10;
+                background: var(--main-body-background-color, #FAFAFA);
+                box-shadow: inset 0 -1px 0 var(--doc-codebox-border-color, #E6E6E6);           }
+        }
+    }
+
     // Code blocks
     code,
     pre {

--- a/docs/current/core_extensions/overview.md
+++ b/docs/current/core_extensions/overview.md
@@ -10,6 +10,8 @@ title: Core Extensions
 
 ## List of Core Extensions
 
+<div class="sticky_header_table"></div>
+
 | Name                                                                     | Description                                                             | Maintainer       | Support&nbsp;tier | Aliases                 |
 | :----------------------------------------------------------------------- | :---------------------------------------------------------------------- | ---------------- | :---------------- | :---------------------- |
 | [autocomplete]({% link docs/current/core_extensions/autocomplete.md %})   | Adds support for autocomplete in the shell                              | DuckDB&nbsp;team | Secondary         |                         |


### PR DESCRIPTION
- add `<div class="sticky_header_table"></div>` right before the table to make the table header sticky. Desktop only.
- minor improvements