### PR TITLE
docs: fix key-value metadata link to include correct anchor

### DIFF
--- a/docs/current/data/parquet/overview.md
+++ b/docs/current/data/parquet/overview.md
@@ -260,7 +260,7 @@ COPY tbl
     (FORMAT parquet, COMPRESSION zstd, COMPRESSION_LEVEL 1);
 ```
 
-Write to Parquet file with [key-value metadata]({% link docs/current/data/parquet/metadata.md %}):
+Write to Parquet file with [key-value metadata]({% link docs/current/data/parquet/metadata.md %}#parquet-key-value-metadata):
 
 ```sql
 COPY (


### PR DESCRIPTION
## Summary

The "key-value metadata" link in the Parquet overview page currently points to `metadata.html` but should include the specific anchor `#parquet-key-value-metadata` for direct navigation. This matches the existing link on line 89 of the same file which already uses the correct anchor.

## Changes

Updated the link in `docs/current/data/parquet/overview.md` (write parquet section) to include the `#parquet-key-value-metadata` anchor.

Closes #6723