### PR TITLE
Changed reference label from Rust Installation Page to Python

### DIFF
--- a/docs/current/clients/python/overview.md
+++ b/docs/current/clients/python/overview.md
@@ -10,7 +10,7 @@ redirect_from:
 title: Python API
 ---
 
-> Installation To use the DuckDB Python client, visit the [Rust installation page]({% link install/index.html %}?environment=python).
+> Installation To use the DuckDB Python client, visit the [Python installation page]({% link install/index.html %}?environment=python).
 >
 > The latest stable version of the DuckDB Python client is {{ site.current_duckdb_version }}.
 


### PR DESCRIPTION
This change simply changes the label for the reference to the Python installation from "Rust" -> "Python".