### PR TITLE
Add description for Postgres hstore functions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GIT
 
 GIT
   remote: https://github.com/duckdb/rouge.git
-  revision: 7eaeeb775fa02ed77d9308f1024c97b4779d130c
+  revision: 2023632e6aef0db6c509f9487663852f0ecb4bea
   branch: duckdb
   specs:
     rouge (3.3823.1)

--- a/docs/current/core_extensions/postgres.md
+++ b/docs/current/core_extensions/postgres.md
@@ -399,3 +399,18 @@ CALL pg_clear_cache();
 ```
 
 > Deprecated The old `postgres_attach` function is deprecated. It is recommended to switch over to the new `ATTACH` syntax.
+
+## Working with hstore columns
+
+DuckDB will return data from [hstore](https://www.postgresql.org/docs/current/hstore.html) columns as `varchar` of their text representation, like `key=>value, foo=>bar`.
+You can use the `postgres_hstore_get` function to read the value for a given key, or `postgres_hstore_to_json` to convert the whole set of key/value pairs to JSON for further processing.
+```
+SELECT postgres_hstore_get('a=>b, c=>d', 'a');
+-- b
+
+SELECT postgres_hstore_get('a=>b, c=>d', 'missingkey');
+-- NULL
+
+SELECT postgres_hstore_to_json('a=>b, c=>d, e => null');
+-- {"a": "b", "c": "d", e: null}
+```

--- a/docs/current/core_extensions/postgres.md
+++ b/docs/current/core_extensions/postgres.md
@@ -400,11 +400,12 @@ CALL pg_clear_cache();
 
 > Deprecated The old `postgres_attach` function is deprecated. It is recommended to switch over to the new `ATTACH` syntax.
 
-## Working with hstore columns
+## Working with hstore Columns
 
-DuckDB will return data from [hstore](https://www.postgresql.org/docs/current/hstore.html) columns as `varchar` of their text representation, like `key=>value, foo=>bar`.
+DuckDB will return data from [hstore](https://www.postgresql.org/docs/current/hstore.html) columns as `VARCHAR` of their text representation, like `key=>value, foo=>bar`.
 You can use the `postgres_hstore_get` function to read the value for a given key, or `postgres_hstore_to_json` to convert the whole set of key/value pairs to JSON for further processing.
-```
+
+```sql
 SELECT postgres_hstore_get('a=>b, c=>d', 'a');
 -- b
 


### PR DESCRIPTION
This PR adds a short description for two functions I wrote [that recently made it into the postgres extension](https://github.com/duckdb/duckdb-postgres/pull/437).
Is the format for the examples okay like that, or should I split it up into code, then an actual markdown result table?
Of course, please feel free to also suggest any other changes.