### PR TITLE
Chore logging docs

### DIFF
--- a/docs/current/operations_manual/logging/overview.md
+++ b/docs/current/operations_manual/logging/overview.md
@@ -189,7 +189,7 @@ Note that the default buffer size is different for different log storages:
 So for example, if you want to increase your `stdout` logging performance, simply enable buffering to greatly (>10x) speed up 
 your logging:
 
-```SQL
+```sql
 CALL enable_logging(storage = 'stdout', storage_buffer_size = 2048);
 ```
 

--- a/docs/lts/operations_manual/logging/overview.md
+++ b/docs/lts/operations_manual/logging/overview.md
@@ -186,7 +186,7 @@ Note that the default buffer size is different for different log storages:
 So for example, if you want to increase your `stdout` logging performance, simply enable buffering to greatly (>10x) speed up 
 your logging:
 
-```SQL
+```sql
 CALL enable_logging(storage = 'stdout', storage_buffer_size = 2048);
 ```
 
@@ -195,7 +195,7 @@ Simply disable the
 buffering using:
 
 ```sql
-CALL enable_logging(storage_path = '/tmp/mylogs', storage_buffer_size = 2048);
+CALL enable_logging(storage_path = '/tmp/mylogs', storage_buffer_size = 0);
 ```
 
 ### Syntactic Sugar


### PR DESCRIPTION
Follow up on #6833 for LTS docs version
Additional fix to solve example formatting problem:
<img width="1004" height="296" alt="image" src="https://github.com/user-attachments/assets/87210d62-fc4d-4bd8-912e-7d022591307f" />
