### PR TITLE
Fix Quack Stateless Query Example

### DIFF
--- a/docs/current/quack/overview.md
+++ b/docs/current/quack/overview.md
@@ -96,7 +96,7 @@ To query a local database via HTTP, run:
 ```sql
 FROM quack_query(
     'quack:localhost',
-    'SELECT 42'
+    'SELECT 42',
     token = '⟨MY_QUACK_TOKEN_01234567890ABCDEF⟩');
 ```
 


### PR DESCRIPTION
- Add missing comma to stateless query example

<img width="1920" height="1080" alt="Screenshot from 2026-05-15 12-13-53" src="https://github.com/user-attachments/assets/7ecd7722-889d-4ceb-81f7-954cd921fed2" />
