### PR TITLE
Fix typo in function name

### DIFF
--- a/docs/current/sql/statements/create_macro.md
+++ b/docs/current/sql/statements/create_macro.md
@@ -322,5 +322,5 @@ You can use the following query to display the list of macros and table macros:
 
 ```sql
 SELECT schema_name, function_name, function_type, parameters
-FROM duckdb_function();
+FROM duckdb_functions();
 ```


### PR DESCRIPTION
The execution of the sample:

```sql
SELECT schema_name, function_name, function_type, parameters FROM duckdb_function();
```

Returns the error:

```raw
Catalog Error:
Table Function with name duckdb_function does not exist!
Did you mean "duckdb_functions"?

LINE 2: FROM duckdb_function();
             ^
```