### PR TITLE
Add QuackDB tertiary client

### DIFF
--- a/docs/current/clients/tertiary_clients/overview.md
+++ b/docs/current/clients/tertiary_clients/overview.md
@@ -15,7 +15,8 @@ Tertiary clients come without any support guarantees.
 | [Common Lisp](https://github.com/ak-coram/cl-duckdb)               | [ak-coram](https://github.com/ak-coram)               |
 | [Crystal](https://github.com/amauryt/crystal-duckdb)               | [amauryt](https://github.com/amauryt)                 |
 | [Dart]({% link docs/current/clients/tertiary_clients/dart.md %})   | [TigerEye](https://www.tigereye.com/)                 |
-| [Elixir](https://github.com/AlexR2D2/duckdbex)                     | [AlexR2D2](https://github.com/AlexR2D2/duckdbex)      |
+| [Elixir (Duckdbex)](https://github.com/AlexR2D2/duckdbex)            | [AlexR2D2](https://github.com/AlexR2D2/duckdbex)      |
+| [Elixir (QuackDB)](https://github.com/elixir-vibe/quackdb)          | [Danila Poyarkov](https://github.com/dannote)         |
 | [Erlang](https://github.com/mmzeeman/educkdb)                      | [MM Zeeman](https://github.com/mmzeeman)              |
 | [Haskell](https://github.com/tritlo/duckdb-haskell)                | [Tritlo](https://github.com/tritlo)                   |
 | [Julia]({% link docs/current/clients/tertiary_clients/julia.md %}) | The DuckDB team                                       |


### PR DESCRIPTION
Adds QuackDB to the tertiary clients list and renames the existing Elixir row to “Elixir (Duckdbex)” so the two Elixir clients are distinguishable in the table.

The two projects cover different integration architectures:

- Duckdbex embeds DuckDB in the BEAM through native C++/NIF bindings.
- QuackDB is an Elixir client for DuckDB's experimental Quack protocol. It is built around DBConnection/Ecto, supervised DuckDB processes, connection pooling, native append APIs, Explorer/Table.Reader integration, telemetry, and managed DuckDB binaries.

So this gives Elixir users both current options: embedded native bindings and the Quack protocol/client-driver approach.