### PR TITLE
Refresh published community_extensions.csv on docs update

### DIFF
--- a/.github/workflows/community_extension_docs.yml
+++ b/.github/workflows/community_extension_docs.yml
@@ -29,6 +29,11 @@ jobs:
         unzip generated_md.zip
         cp build/docs/*.md community_extensions/extensions/.
         cp build/docs/extensions_list.md.tmp _includes/list_of_community_extensions.md
+        # Refresh the published static CSV (served at
+        # https://duckdb.org/community_extensions/community_extensions.csv).
+        # It is committed to this repo, so it must be regenerated here too;
+        # the "git add --all community_extensions" below stages it.
+        cp build/docs/community_extensions.csv community_extensions/community_extensions.csv
         rm -r generated_md.zip
         rm -rf build
 


### PR DESCRIPTION
## Problem

`https://duckdb.org/community_extensions/community_extensions.csv` is stale — it lists only ~15 extensions while the docs page lists 250+. Reported in duckdb/community-extensions#1677.

That URL is served from a **committed static file** in this repo, `community_extensions/community_extensions.csv`. The scheduled auto-update job (`.github/workflows/community_extension_docs.yml`) regenerates the docs via `duckdb/community-extensions/.github/workflows/generate_docs.yml`, but its `deploy_docs` step only copies the markdown list and per-extension pages into the auto-update PR:

```sh
cp build/docs/*.md community_extensions/extensions/.
cp build/docs/extensions_list.md.tmp _includes/list_of_community_extensions.md
```

The generator also produces `build/docs/community_extensions.csv`, but nothing copies it into the committed path, so the published CSV is never refreshed. (The only `aws s3 cp` of that CSV lives in `community-extensions/deploy_docs.yml`, gated `if: github.repository == 'duckdb/duckdb-web'`, which is unreachable from that repo.)

## Fix

Copy the freshly generated `build/docs/community_extensions.csv` into `community_extensions/community_extensions.csv` during the deploy step. The existing `git add --all community_extensions` already stages it into the auto-update PR, so no other change is needed.

> Note: the generator-side crash that had been failing these runs was fixed in duckdb/community-extensions#2034 (merged). With that fix the job is green again, so this change will take effect on the next scheduled run.

Refs duckdb/community-extensions#1677