### PR TITLE
docs: fix typo “successfull” → “successful” (postgres extension)

### DIFF
--- a/docs/current/core_extensions/postgres/functions.md
+++ b/docs/current/core_extensions/postgres/functions.md
@@ -33,7 +33,7 @@ None.
 
 A table with the following columns:
 
- - `Success` (`BOOLEAN`): a flag whether the cache clearing was successfull
+ - `Success` (`BOOLEAN`): a flag whether the cache clearing was successful
 
 > Currently the table result is always returned with zero rows, so the flag value is not available.
 
@@ -130,7 +130,7 @@ Optional named parameters:
 
 A table with the following columns:
 
- - `Success` (`BOOLEAN`): a flag whether the cache clearing was successfull
+ - `Success` (`BOOLEAN`): a flag whether the cache clearing was successful
 
 > Currently the table result is always returned with zero rows, so the flag value is not available.
 


### PR DESCRIPTION
Fixes a small typo (“successfull”) that appears twice in the Postgres extension function reference.