### PR TITLE
Add Parquet tip: sort rows before writing to improve row group pruning

### DIFF
--- a/docs/current/data/parquet/tips.md
+++ b/docs/current/data/parquet/tips.md
@@ -70,4 +70,18 @@ COPY
 > If multiple threads are active, the number of row groups in a file may slightly exceed the specified number of row groups to limit the amount of locking – similarly to the behavior of [`FILE_SIZE_BYTES`](../../sql/statements/copy#copy--to-options).
 > However, if `PER_THREAD_OUTPUT` is set, only one thread writes to each file, and it becomes accurate again.
 
+### Sorting Rows to Improve Row Group Pruning
+
+DuckDB writes per-column statistics, including min/max values, for every row group, and as described above the reader uses these to skip row groups that cannot match a query’s `WHERE` clause.
+Sorting the data on the columns that you filter on most often before writing makes these min/max ranges tight and non-overlapping between row groups, so that highly selective queries on those columns scan far fewer row groups:
+
+```sql
+COPY
+    (FROM 'events.parquet' ORDER BY event_time)
+    TO 'events-sorted.parquet'
+    (FORMAT parquet);
+```
+
+This pairs well with a `ROW_GROUP_SIZE` that keeps each row group focused on a narrow range of the sort key.
+
 See the [Performance Guide on “File Formats”]({% link docs/current/guides/performance/file_formats.md %}#parquet-file-sizes) for more tips.


### PR DESCRIPTION
The "Tips for Writing Parquet Files" page documents `ROW_GROUP_SIZE` and notes that the reader uses row-group min/max metadata for predicate pushdown, but it does not mention the most effective way to take advantage of that pruning: **sorting the data on commonly-filtered columns before writing**.

Sorting makes each row group's min/max ranges tight and non-overlapping, so highly selective queries on those columns scan far fewer row groups. This comes up regularly (e.g. when compacting Parquet files by a key), so I added a short subsection with an example next to the existing row-group tips.

Targeted `docs/current`. Happy to also apply it to `docs/lts` if youd like.

---
*Disclosure: drafted with AI assistance (Claude Code); reviewed by me.*