### PR TITLE
Add "IF EXISTS" and fully-qualified table name to ALTER sytax

### DIFF
--- a/js/current/statements/alter.js
+++ b/js/current/statements/alter.js
@@ -43,7 +43,8 @@ function GenerateAlterTable(options = {}) {
 	return Diagram([
 		AutomaticStack([
 			Keyword("ALTER TABLE"),
-			Expression("table-name"),
+			GenerateIfExists(),
+			GenerateQualifiedTableName(),
 			Choice(0, [
 				Sequence([
 					Keyword("ADD"),


### PR DESCRIPTION
Updates the railroad diagram for `ALTER TABLE`.

`ALTER TABLE IF EXISTS` is valid DuckDB syntax:

```sql
D ALTER TABLE tbl2 RENAME TO tbl3;
Catalog Error:
Table with name tbl2 does not exist!
Did you mean "tbl1"?
D ALTER TABLE IF EXISTS tbl2 RENAME TO tbl3;
-- no error
```

`ALTER TABLE` also accepts fully qualified table names:
```sql
CREATE TABLE tbl1 (i INT);
ALTER TABLE memory.main.tbl1 ADD COLUMN j INT;
ALTER TABLE main.tbl1 ADD COLUMN k INT;
```

Both are now reflected in the railroad diagram.