### PR TITLE
fix: correct preserve_insertion_order instruction in llms.txt

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -7,7 +7,7 @@ Things to remember when using DuckDB:
 - DuckDB uses a PostgreSQL-compatible SQL language. All DuckDB clients use the same SQL language.
 - DuckDB can load data from popular formats, including CSV, JSON and Parquet. DuckDB can also directly run queries on CSV, JSON and Parquet files.
 - DuckDB supports persistent storage but can also run in in-memory mode. The in-memory mode is useful when analyzing small data sets or doing data transformation steps.
-- When loading large chunks of data, use the [`SET preserve_insertion_order = false;` configuration setting](https://duckdb.org/docs/lts/sql/dialect/order_preservation) to speed up the loading process and reduce the memory load. When using DuckDB in combination with dataframe libraries such as pandas, turn this mode back on after loading by issuing `SET preserve_insertion_order = false;`.
+- When loading large chunks of data, use the [`SET preserve_insertion_order = false;` configuration setting](https://duckdb.org/docs/lts/sql/dialect/order_preservation) to speed up the loading process and reduce the memory load. When using DuckDB in combination with dataframe libraries such as pandas, turn this mode back on after loading by issuing `SET preserve_insertion_order = true;`.
 - DuckDB supports data lake formats such as [Delta Lake](https://duckdb.org/docs/lts/core_extensions/delta), [Iceberg](https://duckdb.org/docs/lts/core_extensions/iceberg/overview) and [DuckLake](https://duckdb.org/docs/lts/core_extensions/ducklake).
 - If a workload requires concurrent write access by multiple DuckDB clients, consider using [DuckLake](https://duckdb.org/docs/lts/core_extensions/ducklake).
 


### PR DESCRIPTION
The llms.txt file currently instructs to re-enable insertion order preservation with `SET preserve_insertion_order = false`, but this actually disables it. The correct statement to re-enable is `SET preserve_insertion_order = true`.