### PR TITLE
fix: use .length for jQuery element existence check

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -486,7 +486,7 @@ $(document).ready(function(){
 
 	
 	// Appending Content-List of Documentation
-	if ( $('.wrap.documentation') != 0 ) {
+	if ( $('.wrap.documentation').length ) {
 	    contentlist = $('ul.sidenav').clone()
 	    contentlist.find('svg').remove()
 	    $('#docusitemaphere').append(contentlist).find("ul").removeAttr("style")


### PR DESCRIPTION
In js/script.js, the condition `$('.wrap.documentation') != 0` always evaluates to true because a jQuery object is never equal to the integer 0. This causes the content list cloning code to run on every page instead of only documentation pages. Changed to use `.length` which correctly checks whether matching elements exist.