### PR TITLE
fix: correct string slice and comparison in C API doc generator

### DIFF
--- a/scripts/generate_c_api_docs.py
+++ b/scripts/generate_c_api_docs.py
@@ -208,7 +208,7 @@ def highlight_function_prototype(function_prototype, function_name):
         last_pos = end
     if last_pos < len(function_prototype):
         result += process_function_part(
-            function_prototype[last_pos:start], function_name
+            function_prototype[last_pos:], function_name
         )
     return result
 
@@ -360,7 +360,7 @@ total_quick_docs = ''
 total_docs = ""
 for entry in documentation_list:
     group_name = entry[1]
-    if group_name is not current_group_name:
+    if group_name != current_group_name:
         if current_group_name is not None:
             total_quick_docs += quick_docs_end() + '\n'
 


### PR DESCRIPTION
Two bugs in `scripts/generate_c_api_docs.py`:

1. After the regex `finditer` loop, `function_prototype[last_pos:start]` uses the stale `start` value from the last match iteration, truncating the remaining prototype text. Changed to `function_prototype[last_pos:]`.

2. String group name comparison uses `is not` (identity check) instead of `!=` (value comparison). While CPython interns short strings making this work in practice, `!=` is the correct operator for value comparison.