### PR TITLE
fix: pipe GitHub token via stdin instead of writing to disk

### DIFF
--- a/.github/workflows/community_extension_docs.yml
+++ b/.github/workflows/community_extension_docs.yml
@@ -46,12 +46,9 @@ jobs:
         git config user.name "Quack Mc Docs"
         git commit -m "chore: update Community Extensions docs"
         git push -f origin auto_update_community_extensions_docs
-        # Store the PAT in a file that can be accessed by the
-        # GitHub CLI.
-        echo "${{ secrets.GH_UPDATE_DOCS_TOKEN }}" > token.txt
         # Authorize GitHub CLI for the current repository and
         # create a pull-requests containing the updates.
-        gh auth login --with-token < token.txt
+        echo "${{ secrets.GH_UPDATE_DOCS_TOKEN }}" | gh auth login --with-token
         gh pr create \
           --body "" \
           --title "chore: update Community Extensions docs" \

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -55,12 +55,9 @@ jobs:
             git config user.name "Quack Mc Docs"
             git commit -m "chore: update docs"
             git push -f origin auto_update_docs
-            # Store the PAT in a file that can be accessed by the
-            # GitHub CLI.
-            echo "${{ secrets.GH_UPDATE_DOCS_TOKEN }}" > token.txt
             # Authorize GitHub CLI for the current repository and
             # create a pull-requests containing the updates.
-            gh auth login --with-token < token.txt
+            echo "${{ secrets.GH_UPDATE_DOCS_TOKEN }}" | gh auth login --with-token
             gh pr create \
              --body "" \
              --title "chore: update DuckDB docs" \


### PR DESCRIPTION
## Summary

- `update-docs.yml` and `community_extension_docs.yml` both write `GH_UPDATE_DOCS_TOKEN` to a `token.txt` file on disk, then read it back for `gh auth login --with-token < token.txt`. This leaves the PAT on the runner filesystem for the remainder of the job.
- Replace with `echo "${{ secrets.GH_UPDATE_DOCS_TOKEN }}" | gh auth login --with-token` to pipe the token directly via stdin, avoiding any file write.
- Remove the now-unnecessary comments about storing the PAT in a file.

## Test plan

- [ ] Verify `update-docs` workflow runs successfully on the next scheduled trigger or manual dispatch
- [ ] Verify `community_extension_docs` workflow runs successfully on the next scheduled trigger or manual dispatch