### PR TITLE
Remove unused imports, fix no-op copies, and fix typo in scripts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,3 @@ icalendar
 
 ipython
 black
-
-python-frontmatter

--- a/scripts/archive_docs.py
+++ b/scripts/archive_docs.py
@@ -110,7 +110,6 @@ shutil.copy(
 )
 archive_stable(old_stable_version)
 
-shutil.copy("_data/menu_docs_current.json", f"_data/menu_docs_current.json")
 archive_preview()
 
 shutil.move("js/stable", f"js/{old_stable_version}")

--- a/scripts/copy_stable_to_preview.py
+++ b/scripts/copy_stable_to_preview.py
@@ -1,4 +1,3 @@
-import sys
 import os
 import shutil
 import frontmatter
@@ -44,5 +43,4 @@ def copy_docs():
                 shutil.copy2(src_file, dst_file)
 
 
-shutil.copy("_data/menu_docs_current.json", f"_data/menu_docs_current.json")
 copy_docs()

--- a/scripts/generate_config_docs.py
+++ b/scripts/generate_config_docs.py
@@ -2,8 +2,6 @@ import os
 import sys
 import re
 import subprocess
-import csv
-import io
 
 
 def run_duckdb_script(cmd):

--- a/scripts/generate_profiling_docs.py
+++ b/scripts/generate_profiling_docs.py
@@ -1,9 +1,7 @@
 import argparse
-import os
 import sys
 from pathlib import Path
 
-from jinja2.optimizer import Optimizer
 from tabulate import tabulate
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -18,7 +16,7 @@ END_GROUPS_MARKER = "<!-- END_GROUPS -->"
 OPTIMIZER_MARKER = "<!-- OPTIMIZER_METRICS -->"
 END_OPTIMIZER_MARKER = "<!-- END_OPTIMIZER_METRICS -->"
 CUMULATIVE_MARKER = "<!-- CUMULATIVE_METRICS -->"
-END_CUMALATIVE_MARKER = "<!-- END_CUMULATIVE_METRICS -->"
+END_CUMULATIVE_MARKER = "<!-- END_CUMULATIVE_METRICS -->"
 EXAMPLES_MARKER = "<!-- EXAMPLES -->"
 END_EXAMPLES_MARKER = "<!-- END_EXAMPLES -->"
 
@@ -184,7 +182,7 @@ def main():
         # write cumulative metrics
         f.write(
             retrieve_template(
-                METRICS_DOC_TEMPLATE, CUMULATIVE_MARKER, END_CUMALATIVE_MARKER
+                METRICS_DOC_TEMPLATE, CUMULATIVE_MARKER, END_CUMULATIVE_MARKER
             )
         )
         for metric in cumulative_metrics:

--- a/scripts/redirect.py
+++ b/scripts/redirect.py
@@ -1,6 +1,5 @@
 import frontmatter
 import sys
-from glob import glob
 from pathlib import Path
 import re
 import textwrap


### PR DESCRIPTION
## Summary

- Remove unused imports across several scripts: `csv` and `io` from `generate_config_docs.py`, `sys` from `copy_stable_to_preview.py`, `os` and `jinja2.optimizer.Optimizer` from `generate_profiling_docs.py`, `glob` from `redirect.py`
- Remove no-op `shutil.copy` calls where source and destination are identical (`_data/menu_docs_current.json` to itself) in `copy_stable_to_preview.py` and `archive_docs.py`
- Fix `CUMALATIVE` typo to `CUMULATIVE` in variable name in `generate_profiling_docs.py`
- Remove duplicate `python-frontmatter` entry from `requirements.txt`

## Test plan

- [x] Verified each issue exists in the current codebase before fixing
- [ ] Confirm no behavioral changes: unused imports are never referenced, no-op copies had identical src/dst, typo fix is internal variable naming only