### PR TITLE
ci: update Python 3.8 to 3.12 in stackoverflow workflow

### DIFF
--- a/.github/workflows/stackoverflow.yml
+++ b/.github/workflows/stackoverflow.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setting up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.8"
+          python-version: "3.12"
           architecture: "x64"
           cache: 'pip'
           


### PR DESCRIPTION
## Summary

- Update `python-version` from 3.8 to 3.12 in `.github/workflows/stackoverflow.yml`
- Python 3.8 reached end-of-life in October 2024 and is no longer receiving security updates
- `actions/setup-python` emits deprecation warnings for EOL Python versions

## Test plan

- [ ] Verify the `stackoverflow.yml` workflow runs successfully with Python 3.12
- [ ] Confirm `duckdb`, `requests`, and `pytz` packages install without issues on 3.12