### PR TITLE
Add SRI hashes to external CDN script and link tags

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -28,8 +28,8 @@
 	{% if page.body_class contains "duckcon" %}
 	<link rel="preconnect" href="https://api.mapbox.com" crossorigin>
 	<link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
-	<link href='https://api.mapbox.com/mapbox-gl-js/v3.17.0-beta.1/mapbox-gl.css' rel='stylesheet' />
-	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@12/swiper-bundle.min.css?2" />
+	<link href='https://api.mapbox.com/mapbox-gl-js/v3.17.0-beta.1/mapbox-gl.css' rel='stylesheet' integrity="sha384-iZHx8ei75G5yWmKdvT9TwWafArVHCZ5OvZlUQWShQGrJFq5sBlxK+tu/1cGonuYJ" crossorigin="anonymous" />
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@12/swiper-bundle.min.css?2" integrity="sha384-+eoVPirEHy8XSrf7sRozx+2OTKCWm1qfVFWnQ7qiXW6vAb+GUXRw4gq7sU+hq6HG" crossorigin="anonymous" />
 	{% endif %}
 
 	<link rel="apple-touch-icon" sizes="180x180" href="{% link images/favicon/apple-touch-icon.png %}">
@@ -64,7 +64,7 @@
 	{% endif %}
 
 	{% if page.body_class contains "duckcon" %}
-	<script src='https://api.mapbox.com/mapbox-gl-js/v3.17.0-beta.1/mapbox-gl.js'></script>
+	<script src='https://api.mapbox.com/mapbox-gl-js/v3.17.0-beta.1/mapbox-gl.js' integrity="sha384-Yy3wODAOvfT0/YULUDobkC+draTm8Y1fuJqn6+alPRUHh5X3CkeUWyzdUf8gHv9S" crossorigin="anonymous"></script>
 	{% endif %}
 </head>
 <body class="layout_default{% if page.body_class %} {{ page.body_class }}{% endif %}">
@@ -187,7 +187,7 @@
 	<script src="/js/ua-parser.min.js" defer></script>
 	{% endif %}
 	{% if page.body_class contains "duckcon" %}
-	<script src="https://cdn.jsdelivr.net/npm/swiper@12/swiper-bundle.min.js" defer></script>
+	<script src="https://cdn.jsdelivr.net/npm/swiper@12/swiper-bundle.min.js" integrity="sha384-TmUUNA9gRm9TspAqMh20CdxlcwkNFW3UyIOibSljonhpJ1UfGenJDyQvO/EbWwpW" crossorigin="anonymous" defer></script>
 	{% endif %}
 	<script src="/js/script.js?{{ site.time | date: '%s' }}" defer></script>
 	{% if page.body_class contains "installation" %}


### PR DESCRIPTION
## Summary

Adds [Subresource Integrity (SRI)](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) hashes to all external CDN resources loaded in `_layouts/default.html`:

- `mapbox-gl.css` (v3.17.0-beta.1) from api.mapbox.com
- `mapbox-gl.js` (v3.17.0-beta.1) from api.mapbox.com
- `swiper-bundle.min.css` (@12) from cdn.jsdelivr.net
- `swiper-bundle.min.js` (@12) from cdn.jsdelivr.net

Each tag now includes `integrity="sha384-..."` and `crossorigin="anonymous"` attributes. This ensures the browser verifies the fetched resource against the expected hash before executing it, mitigating supply-chain attacks where a CDN serves tampered content.

`_layouts/docu.html` was also reviewed and contains no external CDN resources.

## Test plan

- [ ] Verify DuckCon pages load correctly (these are the only pages that use the affected resources, gated behind `page.body_class contains "duckcon"`)
- [ ] Confirm Mapbox GL map renders on DuckCon pages
- [ ] Confirm Swiper carousel functions on DuckCon pages
- [ ] Check browser console for SRI-related errors on non-DuckCon pages (there should be none, since these tags are conditionally included)