### PR TITLE
Refine link icons and docs/blog styling

### DIFF
--- a/_sass/abstracts/_mixins.scss
+++ b/_sass/abstracts/_mixins.scss
@@ -445,7 +445,7 @@
 	}
 	
 	table tbody tr:hover {
-		background: var(--doc-codebox-border-color, #E6E6E6);
+		background: var(--doc-codebox-button-background-color, rgba(242, 242, 242, 0.6));
 	}
 	
 	div.highlight {

--- a/_sass/base/_typography.scss
+++ b/_sass/base/_typography.scss
@@ -7,83 +7,36 @@
 // =============================================================================
 
 
-/** External Links in Fließtext **/
+/** External, Download and Video Links in Fließtext **/
 #main_content_wrap a.externallink,
-.singleentry .content a.externallink{
-	display: inline;
-	word-break: break-word;
-	&::after{
-		content: "";
-		mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' fill='none' viewBox='0 0 14 14'%3E%3Cpath stroke='%23000' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M12.25 5.25v-3.5m0 0h-3.5m3.5 0L7 7M5.833 1.75H4.55c-.98 0-1.47 0-1.844.19a1.75 1.75 0 0 0-.765.766c-.191.374-.191.864-.191 1.844v4.9c0 .98 0 1.47.19 1.845.169.329.436.597.766.764.374.191.864.191 1.844.191h4.9c.98 0 1.47 0 1.845-.19a1.75 1.75 0 0 0 .764-.766c.191-.374.191-.864.191-1.844V8.167'/%3E%3C/svg%3E");
-		display: inline-block;
-		-webkit-transition: all .3s;
-		-o-transition: all .3s;
-		transition: all .3s;
-		width: .875em;
-		height: .875em;
-		mask-size: contain;
-		mask-repeat: no-repeat;
-		mask-position: center center;
-		margin-left: .2em;
-		margin-right: 1px;
-		transform: translateY(.125em);
-		background-color: var(--main-text-secondary-color, #666);
-	}
-	&:hover::after{
-		background-color: var(--main-link-hover-color, #998B00);
-	}
-}
-
-/** Download Links (PDF, ZIP, etc.) **/
+.singleentry .content a.externallink,
 #main_content_wrap a.downloadlink,
-.singleentry .content a.downloadlink{
-	display: inline;
-	word-break: break-word;
-	&::after{
-		content: "";
-		mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' fill='none' viewBox='0 0 14 14'%3E%3Cpath stroke='%23000' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M12.25 8.75v.7c0 .98 0 1.47-.19 1.845a1.75 1.75 0 0 1-.766.764c-.374.191-.864.191-1.844.191h-4.9c-.98 0-1.47 0-1.844-.19a1.75 1.75 0 0 1-.765-.766c-.191-.374-.191-.864-.191-1.844v-.7m8.167-2.917L7 8.75m0 0L4.083 5.833M7 8.75v-7'/%3E%3C/svg%3E");
-		display: inline-block;
-		-webkit-transition: all .3s;
-		-o-transition: all .3s;
-		transition: all .3s;
-		width: .875em;
-		height: .875em;
-		mask-size: contain;
-		mask-repeat: no-repeat;
-		mask-position: center center;
-		margin-left: .2em;
-		margin-right: 1px;
-		transform: translateY(.125em);
-		background-color: var(--main-text-secondary-color, #666);
-	}
-	&:hover::after{
-		background-color: var(--main-link-hover-color, #998B00);
-	}
-}
-
-/** Video Links (YouTube, Vimeo) **/
+.singleentry .content a.downloadlink,
 #main_content_wrap a.videolink,
 .singleentry .content a.videolink{
 	display: inline;
-	word-break: break-word;
-	&::after{
-		content: "";
-		mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' fill='none' viewBox='0 0 14 14'%3E%3Cpath stroke='%23000' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M12.587 5.658a1.48 1.48 0 0 0-1.03-1.06c-.911-.223-4.56-.223-4.56-.223s-3.648 0-4.56.244a1.47 1.47 0 0 0-1.029 1.06 15.4 15.4 0 0 0-.244 2.806c-.006.947.076 1.893.244 2.826a1.47 1.47 0 0 0 1.029 1.018c.912.244 4.56.244 4.56.244s3.649 0 4.56-.244a1.47 1.47 0 0 0 1.03-1.06q.248-1.381.243-2.784a15.4 15.4 0 0 0-.244-2.827'/%3E%3Cpath stroke='%23000' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.35' d='M5.685 6.98c0-.279 0-.418.058-.496a.3.3 0 0 1 .213-.116c.097-.007.214.069.448.22l2.3 1.478c.203.13.305.196.34.279.03.072.03.154 0 .227-.035.083-.137.148-.34.279l-2.3 1.478c-.234.151-.351.226-.448.22a.3.3 0 0 1-.213-.117c-.058-.078-.058-.217-.058-.495z'/%3E%3C/svg%3E");
-		display: inline-block;
-		-webkit-transition: all .3s;
-		-o-transition: all .3s;
-		transition: all .3s;
+	overflow-wrap: break-word;
+
+	.linkicon-wrap{
+		white-space: nowrap;
+	}
+
+	svg.linkicon{
 		width: .875em;
 		height: .875em;
-		mask-size: contain;
-		mask-repeat: no-repeat;
-		mask-position: center center;
+		fill: none;
+		stroke-width: 2.4;
 		margin-left: .2em;
 		margin-right: 1px;
-		transform: translateY(.125em);
-		background-color: var(--main-text-secondary-color, #666);
+		vertical-align: -0.14em;
+		color: var(--main-text-secondary-color, #666);
+		-webkit-transition: color .3s;
+		-o-transition: color .3s;
+		transition: color .3s;
 	}
-	&:hover::after{
-		background-color: var(--main-link-hover-color, #998B00);
+
+	&:hover svg.linkicon{
+		color: var(--main-link-hover-color, #998B00);
 	}
 }
+

--- a/_sass/pages/_blog.scss
+++ b/_sass/pages/_blog.scss
@@ -604,6 +604,9 @@ h5 a {
 		.postcontent{
 			margin: 0 auto;
 			@include blog-typography;
+			details summary{
+				font-size: var(--type-body-large, 18px);
+			}
 			.video-container{
 				margin: 30px 0;
 				position: relative;
@@ -671,7 +674,7 @@ h5 a {
 						li{
 							line-height: 1;
 						&.current > a{
-								color: $purple;
+								color: var(--main-text-primary-color, #0D0D0D);
 							}
 						}
 						a{

--- a/_sass/pages/_docs-content.scss
+++ b/_sass/pages/_docs-content.scss
@@ -630,12 +630,30 @@ body.layout_default.blog_typography {
             gap: 5px;
             align-items: center;
             cursor: pointer;
-            transition: padding .3s;
+            text-decoration: underline;
+            text-decoration-color: var(--main-text-tertiary-color, #B2B2B2);
+            text-decoration-thickness: 1px;
+            text-underline-offset: 0.16em;
+            transition: color .3s, text-decoration-color .3s, padding .3s;
 
+            span,
             a{
                 color: inherit;
+                text-decoration-color: var(--main-text-tertiary-color, #B2B2B2) !important;
+                text-decoration-thickness: 1px !important;
+                text-underline-offset: 0.16em;
             }
-            
+
+            &:hover{
+                color: var(--main-link-hover-color, #998B00);
+                text-decoration-color: var(--main-link-hover-color, #998B00);
+
+                span,
+                a{
+                    text-decoration-color: var(--main-link-hover-color, #998B00) !important;
+                }
+            }
+
             &::after{
                 mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' fill='none' viewBox='0 0 14 14'%3E%3Cpath stroke='%23000' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.35' d='m2.102 5.05 4.9 4.9 4.9-4.9'/%3E%3C/svg%3E");
                 mask-size: contain;
@@ -646,11 +664,15 @@ body.layout_default.blog_typography {
                 content: "";
                 width: 14px;
                 height: 14px;
-                transition: transform .3s;
+                transition: transform .3s, background-color .3s;
                 position: absolute;
                 transform: translate(5px, 4px);
             }
-            
+
+            &:hover::after{
+                background-color: var(--main-link-hover-color, #998B00);
+            }
+
             &::marker {
                 display: none;
             }

--- a/_sass/pages/_duckcon.scss
+++ b/_sass/pages/_duckcon.scss
@@ -578,8 +578,8 @@
                     color: var(--main-text-secondary-color, #B2B2B2);
                 }
 
-                &.downloadlink::after {
-                    background-color: currentColor !important;
+                &.downloadlink svg.linkicon {
+                    color: inherit !important;
                 }
             }
         }

--- a/js/script.js
+++ b/js/script.js
@@ -523,6 +523,23 @@ $('.headercontent a, .mainlinks a, .box-link a, .footercontent a, .highlight a, 
 $('table a.videolink:contains(GitHub)').removeClass('videolink').addClass('nobg');
 $('.supporterboard a.videolink').removeClass('videolink').addClass('nobg');
 
+// Append sprite icons to external, download and video links, gluing the icon to the last word
+$('#main_content_wrap, .singleentry .content').find('a.externallink, a.downloadlink, a.videolink').each(function() {
+	var $a = $(this);
+	if ($a.find('svg.linkicon').length) return;
+	var icon = $a.hasClass('videolink') ? 'youtube' : ($a.hasClass('downloadlink') ? 'download-01' : 'link-external-02');
+	var $svg = $('<svg class="icon linkicon"><use href="#' + icon + '"></use></svg>');
+	var contents = $a.contents();
+	var last = contents.length ? contents[contents.length - 1] : null;
+	var match = (last && last.nodeType === 3) ? last.nodeValue.match(/(\S+)(\s*)$/) : null;
+	if (match) {
+		last.nodeValue = last.nodeValue.slice(0, match.index);
+		$('<span class="linkicon-wrap"></span>').text(match[1]).append($svg).appendTo($a);
+	} else {
+		$a.append($svg);
+	}
+});
+
 // Wrap external links followed by a "." in a nobreak span
 $('body.documentation #main_content_wrap a.externallink').each(function () {
 	const link = $(this);


### PR DESCRIPTION
- Unify text underline on details/summary foldouts with the link style
- Match summary foldout font size to body copy in blog posts
- Append external/video/download link icons via the SVG sprite (use) instead of ::after masks; icon stays glued to the last word so it never wraps alone
- Adjusted <tr> hover in blog posts
- Corrected active TOC entry color in blog post