### PR TITLE
Small layout adjustments on Getting Started pages

### DIFF
--- a/docs/0.10/index.md
+++ b/docs/0.10/index.md
@@ -1,5 +1,6 @@
 ---
 layout: docu
+copy_markdown: false
 title: Documentation
 ---
 

--- a/docs/1.0/index.md
+++ b/docs/1.0/index.md
@@ -1,5 +1,6 @@
 ---
 layout: docu
+copy_markdown: false
 title: Documentation
 ---
 

--- a/docs/1.1/index.md
+++ b/docs/1.1/index.md
@@ -1,5 +1,6 @@
 ---
 layout: docu
+copy_markdown: false
 title: Documentation
 ---
 

--- a/docs/1.2/index.md
+++ b/docs/1.2/index.md
@@ -1,5 +1,6 @@
 ---
 layout: docu
+copy_markdown: false
 title: Documentation
 ---
 

--- a/docs/1.3/index.md
+++ b/docs/1.3/index.md
@@ -1,5 +1,6 @@
 ---
 layout: docu
+copy_markdown: false
 title: Documentation
 ---
 

--- a/docs/lts/index.md
+++ b/docs/lts/index.md
@@ -1,12 +1,13 @@
 ---
 layout: docu
+copy_markdown: false
 title: Documentation
 ---
 
 ## Connecting to DuckDB
 
 <div class="box-link-wrapper">
-    <div class="box-link half-width">
+    <div class="box-link third-width">
         <a href="{% link docs/lts/connect/overview.md %}"></a>
         <span class="symbol"><img src="{% link images/icons/link.svg %}"></span>
         <span>DuckDB connection overview</span>
@@ -17,73 +18,73 @@ title: Documentation
 ## Client APIs
 
 <div class="box-link-wrapper">
-    <div class="box-link half-width">
+    <div class="box-link third-width">
         <a href="{% link docs/lts/clients/c/overview.md %}"></a>
         <span class="symbol"><img src="{% link images/icons/c.svg %}"></span>
         <span>C</span>
         <svg class="chevron"><use href="#chevron-right"></use></svg>
     </div>
-    <div class="box-link half-width">
+    <div class="box-link third-width">
         <a href="{% link docs/lts/clients/cpp.md %}"></a>
         <span class="symbol"><img src="{% link images/icons/cpp.svg %}"></span>
         <span>C++</span>
         <svg class="chevron"><use href="#chevron-right"></use></svg>
     </div>
-    <div class="box-link half-width">
+    <div class="box-link third-width">
         <a href="{% link docs/lts/clients/cli/overview.md %}"></a>
         <span class="symbol"><img src="{% link images/icons/cli.svg %}"></span>
         <span>CLI (command line interface)</span>
         <svg class="chevron"><use href="#chevron-right"></use></svg>
     </div>
-    <div class="box-link half-width">
+    <div class="box-link third-width">
         <a href="{% link docs/lts/clients/go.md %}"></a>
         <span class="symbol"><img src="{% link images/icons/go.svg %}"></span>
         <span>Go</span>
         <svg class="chevron"><use href="#chevron-right"></use></svg>
     </div>
-    <div class="box-link half-width">
+    <div class="box-link third-width">
         <a href="{% link docs/lts/clients/java.md %}"></a>
         <span class="symbol"><img src="{% link images/icons/java.svg %}"></span>
         <span>Java (JDBC)</span>
         <svg class="chevron"><use href="#chevron-right"></use></svg>
     </div>
-    <div class="box-link half-width">
+    <div class="box-link third-width">
         <a href="{% link docs/lts/clients/node_neo/overview.md %}"></a>
         <span class="symbol"><img src="{% link images/icons/nodejs.svg %}"></span>
         <span>Node.js</span>
         <svg class="chevron"><use href="#chevron-right"></use></svg>
     </div>
-    <div class="box-link half-width">
+    <div class="box-link third-width">
         <a href="{% link docs/lts/clients/odbc/overview.md %}"></a>
         <span class="symbol"><img src="{% link images/icons/odbc.svg %}"></span>
         <span>ODBC</span>
         <svg class="chevron"><use href="#chevron-right"></use></svg>
     </div>
-    <div class="box-link half-width">
+    <div class="box-link third-width">
         <a href="{% link docs/lts/clients/python/overview.md %}"></a>
         <span class="symbol"><img src="{% link images/icons/python.svg %}"></span>
         <span>Python</span>
         <svg class="chevron"><use href="#chevron-right"></use></svg>
     </div>
-    <div class="box-link half-width">
+    <div class="box-link third-width">
         <a href="{% link docs/lts/clients/r.md %}"></a>
         <span class="symbol"><img src="{% link images/icons/r.svg %}"></span>
         <span>R</span>
         <svg class="chevron"><use href="#chevron-right"></use></svg>
     </div>
-    <div class="box-link half-width">
+    <div class="box-link third-width">
         <a href="{% link docs/lts/clients/rust.md %}"></a>
         <span class="symbol"><img src="{% link images/icons/rust.svg %}"></span>
         <span>Rust</span>
         <svg class="chevron"><use href="#chevron-right"></use></svg>
     </div>
-    <div class="box-link half-width">
+    <div class="box-link third-width">
         <a href="{% link docs/lts/clients/wasm/overview.md %}"></a>
         <span class="symbol"><img src="{% link images/icons/webassembly.svg %}"></span>
         <span>WebAssembly</span>
         <svg class="chevron"><use href="#chevron-right"></use></svg>
     </div>
-    <div class="box-link half-width">
+    <div class="box-link third-width">
         <a href="{% link docs/lts/clients/overview.md %}"></a>
         <span class="symbol"><img src="{% link images/icons/doc.svg %}"></span>
         <span>All client APIs</span>
@@ -94,13 +95,13 @@ title: Documentation
 ## SQL
 
 <div class="box-link-wrapper">
-    <div class="box-link half-width">
+    <div class="box-link third-width">
         <a href="{% link docs/lts/sql/introduction.md %}"></a>
         <span class="symbol"><img src="{% link images/icons/doc.svg %}"></span>
         <span>Introduction</span>
         <svg class="chevron"><use href="#chevron-right"></use></svg>
     </div>
-    <div class="box-link half-width">
+    <div class="box-link third-width">
         <a href="{% link docs/lts/sql/statements/overview.md %}"></a>
         <span class="symbol"><img src="{% link images/icons/attention.svg %}"></span>
         <span>Statements</span>
@@ -111,25 +112,25 @@ title: Documentation
 ## Other
 
 <div class="box-link-wrapper">
-    <div class="box-link half-width">
+    <div class="box-link third-width">
         <a href="{% link docs/lts/guides/overview.md %}"></a>
         <span class="symbol"><img src="{% link images/icons/folder.svg %}"></span>
         <span>Guides</span>
         <svg class="chevron"><use href="#chevron-right"></use></svg>
     </div>
-    <div class="box-link half-width">
+    <div class="box-link third-width">
         <a href="{% link install/index.html %}"></a>
         <span class="symbol"><img src="{% link images/icons/database.svg %}"></span>
         <span>Installation</span>
         <svg class="chevron"><use href="#chevron-right"></use></svg>
     </div>
-    <div class="box-link half-width">
+    <div class="box-link third-width">
         <a href="{% link docs/lts/dev/building/overview.md %}"></a>
         <span class="symbol"><img src="{% link images/icons/wrench.svg %}"></span>
         <span>Building DuckDB</span>
         <svg class="chevron"><use href="#chevron-right"></use></svg>
     </div>
-    <div class="box-link half-width">
+    <div class="box-link third-width">
         <a href="{% link docs/lts/guides/offline-copy.md %}"></a>
         <span class="symbol"><img src="{% link images/icons/doc.svg %}"></span>
         <span>Browsing offline</span>


### PR DESCRIPTION
- Remove "Copy Markdown" button on "Getting Started" pages
- Set box-link width on LTS version "Getting Started" to third-width