### PR TITLE
Add a PyTorch integration guide for Python users

### DIFF
--- a/_data/menu_docs_current.json
+++ b/_data/menu_docs_current.json
@@ -1635,6 +1635,10 @@
                   "url": "polars"
                 },
                 {
+                  "page": "Integration with PyTorch",
+                  "url": "pytorch"
+                },
+                {
                   "page": "Using fsspec Filesystems",
                   "url": "filesystems"
                 }

--- a/_data/menu_docs_lts.json
+++ b/_data/menu_docs_lts.json
@@ -1515,6 +1515,10 @@
                   "url": "polars"
                 },
                 {
+                  "page": "Integration with PyTorch",
+                  "url": "pytorch"
+                },
+                {
                   "page": "Using fsspec Filesystems",
                   "url": "filesystems"
                 }

--- a/docs/current/guides/overview.md
+++ b/docs/current/guides/overview.md
@@ -120,6 +120,7 @@ To find a list of these tools, check out the [Awesome DuckDB repository](https:/
 
 * [How to use Ibis to query DuckDB with or without SQL]({% link docs/current/guides/python/ibis.md %})
 * [How to use DuckDB with Polars DataFrames via Apache Arrow]({% link docs/current/guides/python/polars.md %})
+* [How to stream DuckDB query results to PyTorch via Apache Arrow]({% link docs/current/guides/python/pytorch.md %})
 
 ## SQL Features
 

--- a/docs/current/guides/python/pytorch.md
+++ b/docs/current/guides/python/pytorch.md
@@ -1,0 +1,75 @@
+---
+layout: docu
+redirect_from:
+- /docs/guides/python/pytorch
+- /docs/preview/guides/python/pytorch
+- /docs/stable/guides/python/pytorch
+title: Integration with PyTorch
+---
+
+[PyTorch](https://pytorch.org/) tensors can be built from DuckDB query results by exporting each result batch as [Apache Arrow](https://arrow.apache.org/docs/format/Columnar.html). This pattern is useful when training or serving models on Parquet data because DuckDB can filter and project the input before the batches are converted to tensors.
+
+## Installation
+
+```batch
+pip install -U duckdb pyarrow torch
+```
+
+## DuckDB to PyTorch
+
+This example queries a Parquet-backed Arrow dataset, streams the result as `RecordBatch` objects, and converts each batch into feature and label tensors.
+
+```python
+import pathlib
+import tempfile
+
+import duckdb
+import numpy as np
+import pyarrow as pa
+import pyarrow.dataset as ds
+import pyarrow.parquet as pq
+import torch
+
+base_path = pathlib.Path(tempfile.mkdtemp())
+parquet_dir = base_path / "train"
+
+table = pa.table(
+    {
+        "feature_0": [0.1, 0.3, 0.5, 0.7],
+        "feature_1": [1.0, 0.0, 1.0, 0.0],
+        "label": [0, 1, 1, 0],
+    }
+)
+pq.write_to_dataset(table, str(parquet_dir))
+
+con = duckdb.connect()
+train_dataset = ds.dataset(str(parquet_dir))
+
+reader = con.execute("""
+    SELECT feature_0, feature_1, label
+    FROM train_dataset
+    WHERE label = 1
+""").to_arrow_reader(batch_size=2)
+
+for batch in reader:
+    features = torch.tensor(
+        np.column_stack(
+            [
+                batch.column(0).to_numpy(),
+                batch.column(1).to_numpy(),
+            ]
+        ),
+        dtype=torch.float32,
+    )
+    labels = torch.tensor(batch.column(2).to_numpy(), dtype=torch.int64)
+
+    print(features.shape, labels)
+```
+
+```text
+torch.Size([2, 2]) tensor([1, 1])
+```
+
+DuckDB pushes the `WHERE label = 1` filter and the selected columns into the dataset scan, so only the requested rows and columns are converted to tensors. The `to_arrow_reader` method streams the result in batches instead of materializing the full result in memory at once.
+
+To learn more about querying Arrow objects directly, see the [“SQL on Apache Arrow” guide]({% link docs/current/guides/python/sql_on_arrow.md %}) and the [“Export to Apache Arrow” guide]({% link docs/current/guides/python/export_arrow.md %}).

--- a/docs/lts/guides/overview.md
+++ b/docs/lts/guides/overview.md
@@ -108,6 +108,7 @@ To find a list of these tools, check out the [Awesome DuckDB repository](https:/
 
 * [How to use Ibis to query DuckDB with or without SQL]({% link docs/lts/guides/python/ibis.md %})
 * [How to use DuckDB with Polars DataFrames via Apache Arrow]({% link docs/lts/guides/python/polars.md %})
+* [How to stream DuckDB query results to PyTorch via Apache Arrow]({% link docs/lts/guides/python/pytorch.md %})
 
 ## SQL Features
 

--- a/docs/lts/guides/python/pytorch.md
+++ b/docs/lts/guides/python/pytorch.md
@@ -1,0 +1,71 @@
+---
+layout: docu
+title: Integration with PyTorch
+---
+
+[PyTorch](https://pytorch.org/) tensors can be built from DuckDB query results by exporting each result batch as [Apache Arrow](https://arrow.apache.org/docs/format/Columnar.html). This pattern is useful when training or serving models on Parquet data because DuckDB can filter and project the input before the batches are converted to tensors.
+
+## Installation
+
+```batch
+pip install -U duckdb pyarrow torch
+```
+
+## DuckDB to PyTorch
+
+This example queries a Parquet-backed Arrow dataset, streams the result as `RecordBatch` objects, and converts each batch into feature and label tensors.
+
+```python
+import pathlib
+import tempfile
+
+import duckdb
+import numpy as np
+import pyarrow as pa
+import pyarrow.dataset as ds
+import pyarrow.parquet as pq
+import torch
+
+base_path = pathlib.Path(tempfile.mkdtemp())
+parquet_dir = base_path / "train"
+
+table = pa.table(
+    {
+        "feature_0": [0.1, 0.3, 0.5, 0.7],
+        "feature_1": [1.0, 0.0, 1.0, 0.0],
+        "label": [0, 1, 1, 0],
+    }
+)
+pq.write_to_dataset(table, str(parquet_dir))
+
+con = duckdb.connect()
+train_dataset = ds.dataset(str(parquet_dir))
+
+reader = con.execute("""
+    SELECT feature_0, feature_1, label
+    FROM train_dataset
+    WHERE label = 1
+""").to_arrow_reader(batch_size=2)
+
+for batch in reader:
+    features = torch.tensor(
+        np.column_stack(
+            [
+                batch.column(0).to_numpy(),
+                batch.column(1).to_numpy(),
+            ]
+        ),
+        dtype=torch.float32,
+    )
+    labels = torch.tensor(batch.column(2).to_numpy(), dtype=torch.int64)
+
+    print(features.shape, labels)
+```
+
+```text
+torch.Size([2, 2]) tensor([1, 1])
+```
+
+DuckDB pushes the `WHERE label = 1` filter and the selected columns into the dataset scan, so only the requested rows and columns are converted to tensors. The `to_arrow_reader` method streams the result in batches instead of materializing the full result in memory at once.
+
+To learn more about querying Arrow objects directly, see the [“SQL on Apache Arrow” guide]({% link docs/lts/guides/python/sql_on_arrow.md %}) and the [“Export to Apache Arrow” guide]({% link docs/lts/guides/python/export_arrow.md %}).


### PR DESCRIPTION
## Summary
* add current and lts Python guides showing how to stream DuckDB query results into PyTorch tensors via Apache Arrow
* link the new guide from the guides landing pages
* add the guide to both current and lts docs menus

## Testing
* npx --yes markdownlint-cli docs/current/guides/python/pytorch.md docs/lts/guides/python/pytorch.md docs/current/guides/overview.md docs/lts/guides/overview.md --config .markdownlint.jsonc
* parsed _data/menu_docs_current.json and _data/menu_docs_lts.json successfully
* ran the Python example in a local environment with duckdb, pyarrow, numpy, and torch installed