### PR TITLE
Add Julia repo URL

### DIFF
--- a/docs/current/dev/repositories.md
+++ b/docs/current/dev/repositories.md
@@ -28,6 +28,7 @@ Several components of DuckDB are maintained in separate repositories.
 * [`duckdb-swift`](https://github.com/duckdb/duckdb-swift): Swift client
 * [`duckdb-wasm`](https://github.com/duckdb/duckdb-wasm): WebAssembly client
 * [`duckplyr`](https://github.com/tidyverse/duckplyr): a drop-in replacement for dplyr in R
+* [`DuckDB.jl`](https://github.com/duckdb/DuckDB.jl): Julia client
 
 ## Connectors
 


### PR DESCRIPTION
Ref: https://github.com/duckdblabs/duckdb-internal/issues/1148#issuecomment-5055568657

We took Julia out of tree, this adds the repo URL to the list in the docs. I don't see any other references to the repo that need updating.