### PR TITLE
Add a note to Postgres overview page

### DIFF
--- a/docs/current/core_extensions/postgres/overview.md
+++ b/docs/current/core_extensions/postgres/overview.md
@@ -46,6 +46,8 @@ By default, all schemas are attached. When working with large instances, it can 
 ATTACH 'dbname=postgres user=postgres host=127.0.0.1' AS db (TYPE postgres, SCHEMA 'public');
 ```
 
+> Deprecated The old `postgres_attach` function is deprecated. It is recommended to switch over to the new `ATTACH` syntax.
+
 ### Configuration
 
 The `ATTACH` command takes as input either a [`libpq` connection string](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING)
@@ -353,7 +355,13 @@ To avoid having to continuously fetch schema data from PostgreSQL, DuckDB keeps 
 CALL pg_clear_cache();
 ```
 
-> Deprecated The old `postgres_attach` function is deprecated. It is recommended to switch over to the new `ATTACH` syntax.
+In version 1.5.5 a support for automatic detection of schema changes was added using a "staleness query"
+(contributed by Brandon Freeman in [duckdb/duckdb-postgres#514](https://github.com/duckdb/duckdb-postgres/pull/514)):
+
+ - when `pg_staleness_query_enabled` option (`BOOLEAN`, default: `FALSE`) is enabled, on every catalog access a query is run that
+   checks Postgres' `pg_class.xmin` column value in every table and reloads the cache automatically, if a change is detected
+
+ - for Postgres-wire-compatible databases a custom "staleness query" can be set using `pg_staleness_query` option.
 
 ## Working with hstore Columns
 


### PR DESCRIPTION
This PR adds a note about the `pg_staleness_query_enabled` option that was added in 1.5.5.