### PR TITLE
disable c api doc generation

### DIFF
--- a/scripts/generate_all_docs.sh
+++ b/scripts/generate_all_docs.sh
@@ -11,7 +11,9 @@ DUCKDB=$1;
 echo "Generating docs using duckdb source in $DUCKDB"
 
 python3 ./scripts/generate_config_docs.py $DUCKDB/build/release/duckdb
-python3 ./scripts/generate_c_api_docs.py $DUCKDB
+# C API doc generation is disabled while the C API spec migrates from the JSON
+# format to the YAML + capigen format.
+# python3 ./scripts/generate_c_api_docs.py $DUCKDB
 python3 ./scripts/generate_python_docs.py
 python3 ./scripts/generate_sql_function_docs.py $DUCKDB/build/release/duckdb
 node ./scripts/generate_nodejs_docs.js $DUCKDB/../duckdb-node


### PR DESCRIPTION
While we're moving to the new yaml-based api spec