### PR TITLE
Document SET GLOBAL instance scope

### DIFF
--- a/docs/current/configuration/secrets_manager.md
+++ b/docs/current/configuration/secrets_manager.md
@@ -76,6 +76,8 @@ By default, this will write the secret (unencrypted) to the `~/.duckdb/stored_se
 SET secret_directory = 'path/to/my_secrets_dir';
 ```
 
+The `secret_directory` setting applies to the current DuckDB instance and is not persisted across DuckDB instances. If you use a custom secrets directory, set `secret_directory` again when starting a new DuckDB instance before creating or using persistent secrets from that directory.
+
 Note that setting the value of the `home_directory` configuration option has no effect on the location of the secrets.
 
 ## Deleting Secrets

--- a/docs/current/sql/statements/set.md
+++ b/docs/current/sql/statements/set.md
@@ -84,6 +84,8 @@ Configuration options can have different scopes:
 
 When not specified, the default scope for the configuration option is used. For most options this is `GLOBAL`.
 
+> Note `GLOBAL` settings apply to the current DuckDB instance. They are not written to the database file or persisted across DuckDB instances. If all connections to an instance are closed and a new instance is started, configuration options use their defaults unless they are set again.
+
 ## Configuration
 
 See the [Configuration]({% link docs/current/configuration/overview.md %}) page for the full list of configuration options.

--- a/docs/current/sql/statements/set.md
+++ b/docs/current/sql/statements/set.md
@@ -84,7 +84,7 @@ Configuration options can have different scopes:
 
 When not specified, the default scope for the configuration option is used. For most options this is `GLOBAL`.
 
-> Note `GLOBAL` settings apply to the current DuckDB instance. They are not written to the database file or persisted across DuckDB instances. If all connections to an instance are closed and a new instance is started, configuration options use their defaults unless they are set again.
+> `GLOBAL` settings apply to the current DuckDB instance. They are not written to the database file or persisted across DuckDB instances. If all connections to an instance are closed and a new instance is started, configuration options use their defaults unless they are set again.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

Clarifies that `GLOBAL` configuration settings apply to the current DuckDB instance and are not persisted to disk across restarted instances.

Adds a `secret_directory` note so users with a custom persistent secrets directory know to set it again before creating or using persistent secrets in a new DuckDB instance.

Closes duckdb/duckdb-web#6681.
References duckdb/duckdb#21740.

## Validation

* `git diff --check`
* `npx.cmd markdownlint-cli docs/current/sql/statements/set.md docs/current/configuration/secrets_manager.md --config .markdownlint.jsonc`