### PR TITLE
Document list unnesting functions

### DIFF
--- a/docs/current/sql/functions/list.md
+++ b/docs/current/sql/functions/list.md
@@ -68,6 +68,7 @@ title: List Functions
 | [`filter(list, lambda(x))`](#list_filterlist-lambdax) | Alias for `list_filter`. |
 | [`flatten(nested_list)`](#flattennested_list) | [Flattens](#flattening) a nested list by one level. |
 | [`generate_series(start[, stop][, step])`](#generate_seriesstart-stop-step) | Creates a list of values between `start` and `stop` - the stop parameter is inclusive. |
+| [`generate_subscripts(arr, dim)`](#generate_subscriptsarr-dim) | Generates indexes along the `dim`th dimension of `arr`. See the [unnest page]({% link docs/current/sql/query_syntax/unnest.md %}) for an example of tracking list entry positions. |
 | [`grade_up(list[, col1][, col2])`](#list_grade_uplist-col1-col2) | Alias for `list_grade_up`. |
 | [`len(list)`](#lengthlist) | Alias for `length`. |
 | [`length(list)`](#lengthlist) | Returns the length of the `list`. |
@@ -143,7 +144,7 @@ title: List Functions
 | [`range(start[, stop][, step])`](#rangestart-stop-step) | Creates a list of values between `start` and `stop` - the stop parameter is exclusive. |
 | [`reduce(list, lambda(x,y)[, initial_value])`](#list_reducelist-lambdaxy-initial_value) | Alias for `list_reduce`. |
 | [`repeat(list, count)`](#repeatlist-count) | Repeats the `list` `count` number of times. |
-| [`unnest(list)`](#unnestlist) | Unnests a list by one level. Note that this is a special function that alters the cardinality of the result. See the [unnest page]({% link docs/current/sql/query_syntax/unnest.md %}) for more details. |
+| [`unnest(list[, recursive := boolean][, max_depth := integer])`](#unnestlist-recursive--boolean-max_depth--integer) | Unnests a list. This is a special function that alters the cardinality of the result. See the [unnest page]({% link docs/current/sql/query_syntax/unnest.md %}) for more details, including recursive unnesting and depth limits. |
 | [`unpivot_list(arg, ...)`](#unpivot_listarg-) | Identical to list_value, but generated as part of unpivot for better error messages. |
 
 <!-- markdownlint-enable MD056 -->
@@ -261,6 +262,14 @@ title: List Functions
 | **Description** | Creates a list of values between `start` and `stop` - the stop parameter is inclusive. |
 | **Example** | `generate_series(2, 5, 3)` |
 | **Result** | `[2, 5]` |
+
+#### `generate_subscripts(arr, dim)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Generates indexes along the `dim`th dimension of `arr`. See the [unnest page]({% link docs/current/sql/query_syntax/unnest.md %}) for an example of tracking list entry positions. |
+| **Example** | `generate_subscripts([4, 5, 6], 1)` |
+| **Result** | Multiple rows: `'1'`, `'2'`, `'3'` |
 
 #### `length(list)`
 
@@ -801,11 +810,11 @@ title: List Functions
 | **Example** | `repeat([1, 2, 3], 5)` |
 | **Result** | `[1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3]` |
 
-#### `unnest(list)`
+#### `unnest(list[, recursive := boolean][, max_depth := integer])`
 
 <div class="nostroke_table"></div>
 
-| **Description** | Unnests a list by one level. Note that this is a special function that alters the cardinality of the result. See the [unnest page]({% link docs/current/sql/query_syntax/unnest.md %}) for more details. |
+| **Description** | Unnests a list. This is a special function that alters the cardinality of the result. See the [unnest page]({% link docs/current/sql/query_syntax/unnest.md %}) for more details, including recursive unnesting and depth limits. |
 | **Example** | `unnest([1, 2, 3])` |
 | **Result** | Multiple rows: `'1'`, `'2'`, `'3'` |
 
@@ -883,6 +892,12 @@ l.list_apply(lambda x, i: {'filter': g(x, i), 'result': f(x, i)})
     .list_filter(lambda x: x.filter)
     .list_apply(lambda x: x.result)
 ```
+
+## Unnesting Functions
+
+The [`unnest`](#unnestlist-recursive--boolean-max_depth--integer) function emits list entries as rows. The [`generate_subscripts`](#generate_subscriptsarr-dim) function emits list indexes and can be used with `unnest` to keep track of list entry positions.
+
+For details on `unnest` behavior, including recursive unnesting, depth limits and examples using `generate_subscripts`, see the [Unnesting]({% link docs/current/sql/query_syntax/unnest.md %}) page.
 
 ## Range Functions
 
@@ -962,20 +977,6 @@ SELECT generate_series(2, 5, 3);
 ```text
 [2, 5]
 ```
-
-#### `generate_subscripts(arr, dim)`
-
-The `generate_subscripts(arr, dim)` function generates indexes along the `dim`th dimension of array `arr`.
-
-```sql
-SELECT generate_subscripts([4, 5, 6], 1) AS i;
-```
-
-| i |
-|--:|
-| 1 |
-| 2 |
-| 3 |
 
 ### Date Ranges
 

--- a/docs/current/sql/query_syntax/unnest.md
+++ b/docs/current/sql/query_syntax/unnest.md
@@ -154,7 +154,7 @@ SELECT unnest([[[1, 2], [3, 4]], [[5, 6], [7, 8, 9], []], [[10, 11]]], max_depth
 
 ### Keeping Track of List Entry Positions
 
-To keep track of each entry's position within the original list, `unnest` may be combined with [`generate_subscripts`]({% link docs/current/sql/functions/list.md %}#generate_subscripts):
+For non-recursive list unnesting, [`generate_subscripts`]({% link docs/current/sql/functions/list.md %}#generate_subscriptsarr-dim) can be used to emit each entry's position within the original list:
 
 ```sql
 SELECT unnest(l) AS x, generate_subscripts(l, 1) AS index
@@ -168,6 +168,8 @@ FROM (VALUES ([1, 2, 3]), ([4, 5])) tbl(l);
 | 3 | 3     |
 | 4 | 1     |
 | 5 | 2     |
+
+`generate_subscripts` can also be used independently to return indexes for a list. It does not provide positions for recursive `unnest` output.
 
 ### Keep Column Names When Recursively Unnesting
 

--- a/scripts/generate_sql_function_docs.py
+++ b/scripts/generate_sql_function_docs.py
@@ -102,9 +102,17 @@ OVERRIDES: list[DocFunction] = [
     DocFunction(
         category='list',
         name='unnest',
-        parameters=['list'],
-        description="Unnests a list by one level. Note that this is a special function that alters the cardinality of the result. See the unnest page for more details.",
+        parameters=['list', 'recursive := boolean', 'max_depth := integer'],
+        description="Unnests a list. This is a special function that alters the cardinality of the result. See the unnest page for more details, including recursive unnesting and depth limits.",
         examples=["unnest([1, 2, 3])"],
+        nr_optional_arguments=2,
+    ),
+    DocFunction(
+        category='list',
+        name='generate_subscripts',
+        parameters=['arr', 'dim'],
+        description="Generates indexes along the `dim`th dimension of `arr`. See the unnest page for an example of tracking list entry positions.",
+        examples=["generate_subscripts([4, 5, 6], 1)"],
     ),
     # macros
     DocFunction(


### PR DESCRIPTION
## Summary

Updates the generated List Functions documentation for list unnesting helpers:

* adds `generate_subscripts(arr, dim)` to the generated function table and detail entries
* broadens the `unnest` list signature to show the named `recursive` and `max_depth` options
* moves `generate_subscripts` out of the Range Functions section and adds a short Unnesting Functions section
* clarifies that `generate_subscripts` tracks positions for non-recursive list unnesting

Closes duckdb/duckdb-web#7064.
Closes duckdb/duckdb-web#7066.
References duckdb/duckdb-web#7065.

## Validation

* `git diff --check`
* `npx.cmd markdownlint-cli docs/current/sql/functions/list.md docs/current/sql/query_syntax/unnest.md --config .markdownlint.jsonc`
* `py -3.13 -m py_compile scripts/generate_sql_function_docs.py`