### PR TITLE
doc: additional options to COPY

### DIFF
--- a/docs/current/core_extensions/spatial/gdal.md
+++ b/docs/current/core_extensions/spatial/gdal.md
@@ -19,15 +19,18 @@ For example, to export a table to a GeoJSON file, with generated bounding boxes,
 
 ```sql
 COPY ⟨table⟩ TO 'some/file/path/filename.geojson'
-WITH (FORMAT gdal, DRIVER 'GeoJSON', LAYER_CREATION_OPTIONS 'WRITE_BBOX=YES', SRS 'EPSG:4326');
+WITH (FORMAT gdal, DRIVER 'GeoJSON', LAYER_CREATION_OPTIONS ('WRITE_BBOX=YES', 'DESCRIPTION=a sample geojson'), SRS 'EPSG:4326');
 ```
 
 Available options:
 
 * `FORMAT`: is the only required option and must be set to `GDAL` to use the GDAL based copy function.
 * `DRIVER`: is the GDAL driver to use for the export. Use `ST_Drivers()` to list the names of all available drivers.
-* `LAYER_CREATION_OPTIONS`: list of options to pass to the GDAL driver. See the GDAL docs for the driver you are using for a list of available options.
-* `SRS`: Set a spatial reference system as metadata to use for the export. This can be a WKT string, an EPSG code or a proj-string, basically anything you would normally be able to pass to GDAL. Note that this will **not** perform any reprojection of the input geometry, it just sets the metadata if the target driver supports it.
+* `GEOMETRY_TYPE` : the geometry type for the created layer to pass to the GDAL driver. One of `POINT`, `LINESTRING`, `POLYGON`, `MULTIPOINT`, `MULTILINESTRING`, `MULTIPOLYGON` and `GEOMETRYCOLLECTION`.
+* `LAYER_NAME` : assign an alternate name to the new layer
+* `LAYER_CREATION_OPTIONS`: list of layer creation options to pass to the GDAL driver. Use parenthesis to pass a list of options. See the GDAL docs for the driver you are using for a list of available options.
+* `DATASET_CREATION_OPTIONS`: list of dataset creation options to pass to the GDAL driver. Use parenthesis to pass a list of options. See the GDAL docs for the driver you are using for a list of available options.
+* `SRS` or `CRS`: Set a spatial reference system as metadata to use for the export. This can be a WKT string, an EPSG code or a proj-string, basically anything you would normally be able to pass to GDAL. Note that this will **not** perform any reprojection of the input geometry, it just sets the metadata if the target driver supports it.
 
 ## Limitations
 


### PR DESCRIPTION
Documentation of options LAYER_NAME (resp. -nln in ogr2ogr ), GEOMETRY_TYPE (-nlt), CRS and DATASET_CREATION_OPTIONS (-dsco) added. Explicit list support for -lco et -dsco. Analyzed from https://github.com/duckdb/duckdb-spatial/blob/v1.5-variegata/src/spatial/modules/gdal/gdal_module.cpp#L1441