### PR TITLE
Document DECIMAL width and scale syntax and bounds

### DIFF
--- a/docs/current/sql/data_types/numeric.md
+++ b/docs/current/sql/data_types/numeric.md
@@ -43,6 +43,59 @@ Unlike variable-length integer implementations in other systems, there are limit
 
 The data type `DECIMAL(WIDTH, SCALE)` (also available under the alias `NUMERIC(WIDTH, SCALE)`) represents an exact fixed-point decimal value. When creating a value of type `DECIMAL`, the `WIDTH` and `SCALE` can be specified to define which size of decimal values can be held in the field. The `WIDTH` field determines how many digits can be held, and the `scale` determines the number of digits after the decimal point. For example, the type `DECIMAL(3, 2)` can fit the value `1.23`, but cannot fit the value `12.3` or the value `1.234`. The default `WIDTH` and `SCALE` is `DECIMAL(18, 3)`, if none are specified. If only the `WIDTH` is specified, the `SCALE` defaults to `0` – for example, `DECIMAL(18)` is equivalent to `DECIMAL(18, 0)` and truncates fractional digits.
 
+### Specifying the `WIDTH` and the `SCALE`
+
+Both parameters are optional, and a trailing comma after the `WIDTH` is accepted. The following spellings therefore all bind to a concrete decimal type:
+
+```sql
+SELECT
+    typeof(1.5::DECIMAL)      AS "DECIMAL",
+    typeof(1.5::DECIMAL())    AS "DECIMAL()",
+    typeof(1.5::DECIMAL(10))  AS "DECIMAL(10)",
+    typeof(1.5::DECIMAL(10,)) AS "DECIMAL(10,)";
+```
+
+|    DECIMAL    |   DECIMAL()   |  DECIMAL(10)  | DECIMAL(10,)  |
+|:--------------|:--------------|:--------------|:--------------|
+| DECIMAL(18,3) | DECIMAL(18,3) | DECIMAL(10,0) | DECIMAL(10,0) |
+
+The `NUMERIC` alias accepts the same spellings and yields the same types.
+
+Note that a bare `DECIMAL` is not an unconstrained decimal type as it is in PostgreSQL and Oracle. DuckDB always binds it to the concrete type `DECIMAL(18, 3)`, which rounds to 3 fractional digits and holds at most 15 digits before the decimal point.
+
+The `WIDTH` must be between 1 and 38, and the `SCALE` must be between 0 and 38 and may not exceed the `WIDTH`. Values outside these bounds are rejected by the binder instead of being clamped:
+
+```sql
+SELECT 1::DECIMAL(39, 2);
+```
+
+```console
+Binder Error:
+DECIMAL type width must be between 1 and 38
+```
+
+```sql
+SELECT 1::DECIMAL(18, 20);
+```
+
+```console
+Binder Error:
+DECIMAL type scale cannot be greater than width
+```
+
+Unlike PostgreSQL and Oracle, DuckDB does not support a negative `SCALE`:
+
+```sql
+SELECT 1::DECIMAL(18, -1);
+```
+
+```console
+Binder Error:
+DECIMAL type scale must be between 0 and 38
+```
+
+### Arithmetic and Internal Representation
+
 Addition, subtraction and multiplication of two fixed-point decimals returns another fixed-point decimal with the required `WIDTH` and `SCALE` to contain the exact result, or throws an error if the required `WIDTH` would exceed the maximal supported `WIDTH`, which is currently 38.
 
 Division of fixed-point decimals does not typically produce numbers with finite decimal expansion. Therefore, DuckDB uses approximate [floating-point arithmetic](#floating-point-types) for all divisions that involve fixed-point decimals and accordingly returns floating-point data types.

--- a/docs/current/sql/data_types/numeric.md
+++ b/docs/current/sql/data_types/numeric.md
@@ -55,7 +55,9 @@ SELECT
     typeof(1.5::DECIMAL(10,)) AS "DECIMAL(10,)";
 ```
 
-|    DECIMAL    |   DECIMAL()   |  DECIMAL(10)  | DECIMAL(10,)  |
+<div class="monospace_table"></div>
+
+| `DECIMAL` | `DECIMAL()` | `DECIMAL(10)` | `DECIMAL(10,)` |
 |:--------------|:--------------|:--------------|:--------------|
 | DECIMAL(18,3) | DECIMAL(18,3) | DECIMAL(10,0) | DECIMAL(10,0) |
 


### PR DESCRIPTION
Closes #6935

The "Fixed-Point Decimals" section did not say which `DECIMAL` spellings are accepted, nor what the `WIDTH`/`SCALE` bounds are. #6963 covered one sub-point (`SCALE` defaults to `0` when only `WIDTH` is given); this covers the rest of what the issue enumerates.

Added to `docs/current/sql/data_types/numeric.md`, purely additive (53 lines, no existing prose changed), split into two new subsections so the existing arithmetic/representation paragraphs keep their own heading:

- **Accepted spellings.** `DECIMAL`, `DECIMAL()`, `DECIMAL(WIDTH)` and `DECIMAL(WIDTH,)` all bind, with a result table showing the type each produces. `NUMERIC` behaves identically.
- **A bare `DECIMAL` is not unconstrained** as it is in PostgreSQL and Oracle: DuckDB binds it to the concrete type `DECIMAL(18, 3)`, so it rounds to 3 fractional digits and holds at most 15 digits before the decimal point.
- **Bounds.** `WIDTH` 1–38, `SCALE` 0–38 and not greater than `WIDTH`; negative `SCALE` is rejected, unlike PostgreSQL and Oracle. Each bound is shown with the verbatim binder error.

**Correction to the issue text.** The issue states the scale range is 0–37. The actual binder message is `DECIMAL type scale must be between 0 and 38`, and `DECIMAL(38, 38)` binds successfully, so the docs now say 0–38. A scale of 38 is only reachable at width 38, since `SCALE > WIDTH` hits a different error first.

Only `docs/current/` was touched; `docs/lts` and `docs/1.x` were left alone.

**Verification** — every snippet and error message was run on DuckDB v1.5.5 (Variegata, `d8cdaa33fd`) and the output pasted verbatim:

```
SELECT typeof(1.5::DECIMAL), typeof(1.5::DECIMAL()), typeof(1.5::DECIMAL(10)), typeof(1.5::DECIMAL(10,));
-- DECIMAL(18,3) | DECIMAL(18,3) | DECIMAL(10,0) | DECIMAL(10,0)   (identical for NUMERIC)

SELECT 1::DECIMAL(39, 2);   -- Binder Error: DECIMAL type width must be between 1 and 38
SELECT 1::DECIMAL(18, 20);  -- Binder Error: DECIMAL type scale cannot be greater than width
SELECT 1::DECIMAL(18, -1);  -- Binder Error: DECIMAL type scale must be between 0 and 38

SELECT 1.2345::DECIMAL;              -- 1.235                (rounds, not truncates)
SELECT 999999999999999.5::DECIMAL;   -- 999999999999999.500  (15 integer digits fit)
SELECT 1000000000000000.0::DECIMAL;  -- Conversion Error: value is out of range!
```

`npx markdownlint-cli docs/current/sql/data_types/numeric.md --config .markdownlint.jsonc` passes with no output; `vale docs/current/sql/data_types/numeric.md` reports 0 errors, 0 warnings, 0 suggestions.
