### PR TITLE
Fix installation and shutdown docs for R

### DIFF
--- a/_includes/installation.html
+++ b/_includes/installation.html
@@ -334,19 +334,18 @@ install.packages("duckdb", repos="https://p3m.dev/cran/__linux__/manylinux_2_28/
     data-docs="{% link docs/lts/clients/r.md %}">
 
 {%- highlight r -%}
-install.packages("duckdb", version="{{ site.lts_duckdb_r_version }}")
+install.packages("DBI")
+install.packages("duckdb.{{ site.lts_short_duckdb_version }}", repos = "https://duckdb.r-universe.dev"))
 {%- endhighlight -%}
 
 <div class="alternative">
 
-<h4>Installing from the Posit Public Package Manager (Linux)</h4>
+<h4>Downloading package file</h4>
+
+Navigate to <a href="https://duckdb.r-universe.dev/duckdb.{{ site.lts_short_duckdb_version }}" target="_blank" rel="noopener noreferrer">https://duckdb.r-universe.dev/duckdb.{{ site.lts_short_duckdb_version }}</a> and download the package file for your platform. Then install it using:
 
 {%- highlight r -%}
-options(HTTPUserAgent = sprintf("R/%s R (%s)",
-    getRversion(),
-    paste(getRversion(), R.version["platform"], R.version["arch"], R.version["os"])
-))
-install.packages("duckdb", version="{{ site.lts_duckdb_r_version }}", repos="https://p3m.dev/cran/__linux__/manylinux_2_28/latest/")
+install.packages("path/to/downloaded/package.ext", repos = NULL)
 {%- endhighlight -%}
 </div>
 </div>

--- a/docs/current/clients/r.md
+++ b/docs/current/clients/r.md
@@ -53,7 +53,7 @@ con <- dbConnect(duckdb(), dbdir = "my-db.duckdb", read_only = FALSE)
 con <- dbConnect(duckdb(), dbdir = "my-db.duckdb", read_only = TRUE)
 ```
 
-Connections are closed implicitly when they go out of scope or if they are explicitly closed using `dbDisconnect()`. To shut down the database instance associated with the connection, use `dbDisconnect(con, shutdown = TRUE)`
+Connections are closed implicitly when they go out of scope or if they are explicitly closed using `dbDisconnect()`. To shut down the database instance associated with the connection, use `duckdb_shutdown()` on the driver object returned by `duckdb()`.
 
 ### Querying
 


### PR DESCRIPTION
The full set of alternative flavors is in https://duckdb.r-universe.dev/builds, though the "dev" flavors are not really for general use. Should we link that too?

@szarnyasg: Please take a look.