### PR TITLE
Document that CREATE TYPE supports the OR REPLACE modifier

### DIFF
--- a/docs/current/sql/statements/create_type.md
+++ b/docs/current/sql/statements/create_type.md
@@ -36,16 +36,21 @@ Create a type alias:
 CREATE TYPE x_index AS INTEGER;
 ```
 
+Replace an existing type:
+
+```sql
+CREATE OR REPLACE TYPE mood AS ENUM ('cheerful', 'gloomy');
+```
+
 ## Syntax
 
 <div id="rrdiagram"></div>
 
 The `CREATE TYPE` clause defines a new data type available to this DuckDB instance.
+Use the `OR REPLACE` modifier to redefine a type that already exists.
 These new types can then be inspected in the [`duckdb_types` table]({% link docs/current/sql/meta/duckdb_table_functions.md %}#duckdb_types).
 
 ## Limitations
 
 * Extending types to support custom operators (such as the PostgreSQL `&&` operator) is not possible via plain SQL.
   Instead, it requires adding additional C++ code. To do this, create an [extension]({% link docs/current/extensions/overview.md %}).
-
-* The `CREATE TYPE` clause does not support the `OR REPLACE` modifier.

--- a/docs/lts/sql/statements/create_type.md
+++ b/docs/lts/sql/statements/create_type.md
@@ -32,16 +32,21 @@ Create a type alias:
 CREATE TYPE x_index AS INTEGER;
 ```
 
+Replace an existing type:
+
+```sql
+CREATE OR REPLACE TYPE mood AS ENUM ('cheerful', 'gloomy');
+```
+
 ## Syntax
 
 <div id="rrdiagram"></div>
 
 The `CREATE TYPE` clause defines a new data type available to this DuckDB instance.
+Use the `OR REPLACE` modifier to redefine a type that already exists.
 These new types can then be inspected in the [`duckdb_types` table]({% link docs/lts/sql/meta/duckdb_table_functions.md %}#duckdb_types).
 
 ## Limitations
 
 * Extending types to support custom operators (such as the PostgreSQL `&&` operator) is not possible via plain SQL.
   Instead, it requires adding additional C++ code. To do this, create an [extension]({% link docs/lts/extensions/overview.md %}).
-
-* The `CREATE TYPE` clause does not support the `OR REPLACE` modifier.


### PR DESCRIPTION
Fixes #6121.

The `CREATE TYPE` pages list a limitation that no longer holds:

> * The `CREATE TYPE` clause does not support the `OR REPLACE` modifier.

`CREATE OR REPLACE TYPE` works on current DuckDB. Verified on v1.5.5:

```console
$ duckdb -c "CREATE TYPE mood AS ENUM ('a', 'b');
CREATE OR REPLACE TYPE mood AS ENUM ('x', 'y');
SELECT 'x'::mood;"
┌─────────────────────┐
│ CAST('x' AS "mood") │
│   enum('x', 'y')    │
├─────────────────────┤
│ x                   │
└─────────────────────┘
```

Same for `STRUCT` types, matching the issue reporter's observation on v1.4.1:

```console
$ duckdb -c "CREATE TYPE t AS STRUCT(a INT);
CREATE OR REPLACE TYPE t AS STRUCT(b VARCHAR);
SELECT {'b': 'hello'}::t;"
┌─────────────────────────────────────────────┐
│ CAST(main.struct_pack(b := 'hello') AS "t") │
│              struct(b varchar)              │
├─────────────────────────────────────────────┤
│ {'b': hello}                                │
└─────────────────────────────────────────────┘
```

## Changes

* Removed the false limitation bullet from `docs/current/sql/statements/create_type.md` and `docs/lts/sql/statements/create_type.md` (the two pages carried the line verbatim).
* Added a positive statement in the Syntax section and a `Replace an existing type:` example, verified against v1.5.5:

  ```sql
  CREATE OR REPLACE TYPE mood AS ENUM ('cheerful', 'gloomy');
  ```

* Left the genuine limitation about custom operators requiring a C++ extension untouched.

## Validation

* Ran every snippet through `duckdb -c` on v1.5.5 before pasting it.
* `npx markdownlint-cli ... --config .markdownlint.jsonc` on both changed files: clean.
* `vale sync && vale` on both changed files: 0 errors, 0 warnings, 0 suggestions.
* `create_type.md` is hand-written; it is not produced by `scripts/generate_all_docs.sh`, and the railroad diagram (`js/.../railroad.js`) is untouched.

Happy to drop the `docs/lts/` hunk if you would rather keep that page frozen — I included it because `scripts/lint.sh` lints `docs/lts/` and the incorrect sentence is identical there.

I have checked "Allow edits from maintainers".
