### PR TITLE
Use S3 URL in "Attach over S3" example

### DIFF
--- a/docs/current/guides/network_cloud_storage/duckdb_over_https_or_s3.md
+++ b/docs/current/guides/network_cloud_storage/duckdb_over_https_or_s3.md
@@ -39,7 +39,7 @@ To connect to a DuckDB database via the S3 API, [configure the authentication]({
 Then, use the [`ATTACH` statement]({% link docs/current/sql/statements/attach.md %}) as follows:
 
 ```sql
-ATTACH 'https://blobs.duckdb.org/databases/stations.duckdb' AS stations_db;
+ATTACH 's3://duckdb-blobs/databases/stations.duckdb' AS stations_db;
 ```
 
 

--- a/docs/lts/guides/network_cloud_storage/duckdb_over_https_or_s3.md
+++ b/docs/lts/guides/network_cloud_storage/duckdb_over_https_or_s3.md
@@ -37,7 +37,7 @@ To connect to a DuckDB database via the S3 API, [configure the authentication]({
 Then, use the [`ATTACH` statement]({% link docs/lts/sql/statements/attach.md %}) as follows:
 
 ```sql
-ATTACH 'https://blobs.duckdb.org/databases/stations.duckdb' AS stations_db;
+ATTACH 's3://duckdb-blobs/databases/stations.duckdb' AS stations_db;
 ```
 
 > Since DuckDB version 1.1, the `ATTACH` statement creates a read-only connection to HTTP endpoints.


### PR DESCRIPTION
In https://github.com/duckdb/duckdb-web/commit/bda4e90895e655e6c9fddc92500d64575f29662d, the `s3://duckdb-blobs/...` URLs got replaced with `http://` URLs because the S3 bucket is not accessible.
However, I think that in the "Attaching to a Database over the S3 API" section, a `s3://` URL should be used in the example regardless.