### PR TITLE
Fix doubled words in tpcds and geometry docs

### DIFF
--- a/docs/current/core_extensions/tpcds.md
+++ b/docs/current/core_extensions/tpcds.md
@@ -9,7 +9,7 @@ redirect_from:
 title: TPC-DS Extension
 ---
 
-> Warning The `tpcds` extension will change in DuckDB version 2.0 to make the generator compatible with with TPC-DS version 4.
+> Warning The `tpcds` extension will change in DuckDB version 2.0 to make the generator compatible with TPC-DS version 4.
 > See the [related PR](https://github.com/duckdb/duckdb/pull/21746) for more details.
 
 The `tpcds` extension implements the data generator and queries for the [TPC-DS benchmark](https://www.tpc.org/tpcds/).

--- a/docs/current/sql/functions/geometry.md
+++ b/docs/current/sql/functions/geometry.md
@@ -6,7 +6,7 @@ redirect_from:
 title: Geometry Functions
 ---
 
-This section describes the functions for for examining and manipulating [`GEOMETRY`]({% link docs/current/sql/data_types/geometry.md %}) values.
+This section describes the functions for examining and manipulating [`GEOMETRY`]({% link docs/current/sql/data_types/geometry.md %}) values.
 
 > The `spatial` extension provides additional functions for working with `GEOMETRY` values, which are documented in the [Spatial Functions]({% link docs/current/core_extensions/spatial/functions.md %}) section.
 


### PR DESCRIPTION
Two small doubled-word typos in the docs prose:

- `docs/current/core_extensions/tpcds.md`: "compatible with with TPC-DS version 4" -> "compatible with TPC-DS version 4".
- `docs/current/sql/functions/geometry.md`: "the functions for for examining and manipulating" -> "the functions for examining and manipulating".

Documentation only.
