### PR TITLE
Fixes some items mentioned in issue 7109 - (enum functions)

### DIFF
--- a/docs/current/sql/functions/enum.md
+++ b/docs/current/sql/functions/enum.md
@@ -18,11 +18,12 @@ CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy', 'anxious');
 ```
 
 These functions can take `NULL` or a specific value of the type as argument(s).
-With the exception of `enum_range_boundary`, the result depends only on the type of the argument and not on its value.
+Most enum functions return a value that depends only on the type of the argument, and not on its value.
+The functions `enum_code()` and `enum_range_boundary()` are exceptions; they return a value that depends on the argument value, as well as its type.
 
 | Name | Description |
 |:--|:-------|
-| [`enum_code(enum_value)`](#enum_codeenum_value) | Returns the numeric value backing the given enum value. |
+| [`enum_code(enum_value)`](#enum_codeenum_value) | Returns the (0-based) numeric value backing the given enum value. |
 | [`enum_first(enum)`](#enum_firstenum) | Returns the first value of the input enum type. |
 | [`enum_last(enum)`](#enum_lastenum) | Returns the last value of the input enum type. |
 | [`enum_range(enum)`](#enum_rangeenum) | Returns all values of the input enum type as an array. |

--- a/docs/current/sql/functions/enum.md
+++ b/docs/current/sql/functions/enum.md
@@ -33,7 +33,7 @@ The functions `enum_code()` and `enum_range_boundary()` are exceptions; they ret
 
 <div class="nostroke_table"></div>
 
-| **Description** | Returns the numeric value backing the given enum value. |
+| **Description** | Returns the (0-based) numeric value backing the given enum value. |
 | **Example** | `enum_code('happy'::mood)` |
 | **Result** | `2` |
 


### PR DESCRIPTION
Status of items mentioned in https://github.com/duckdb/duckdb-web/issues/7109

1) is addressed. "Most enum functions return a value that depends only on the type of the argument, and not on its value. The functions enum_code() and enum_range_boundary() are exceptions; they return a value that depends on the argument value, as well as its type." 

2) is addressed: "Returns the (0-based) numeric value backing the given enum value." 

3) and 4) remain unaddressed. Changing the argument labels would change the anchors and potentially links elsewhere in the documentation. Right now I'm not sure that is desired/worth it. Happy to pick it up if that is approved/desired.