### PR TITLE
Fix SQL function documentation issues

### DIFF
--- a/docs/current/sql/functions/aggregates.md
+++ b/docs/current/sql/functions/aggregates.md
@@ -448,6 +448,7 @@ They all ignore `NULL` values (in the case of a single input column `x`), or pai
 | [`median(x)`](#medianx) | The middle value of the set. For even value counts, quantitative values are averaged and ordinal values return the lower value. |
 | [`mode(x)`](#modex)| The most frequent value. This function is [affected by ordering](#order-by-clause-in-aggregate-functions). |
 | [`quantile_cont(x, pos)`](#quantile_contx-pos) | The interpolated `pos`-quantile of `x` for `-1 <= pos <= 1`. Returns the `pos * (n_nonnull_values - 1)`th (zero-indexed, in the specified order) value of `x` or an interpolation between the adjacent values if the index is not an integer. Values of `pos` between `-1` and `0` correspond to counting backwards from `1`. More precisely, `quantile_cont(x, -y) = quantile_cont(x, 1 - y)`. Intuitively, arranges the values of `x` as equispaced *points* on a line, starting at 0 and ending at 1, and returns the (interpolated) value at `pos`. This is Type 7 in Hyndman & Fan (1996). If `pos` is a `LIST` of `FLOAT`s, then the result is a `LIST` of the corresponding interpolated quantiles. |
+| [`quantile(x, pos)`](#quantilex-pos) | Alias for [`quantile_disc`](#quantile_discx-pos). |
 | [`quantile_disc(x, pos)`](#quantile_discx-pos) | The discrete `pos`-quantile of `x` for `0 <= pos <= 1`. Returns  the `greatest(ceil(pos * n_nonnull_values) - 1, 0)`th (zero-indexed, in the specified order) value of `x`. Intuitively, assigns to each value of `x` an equisized *sub-interval* (left-open and right-closed except for the initial interval) of the interval `[0, 1]`, and picks the value of the sub-interval that contains `pos`. This is Type 1 in Hyndman & Fan (1996). If `pos` is a `LIST` of `FLOAT`s, then the result is a `LIST` of the corresponding discrete quantiles. |
 | [`regr_avgx(y, x)`](#regr_avgxy-x) | The average of the independent variable for non-`NULL` pairs, where x is the independent variable and y is the dependent variable. |
 | [`regr_avgy(y, x)`](#regr_avgyy-x) | The average of the dependent variable for non-`NULL` pairs, where x is the independent variable and y is the dependent variable. |
@@ -535,6 +536,12 @@ They all ignore `NULL` values (in the case of a single input column `x`), or pai
 
 | **Description** | The interpolated `pos`-quantile of `x` for `0 <= pos <= 1`. Returns the `pos * (n_nonnull_values - 1)`th (zero-indexed, in the specified order) value of `x` or an interpolation between the adjacent values if the index is not an integer. Intuitively, arranges the values of `x` as equispaced *points* on a line, starting at 0 and ending at 1, and returns the (interpolated) value at `pos`. This is Type 7 in Hyndman & Fan (1996). If `pos` is a `LIST` of `FLOAT`s, then the result is a `LIST` of the corresponding interpolated quantiles. |
 | **Formula** | - |
+
+#### `quantile(x, pos)`
+
+<div class="nostroke_table"></div>
+
+| **Description** | Alias for [`quantile_disc`](#quantile_discx-pos). |
 
 #### `quantile_disc(x, pos)`
 

--- a/docs/current/sql/functions/utility.md
+++ b/docs/current/sql/functions/utility.md
@@ -35,6 +35,7 @@ The functions below are difficult to categorize into specific function types and
 | [`force_checkpoint(database)`](#force_checkpointdatabase) | Synchronize WAL with file for (optional) database interrupting transactions. |
 | [`gen_random_uuid()`](#gen_random_uuid) | Return a random UUID similar to this: `eeccb8c5-9943-b2bb-bb5e-222f4e14b687`. |
 | [`getenv(var)`](#getenvvar) | Returns the value of the environment variable `var`. Only available in the [command line client]({% link docs/current/clients/cli/overview.md %}). |
+| [`getvariable('variable_name')`](#getvariablevariable_name) | Returns the value of the SQL variable named `variable_name`, or `NULL` if it is not set. |
 | [`hash(value)`](#hashvalue) | Returns a `UBIGINT` with a hash of `value`. The used hash function may change across DuckDB versions.|
 | [`icu_sort_key(string, collator)`](#icu_sort_keystring-collator) | Surrogate [sort key](https://unicode-org.github.io/icu/userguide/collation/architecture.html#sort-keys) used to sort special characters according to the specific locale. Collator parameter is optional. Only available when the ICU extension is installed. |
 | [`if(a, b, c)`](#ifa-b-c) | Ternary conditional operator. |
@@ -215,6 +216,12 @@ The functions below are difficult to categorize into specific function types and
 | **Description** | Returns the value of the environment variable `var`. Only available in the [command line client]({% link docs/current/clients/cli/overview.md %}). |
 | **Example** | `getenv('HOME')` |
 | **Result** | `/path/to/user/home` |
+
+#### `getvariable('variable_name')`
+
+| **Description** | Returns the value of the SQL variable named `variable_name`, or `NULL` if it is not set. See the [`SET VARIABLE` statement]({% link docs/current/sql/statements/set_variable.md %}) for more details. |
+| **Example** | `getvariable('my_var')` |
+| **Result** | various |
 
 #### `hash(value)`
 

--- a/docs/current/sql/functions/window_functions.md
+++ b/docs/current/sql/functions/window_functions.md
@@ -216,12 +216,16 @@ ordering applies to.
 
 ```sql
 -- Compare each athlete's time in an event with the best time to date
-SELECT event, date, athlete, time
-    first_value(time ORDER BY time DESC) OVER w AS record_time,
-    first_value(athlete ORDER BY time DESC) OVER w AS record_athlete,
+SELECT
+    event,
+    date,
+    athlete,
+    time,
+    first_value(time ORDER BY time ASC) OVER w AS record_time,
+    first_value(athlete ORDER BY time ASC) OVER w AS record_athlete,
 FROM meet_results
 WINDOW w AS (PARTITION BY event ORDER BY datetime)
-ORDER BY ALL
+ORDER BY ALL;
 ```
 
 Note that there is no comma separating the arguments from the `ORDER BY` clause.


### PR DESCRIPTION
## Summary
- Fix the window function example for best time to date by using ascending time ordering and valid SQL syntax.
- Add getvariable() to the Utility Functions page.
- List quantile() as an alias for quantile_disc() on the Aggregate Functions page.

Closes #7113.
Closes #7104.
Closes #7103.

## Validation
- npx.cmd markdownlint-cli docs/current/sql/functions/aggregates.md docs/current/sql/functions/utility.md docs/current/sql/functions/window_functions.md --config .markdownlint.jsonc
- git diff --check