### PR TITLE
docs: fix best-time window example (ASC + missing comma)

### DIFF
--- a/docs/current/sql/functions/window_functions.md
+++ b/docs/current/sql/functions/window_functions.md
@@ -216,9 +216,13 @@ ordering applies to.
 
 ```sql
 -- Compare each athlete's time in an event with the best time to date
-SELECT event, date, athlete, time
-    first_value(time ORDER BY time DESC) OVER w AS record_time,
-    first_value(athlete ORDER BY time DESC) OVER w AS record_athlete,
+SELECT
+    event,
+    date,
+    athlete,
+    time,
+    first_value(time ORDER BY time ASC) OVER w AS record_time,
+    first_value(athlete ORDER BY time ASC) OVER w AS record_athlete,
 FROM meet_results
 WINDOW w AS (PARTITION BY event ORDER BY datetime)
 ORDER BY ALL


### PR DESCRIPTION
## Summary
Data-analytics docs fix: \"best time to date\" should use `ORDER BY time ASC`, and the SELECT list was missing a comma after `time`.

Re-opened after an accidental fork-visibility change closed the prior PR.

## Test plan
- [ ] Example matches intended semantics (fastest time to date)
- [ ] SQL snippet is syntactically valid