### PR TITLE
Document BETWEEN collation behavior

### DIFF
--- a/docs/current/sql/expressions/comparison_operators.md
+++ b/docs/current/sql/expressions/comparison_operators.md
@@ -61,4 +61,16 @@ Note that `BETWEEN` and `NOT BETWEEN` are only equivalent to the examples below 
 | `expression IS NOT NULL` | `false` if expression is `NULL`, `true` otherwise |
 | `expression NOTNULL` | alias for `IS NOT NULL` (non-standard) |
 
+An explicit [collation]({% link docs/current/sql/expressions/collations.md %}) on any input to `BETWEEN` applies to the entire `BETWEEN` expression. This can differ from writing the comparisons separately, where the explicit collation applies only to the comparison that contains it:
+
+```sql
+SELECT
+    'B' NOT BETWEEN ('A' COLLATE NOCASE) AND 'a' AS between_result,
+    'B' < ('A' COLLATE NOCASE) OR 'B' > 'a' AS separate_result;
+```
+
+| between_result | separate_result |
+|:---|:---|
+| true | false |
+
 > For the expression `BETWEEN x AND y`, `x` is used as the lower bound and `y` is used as the upper bound. Therefore, if `x > y`, the result will always be `false`.


### PR DESCRIPTION
## Summary

Document that an explicit collation on any input to `BETWEEN` applies to the entire expression, while separately written comparisons apply the collation only to the comparison containing it. Include a compact query demonstrating the different results.

Closes #6718.
Addresses duckdb/duckdb#18989.

## Validation

- verified the example result with DuckDB 1.5.5
- markdownlint
- `git diff --check`

## AI assistance

Codex (GPT-5) assisted with investigating the behavior and drafting the documentation. I manually reviewed the final diff and independently verified the SQL result.