### PR TITLE
Add SeaweedFS: import guide, Iceberg REST catalog example, platform mention

### DIFF
--- a/_data/menu_docs_current.json
+++ b/_data/menu_docs_current.json
@@ -1492,6 +1492,10 @@
                   "url": "fastly_object_storage_import"
                 },
                 {
+                  "page": "SeaweedFS Import",
+                  "url": "seaweedfs_import"
+                },
+                {
                   "page": "Tigris Import",
                   "url": "tigris_import"
                 }

--- a/docs/current/core_extensions/httpfs/s3api.md
+++ b/docs/current/core_extensions/httpfs/s3api.md
@@ -13,7 +13,7 @@ The `httpfs` extension supports reading/writing/[globbing](#globbing) files on o
 
 ## Platforms
 
-The `httpfs` filesystem is tested with [AWS S3](https://aws.amazon.com/s3/), [Minio](https://min.io/), [Google Cloud](https://cloud.google.com/storage/docs/interoperability) and [lakeFS](https://docs.lakefs.io/integrations/duckdb.html). Other services that implement the S3 API (such as [Cloudflare R2](https://www.cloudflare.com/en-gb/developer-platform/r2/) and [Tigris](https://www.tigrisdata.com/)) should also work, but not all features may be supported.
+The `httpfs` filesystem is tested with [AWS S3](https://aws.amazon.com/s3/), [Minio](https://min.io/), [Google Cloud](https://cloud.google.com/storage/docs/interoperability) and [lakeFS](https://docs.lakefs.io/integrations/duckdb.html). Other services that implement the S3 API (such as [Cloudflare R2](https://www.cloudflare.com/en-gb/developer-platform/r2/), [SeaweedFS](https://github.com/seaweedfs/seaweedfs), and [Tigris](https://www.tigrisdata.com/)) should also work, but not all features may be supported.
 
 The following table shows which parts of the S3 API are required for each `httpfs` feature.
 

--- a/docs/current/core_extensions/iceberg/catalogs.md
+++ b/docs/current/core_extensions/iceberg/catalogs.md
@@ -262,7 +262,7 @@ ATTACH '⟨warehouse⟩' AS lakekeeper_catalog (
 
 ## SeaweedFS
 
-[SeaweedFS](https://github.com/seaweedfs/seaweedfs) table buckets embed an Iceberg REST Catalog in the SeaweedFS S3 gateway. Store the catalog's OAuth2 credentials in an Iceberg secret, and the S3 credentials in an S3 secret so DuckDB can read table data from the same gateway:
+[SeaweedFS](https://github.com/seaweedfs/seaweedfs) table buckets provide both halves of an Iceberg deployment: the embedded Iceberg REST Catalog serves the table metadata, and the table bucket stores the table data as Parquet files behind the same SeaweedFS S3 gateway. Store the catalog's OAuth2 credentials in an Iceberg secret, and the S3 credentials in an S3 secret so DuckDB can read the Parquet files from the same gateway:
 
 ```sql
 CREATE SECRET seaweedfs_secret (

--- a/docs/current/core_extensions/iceberg/catalogs.md
+++ b/docs/current/core_extensions/iceberg/catalogs.md
@@ -17,7 +17,7 @@ title: Catalogs
 
 The `iceberg` extension supports attaching Iceberg REST Catalogs. Attaching a catalog is required for [writing to Iceberg]({% link docs/current/core_extensions/iceberg/writing_to_iceberg.md %}). Before attaching an Iceberg REST Catalog, you must install the `iceberg` extension by following the instructions located in the [overview]({% link docs/current/core_extensions/iceberg/overview.md %}).
 
-The section below describes the generic way of attaching an Iceberg REST Catalog. For instructions specific to a catalog implementation, see [Amazon S3 Tables](#amazon-s3-tables), [AWS Glue](#aws-glue-amazon-sagemaker-lakehouse), [Cloudflare R2 Data Catalog](#cloudflare-r2-data-catalog), [Apache Polaris](#apache-polaris), [Lakekeeper](#lakekeeper) and [Google Cloud BigLake](#google-cloud-biglake).
+The section below describes the generic way of attaching an Iceberg REST Catalog. For instructions specific to a catalog implementation, see [Amazon S3 Tables](#amazon-s3-tables), [AWS Glue](#aws-glue-amazon-sagemaker-lakehouse), [Cloudflare R2 Data Catalog](#cloudflare-r2-data-catalog), [Apache Polaris](#apache-polaris), [Lakekeeper](#lakekeeper), [SeaweedFS](#seaweedfs) and [Google Cloud BigLake](#google-cloud-biglake).
 
 ## Attaching an Iceberg REST Catalog
 
@@ -259,6 +259,40 @@ ATTACH '⟨warehouse⟩' AS lakekeeper_catalog (
     SECRET '⟨lakekeeper_secret⟩'
 );
 ```
+
+## SeaweedFS
+
+[SeaweedFS](https://github.com/seaweedfs/seaweedfs) table buckets embed an Iceberg REST Catalog in the SeaweedFS S3 gateway. Store the catalog's OAuth2 credentials in an Iceberg secret, and the S3 credentials in an S3 secret so DuckDB can read table data from the same gateway:
+
+```sql
+CREATE SECRET seaweedfs_secret (
+    TYPE ICEBERG,
+    CLIENT_ID '⟨access_key⟩',
+    CLIENT_SECRET '⟨secret_key⟩',
+    OAUTH2_SERVER_URI 'http://⟨seaweedfs_host⟩:8181/v1/oauth/tokens'
+);
+```
+
+```sql
+CREATE SECRET seaweedfs_storage (
+    TYPE s3,
+    KEY_ID '⟨access_key⟩',
+    SECRET '⟨secret_key⟩',
+    ENDPOINT '⟨seaweedfs_host⟩:8333',
+    URL_STYLE 'path',
+    USE_SSL false
+);
+```
+
+```sql
+ATTACH '⟨table_bucket_name⟩' AS seaweedfs_catalog (
+    TYPE ICEBERG,
+    ENDPOINT 'http://⟨seaweedfs_host⟩:8181',
+    SECRET seaweedfs_secret
+);
+```
+
+Reads and writes work with the default `ATTACH` options, including `CREATE TABLE`, `INSERT`, and `DROP TABLE`.
 
 ## Google Cloud BigLake
 

--- a/docs/current/core_extensions/iceberg/catalogs.md
+++ b/docs/current/core_extensions/iceberg/catalogs.md
@@ -292,7 +292,20 @@ ATTACH '⟨table_bucket_name⟩' AS seaweedfs_catalog (
 );
 ```
 
-Reads and writes work with the default `ATTACH` options, including `CREATE TABLE`, `INSERT`, and `DROP TABLE`.
+Reads and writes work with the default `ATTACH` options, including `CREATE SCHEMA`, `CREATE TABLE`, `INSERT`, and `DROP TABLE`:
+
+```sql
+CREATE SCHEMA seaweedfs_catalog.sales;
+CREATE TABLE seaweedfs_catalog.sales.orders (id BIGINT, region VARCHAR, amount DOUBLE);
+INSERT INTO seaweedfs_catalog.sales.orders VALUES (1, 'NA', 12.5), (2, 'EU', 40.0), (3, 'APAC', 99.9);
+
+SELECT region, sum(amount) AS total
+FROM seaweedfs_catalog.sales.orders
+GROUP BY region
+ORDER BY total DESC;
+
+DROP TABLE seaweedfs_catalog.sales.orders;
+```
 
 ## Google Cloud BigLake
 

--- a/docs/current/core_extensions/iceberg/iceberg_rest_catalogs.md
+++ b/docs/current/core_extensions/iceberg/iceberg_rest_catalogs.md
@@ -179,7 +179,7 @@ ATTACH '⟨warehouse⟩' AS lakekeeper_catalog (
 
 ### SeaweedFS
 
-[SeaweedFS](https://github.com/seaweedfs/seaweedfs) table buckets embed an Iceberg REST Catalog in the SeaweedFS S3 gateway. Store the catalog's OAuth2 credentials in an Iceberg secret, and the S3 credentials in an S3 secret so DuckDB can read table data from the same gateway:
+[SeaweedFS](https://github.com/seaweedfs/seaweedfs) table buckets provide both halves of an Iceberg deployment: the embedded Iceberg REST Catalog serves the table metadata, and the table bucket stores the table data as Parquet files behind the same SeaweedFS S3 gateway. Store the catalog's OAuth2 credentials in an Iceberg secret, and the S3 credentials in an S3 secret so DuckDB can read the Parquet files from the same gateway:
 
 ```sql
 CREATE SECRET seaweedfs_secret (

--- a/docs/current/core_extensions/iceberg/iceberg_rest_catalogs.md
+++ b/docs/current/core_extensions/iceberg/iceberg_rest_catalogs.md
@@ -177,6 +177,40 @@ ATTACH '⟨warehouse⟩' AS lakekeeper_catalog (
 );
 ```
 
+### SeaweedFS
+
+[SeaweedFS](https://github.com/seaweedfs/seaweedfs) table buckets embed an Iceberg REST Catalog in the SeaweedFS S3 gateway. Store the catalog's OAuth2 credentials in an Iceberg secret, and the S3 credentials in an S3 secret so DuckDB can read table data from the same gateway:
+
+```sql
+CREATE SECRET seaweedfs_secret (
+    TYPE iceberg,
+    CLIENT_ID '⟨access_key⟩',
+    CLIENT_SECRET '⟨secret_key⟩',
+    OAUTH2_SERVER_URI 'http://⟨seaweedfs_host⟩:8181/v1/oauth/tokens'
+);
+```
+
+```sql
+CREATE SECRET seaweedfs_storage (
+    TYPE s3,
+    KEY_ID '⟨access_key⟩',
+    SECRET '⟨secret_key⟩',
+    ENDPOINT '⟨seaweedfs_host⟩:8333',
+    URL_STYLE 'path',
+    USE_SSL false
+);
+```
+
+```sql
+ATTACH '⟨table_bucket_name⟩' AS seaweedfs_catalog (
+    TYPE iceberg,
+    ENDPOINT 'http://⟨seaweedfs_host⟩:8181',
+    SECRET seaweedfs_secret
+);
+```
+
+Reads and writes work with the default `ATTACH` options, including `CREATE TABLE`, `INSERT`, and `DROP TABLE`.
+
 ### Google Cloud BigLake
 
 To attach to a [Google Cloud BigLake](https://cloud.google.com/biglake) catalog, you can use extra HTTP headers to specify the GCP project for billing purposes.

--- a/docs/current/core_extensions/iceberg/iceberg_rest_catalogs.md
+++ b/docs/current/core_extensions/iceberg/iceberg_rest_catalogs.md
@@ -209,7 +209,20 @@ ATTACH '⟨table_bucket_name⟩' AS seaweedfs_catalog (
 );
 ```
 
-Reads and writes work with the default `ATTACH` options, including `CREATE TABLE`, `INSERT`, and `DROP TABLE`.
+Reads and writes work with the default `ATTACH` options, including `CREATE SCHEMA`, `CREATE TABLE`, `INSERT`, and `DROP TABLE`:
+
+```sql
+CREATE SCHEMA seaweedfs_catalog.sales;
+CREATE TABLE seaweedfs_catalog.sales.orders (id BIGINT, region VARCHAR, amount DOUBLE);
+INSERT INTO seaweedfs_catalog.sales.orders VALUES (1, 'NA', 12.5), (2, 'EU', 40.0), (3, 'APAC', 99.9);
+
+SELECT region, sum(amount) AS total
+FROM seaweedfs_catalog.sales.orders
+GROUP BY region
+ORDER BY total DESC;
+
+DROP TABLE seaweedfs_catalog.sales.orders;
+```
 
 ### Google Cloud BigLake
 

--- a/docs/current/guides/network_cloud_storage/seaweedfs_import.md
+++ b/docs/current/guides/network_cloud_storage/seaweedfs_import.md
@@ -1,0 +1,80 @@
+---
+layout: docu
+title: SeaweedFS Import
+---
+
+## Prerequisites
+
+For [SeaweedFS](https://github.com/seaweedfs/seaweedfs), the S3-compatible gateway allows you to use DuckDB's S3 support to read and write from SeaweedFS buckets.
+
+This requires the [`httpfs` extension]({% link docs/current/core_extensions/httpfs/overview.md %}), which can be installed using the `INSTALL` SQL command. This only needs to be run once.
+
+To try SeaweedFS locally, create a file `s3config.json` with the S3 credentials:
+
+```json
+{
+  "identities": [
+    {
+      "name": "analyst",
+      "credentials": [
+        {
+          "accessKey": "your_access_key_id",
+          "secretKey": "your_secret_access_key"
+        }
+      ],
+      "actions": ["Admin", "Read", "Write", "List", "Tagging"]
+    }
+  ]
+}
+```
+
+Then start the whole SeaweedFS stack in one container and create a bucket:
+
+```bash
+docker run -d --name seaweedfs -p 8333:8333 \
+    -v "$(pwd)/s3config.json:/etc/seaweedfs/s3config.json" \
+    chrislusf/seaweedfs:latest \
+    mini -dir=/data -s3.config=/etc/seaweedfs/s3config.json
+
+echo "s3.bucket.create -name ⟨your-bucket⟩" | \
+    docker exec -i seaweedfs weed shell -master=localhost:9333
+```
+
+The S3 endpoint listens on port 8333.
+
+## Credentials and Configuration
+
+Create an `S3` secret with the credentials from the SeaweedFS S3 configuration:
+
+```sql
+CREATE SECRET my_secret (
+    TYPE s3,
+    KEY_ID '⟨your_access_key_id⟩',
+    SECRET '⟨your_secret_access_key⟩',
+    ENDPOINT '⟨seaweedfs-host⟩:8333',
+    URL_STYLE 'path',
+    USE_SSL false
+);
+```
+
+* SeaweedFS serves path-style requests, so set `URL_STYLE` to `path`. No wildcard DNS is needed.
+* SeaweedFS does not require a region, so `REGION` can be omitted.
+* Set `USE_SSL false` for a plain-HTTP endpoint such as the local setup above; omit it when the gateway runs behind TLS.
+
+## Querying
+
+After setting up the SeaweedFS credentials, you can query the data using DuckDB's built-in methods, such as `read_csv` or `read_parquet`:
+
+```sql
+SELECT * FROM 's3://⟨your-bucket⟩/⟨file⟩.csv';
+SELECT * FROM read_parquet('s3://⟨your-bucket⟩/⟨file⟩.parquet');
+```
+
+Writing works the same way, including glob reads over the result:
+
+```sql
+COPY (SELECT 42 AS answer) TO 's3://⟨your-bucket⟩/sample/answer.parquet';
+SELECT * FROM read_parquet('s3://⟨your-bucket⟩/sample/*.parquet');
+```
+
+The same SeaweedFS gateway also serves an Iceberg REST Catalog for its table buckets. See the [SeaweedFS catalog example]({% link docs/current/core_extensions/iceberg/catalogs.md %}#seaweedfs) to query Iceberg tables through it.

--- a/docs/current/guides/network_cloud_storage/seaweedfs_import.md
+++ b/docs/current/guides/network_cloud_storage/seaweedfs_import.md
@@ -77,4 +77,4 @@ COPY (SELECT 42 AS answer) TO 's3://⟨your-bucket⟩/sample/answer.parquet';
 SELECT * FROM read_parquet('s3://⟨your-bucket⟩/sample/*.parquet');
 ```
 
-The same SeaweedFS gateway also serves an Iceberg REST Catalog for its table buckets. See the [SeaweedFS catalog example]({% link docs/current/core_extensions/iceberg/catalogs.md %}#seaweedfs) to query Iceberg tables through it.
+SeaweedFS also supports Iceberg: table buckets store the table data as Parquet files, and the gateway's built-in Iceberg REST Catalog serves the table metadata. See the [SeaweedFS catalog example]({% link docs/current/core_extensions/iceberg/catalogs.md %}#seaweedfs) to query Iceberg tables through it.


### PR DESCRIPTION
Adds documentation for using [SeaweedFS](https://github.com/seaweedfs/seaweedfs), an open-source S3-compatible object store whose S3 gateway also embeds an Iceberg REST Catalog:

- A SeaweedFS import guide under network and cloud storage, following the Tigris and Fastly pages: one-container local setup, `CREATE SECRET (TYPE s3, ..., URL_STYLE 'path')`, reading and writing with `read_parquet`/`COPY`, plus the menu entry.
- A SeaweedFS example in the Iceberg catalogs pages (both `catalogs.md` and `iceberg_rest_catalogs.md`, matching the Lakekeeper section): OAuth2 Iceberg secret, paired S3 secret for table data, and `ATTACH`.
- SeaweedFS added to the S3-compatible services sentence on the httpfs S3 API page.

Every statement is verified directly against DuckDB v1.5.5 and the current `chrislusf/seaweedfs` image using the exact commands shown: parquet/CSV writes, reads, and glob reads through the `s3` secret; catalog `ATTACH`, `SELECT`, `CREATE TABLE`, `INSERT`, and `DROP TABLE` with default attach options (no compatibility flags needed); DuckDB-written Iceberg tables read back with PyIceberg to confirm interoperability. SeaweedFS runs a DuckDB-facing Iceberg CI suite on every pull request as well.