### PR TITLE
Fix duckdb_functions() docs to match returned columns

### DIFF
--- a/docs/current/sql/functions/overview.md
+++ b/docs/current/sql/functions/overview.md
@@ -96,5 +96,3 @@ ORDER BY function_name;
 | bit_length    | scalar        | BIGINT      | [col0]                 | [VARCHAR]                        | Number of bits in a string                                                                                                               |
 | bit_position  | scalar        | INTEGER     | [substring, bitstring] | [BIT, BIT]                       | Returns first starting index of the specified substring within bits, or zero if it is not present. The first (leftmost) bit is indexed 1 |
 | bitstring     | scalar        | BIT         | [bitstring, length]    | [VARCHAR, INTEGER]               | Pads the bitstring until the specified length                                                                                            |
-
-> Currently, the description and parameter names of functions are not available in the `duckdb_functions()` function.

--- a/docs/current/sql/meta/duckdb_table_functions.md
+++ b/docs/current/sql/meta/duckdb_table_functions.md
@@ -169,8 +169,9 @@ The `duckdb_functions()` function provides metadata about the functions (includi
 | `database_oid` | Internal identifier of the database containing the index. | `BIGINT` |
 | `schema_name` | The SQL name of the schema where the function resides. | `VARCHAR` |
 | `function_name` | The SQL name of the function. | `VARCHAR` |
+| `alias_of` | The name of the function this is an alias of, or `NULL` if this is not an alias. | `VARCHAR` |
 | `function_type` | The function kind. Value is one of: `table`, `scalar`, `aggregate`, `pragma`, `macro`, `table_macro` | `VARCHAR` |
-| `description` | Description of this function (always `NULL`)| `VARCHAR` |
+| `description` | Description of this function, or `NULL` if none is registered. | `VARCHAR` |
 | `comment` | A comment created by the [`COMMENT ON` statement]({% link docs/current/sql/statements/comment_on.md %}). | `VARCHAR` |
 | `tags` | A map of string key–value pairs. | `MAP(VARCHAR, VARCHAR)` |
 | `return_type` | The logical data type name of the returned value. Applicable for scalar and aggregate functions. | `VARCHAR` |
@@ -180,9 +181,11 @@ The `duckdb_functions()` function provides metadata about the functions (includi
 | `macro_definition` | If this is a [macro]({% link docs/current/sql/statements/create_macro.md %}), the SQL expression that defines it. | `VARCHAR` |
 | `has_side_effects` | `false` if this is a pure function. `true` if this function changes the database state (like sequence functions `nextval()` and `curval()`). | `BOOLEAN` |
 | `internal` | `true` if the function is built-in (defined by DuckDB or an extension), `false` if it was defined using the [`CREATE MACRO` statement]({% link docs/current/sql/statements/create_macro.md %}). | `BOOLEAN` |
+| `extension_name` | The name of the extension that provides this function, or `NULL` if none. | `VARCHAR` |
 | `function_oid` | The internal identifier for this function. | `BIGINT` |
 | `examples` | Examples of using the function. Used to generate the documentation. | `VARCHAR[]` |
 | `stability` | The stability of the function (`CONSISTENT`, `VOLATILE`, `CONSISTENT_WITHIN_QUERY` or `NULL`) | `VARCHAR` |
+| `categories` | Categories of the function. Used to generate the documentation. | `VARCHAR[]` |
 
 ## `duckdb_indexes`
 


### PR DESCRIPTION
The `duckdb_functions()` docs were out of date against core `src/function/table/system/duckdb_functions.cpp`.

The functions overview said descriptions and parameter names are not available, but the sample result table on that same page already shows both, and the table function binds and emits `description` and `parameters`.

The metadata page said `description` is always `NULL` and omitted `alias_of`, `extension_name`, and `categories`. Those columns are bound and populated; empty description, alias, or extension name is returned as `NULL`.

## How to test

```bash
npx markdownlint-cli docs/current/sql/functions/overview.md docs/current/sql/meta/duckdb_table_functions.md --config .markdownlint.jsonc
```

Both pages are hand-written `docs/current/` (no generator markers).
