### PR TITLE
Update build docs to require a C++17 compiler

### DIFF
--- a/docs/current/dev/building/overview.md
+++ b/docs/current/dev/building/overview.md
@@ -21,10 +21,8 @@ This page explains the steps for building DuckDB.
 
 ### Prerequisites
 
-DuckDB needs CMake and a C++11-compliant compiler (e.g., GCC, Apple-Clang, MSVC).
+DuckDB needs CMake and a C++17-compliant compiler (e.g., GCC, Apple-Clang, MSVC).
 Additionally, we recommend using the [Ninja build system](https://ninja-build.org/), which automatically parallelizes the build process.
-
-> Warning DuckDB v2.0 will require [C++17](https://github.com/duckdb/duckdb/pull/21310).
 
 ### Building with the Makefile
 

--- a/why_duckdb.md
+++ b/why_duckdb.md
@@ -17,7 +17,7 @@ There are many database management systems (DBMS) out there. But there is [no on
 
 SQLite is the [world's most widely deployed DBMS](https://www.sqlite.org/mostdeployed.html). Simplicity in installation, and embedded in-process operation are central to its success. DuckDB adopted the ideas of simplicity and in-process operation – but later stepped out of the realm of in-process operations through the [Quack protocol]({% link quack/index.html %}).
 
-DuckDB has **no external dependencies**, neither for compilation nor during run-time. For releases, the entire source tree of DuckDB is compiled into two files, a header and an implementation file, a so-called "amalgamation". This greatly simplifies deployment and integration in other build processes. To build DuckDB, all that is required is a working C++11 compiler (note that DuckDB v2.0 will move to C++17).
+DuckDB has **no external dependencies**, neither for compilation nor during run-time. For releases, the entire source tree of DuckDB is compiled into two files, a header and an implementation file, a so-called "amalgamation". This greatly simplifies deployment and integration in other build processes. To build DuckDB, all that is required is a working C++17 compiler.
 
 For DuckDB, there is no DBMS server software to install, update and maintain. DuckDB does not run as a separate process, but completely **embedded within a host process**. For the analytical use cases that DuckDB targets, this has the additional advantage of **high-speed data transfer** to and from the database. In some cases, DuckDB can process foreign data without copying. For example, the DuckDB Python package can run queries directly on Pandas data without ever importing or copying any data.
 


### PR DESCRIPTION
Fixes #6598.

Core `CMakeLists.txt` on `main` has required C++17 since [duckdb/duckdb#21310](https://github.com/duckdb/duckdb/pull/21310). The building page's clone path (`git clone https://github.com/duckdb/duckdb`) hits that branch, so the C++11 prerequisite and the “v2.0 will require C++17” warning were both out of date.

v1.5.5 still builds as C++11; a C++17 compiler still compiles that line. I did not change `docs/lts/` or `roadmap.md`.

## How to test

```bash
npx markdownlint-cli docs/current/dev/building/overview.md why_duckdb.md --config .markdownlint.jsonc
```

Hand-written `docs/current/` + `why_duckdb.md` only (no generator markers).
