### PR TITLE
docs: document DATA_PAGE_SIZE_LIMIT for Parquet COPY

### DIFF
--- a/docs/current/data/parquet/overview.md
+++ b/docs/current/data/parquet/overview.md
@@ -339,12 +339,12 @@ COPY
     (FORMAT parquet, STRING_DICTIONARY_PAGE_SIZE_LIMIT 100_000);
 ```
 
-To split data pages below the default 100 MB cap, use `DATA_PAGE_SIZE_LIMIT` (bytes). The limit is best-effort at vector granularity:
+To split data pages below the default 100 MiB cap, use `DATA_PAGE_SIZE_LIMIT` (bytes). The limit is best-effort at vector granularity. E.g., to set the limit to 1 MiB, use:
 
 ```sql
 COPY tbl
     TO 'tbl.parquet'
-    (FORMAT parquet, DATA_PAGE_SIZE_LIMIT 1048576);
+    (FORMAT parquet, DATA_PAGE_SIZE_LIMIT 1_048_576);
 ```
 
 DuckDB's `EXPORT` command can be used to export an entire database to a series of Parquet files. See the [“`EXPORT` statement” page]({% link docs/current/sql/statements/export.md %}) for more details:

--- a/docs/current/data/parquet/overview.md
+++ b/docs/current/data/parquet/overview.md
@@ -339,6 +339,14 @@ COPY
     (FORMAT parquet, STRING_DICTIONARY_PAGE_SIZE_LIMIT 100_000);
 ```
 
+To split data pages below the default 100 MB cap, use `DATA_PAGE_SIZE_LIMIT` (bytes). The limit is best-effort at vector granularity:
+
+```sql
+COPY tbl
+    TO 'tbl.parquet'
+    (FORMAT parquet, DATA_PAGE_SIZE_LIMIT 1048576);
+```
+
 DuckDB's `EXPORT` command can be used to export an entire database to a series of Parquet files. See the [“`EXPORT` statement” page]({% link docs/current/sql/statements/export.md %}) for more details:
 
 Export the table contents of the entire database as Parquet:

--- a/docs/current/sql/statements/copy.md
+++ b/docs/current/sql/statements/copy.md
@@ -355,7 +355,7 @@ The below options are applicable when writing Parquet files.
 | `CHUNK_SIZE` | Alias for `ROW_GROUP_SIZE`. | `BIGINT` | 122880 |
 | `KV_METADATA` | Custom key-value metadata to embed in the file footer, supplied as a `STRUCT` of keys to values. `BLOB` values are written as raw bytes; other values are cast to string. | `STRUCT` | (empty) |
 | `SHREDDING` | A `STRUCT` mapping [`VARIANT`]({% link docs/current/sql/data_types/variant.md %}) column names to the type they should be shredded into, e.g., `{variant_col: 'STRUCT(name VARCHAR, age INTEGER)'}`. Enables typed (shredded) storage of `VARIANT` columns. | `STRUCT` | (empty) |
-| `DATA_PAGE_SIZE_LIMIT` | Target uncompressed size of Parquet data pages, in bytes. Pages may still be larger at vector granularity. | `UBIGINT` | `104857600` (100 MB) |
+| `DATA_PAGE_SIZE_LIMIT` | Target uncompressed size of Parquet data pages, in bytes. Pages may still be larger at vector granularity. | `UBIGINT` | `104857600` (100 MiB) |
 | `DICTIONARY_SIZE_LIMIT` | The maximum size of the dictionary used for dictionary encoding, in number of distinct values. Set to `0` to disable dictionary encoding. | `BIGINT` | `ROW_GROUP_SIZE / 5` |
 | `WRITE_BLOOM_FILTER` | Whether to write [Bloom filters](https://en.wikipedia.org/wiki/Bloom_filter) that allow readers to skip row groups. | `BOOLEAN` | `true` |
 | `BLOOM_FILTER_FALSE_POSITIVE_RATIO` | The target false positive ratio of the written Bloom filters. | `DOUBLE` | `0.01` |

--- a/docs/current/sql/statements/copy.md
+++ b/docs/current/sql/statements/copy.md
@@ -355,6 +355,7 @@ The below options are applicable when writing Parquet files.
 | `CHUNK_SIZE` | Alias for `ROW_GROUP_SIZE`. | `BIGINT` | 122880 |
 | `KV_METADATA` | Custom key-value metadata to embed in the file footer, supplied as a `STRUCT` of keys to values. `BLOB` values are written as raw bytes; other values are cast to string. | `STRUCT` | (empty) |
 | `SHREDDING` | A `STRUCT` mapping [`VARIANT`]({% link docs/current/sql/data_types/variant.md %}) column names to the type they should be shredded into, e.g., `{variant_col: 'STRUCT(name VARCHAR, age INTEGER)'}`. Enables typed (shredded) storage of `VARIANT` columns. | `STRUCT` | (empty) |
+| `DATA_PAGE_SIZE_LIMIT` | Target uncompressed size of Parquet data pages, in bytes. Pages may still be larger at vector granularity. | `UBIGINT` | `104857600` (100 MB) |
 | `DICTIONARY_SIZE_LIMIT` | The maximum size of the dictionary used for dictionary encoding, in number of distinct values. Set to `0` to disable dictionary encoding. | `BIGINT` | `ROW_GROUP_SIZE / 5` |
 | `WRITE_BLOOM_FILTER` | Whether to write [Bloom filters](https://en.wikipedia.org/wiki/Bloom_filter) that allow readers to skip row groups. | `BOOLEAN` | `true` |
 | `BLOOM_FILTER_FALSE_POSITIVE_RATIO` | The target false positive ratio of the written Bloom filters. | `DOUBLE` | `0.01` |


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb-web/issues/7118

After https://github.com/duckdb/duckdb/pull/24645, Parquet `COPY` has `DATA_PAGE_SIZE_LIMIT` (default 100 MB). The docs already cover `STRING_DICTIONARY_PAGE_SIZE_LIMIT`; this adds the data-page option next to it (overview example + COPY options table).

I used an assistant on the edit. Maintainers can edit this branch.
