### PR TITLE
Add examples for missing java classes

### DIFF
--- a/docs/current/clients/java/connecting.md
+++ b/docs/current/clients/java/connecting.md
@@ -14,10 +14,11 @@ Every DuckDB feature reachable from Java starts with a `Connection`. This page c
 ## Opening a Connection
 
 In JDBC, database connections are created through the standard `java.sql.DriverManager` class.
-On modern JVMs the driver registers itself with the `DriverManager` automatically when the JDBC JAR is on the classpath (through Java's [service-provider mechanism](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html)), so no setup is needed. If that does not happen for some reason, load the driver class explicitly to force registration:
+On modern JVMs the driver registers itself with the `DriverManager` automatically when the JDBC JAR is on the classpath (through Java's [service-provider mechanism](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html)), so no setup is needed. If that does not happen for some reason, load the `DuckDBDriver` class explicitly to force registration before opening a connection:
 
 ```java
 Class.forName("org.duckdb.DuckDBDriver");
+Connection conn = DriverManager.getConnection("jdbc:duckdb:");
 ```
 
 To create a DuckDB connection, call `DriverManager` with the `jdbc:duckdb:` JDBC URL prefix, like so:

--- a/docs/current/clients/java/data_import.md
+++ b/docs/current/clients/java/data_import.md
@@ -65,6 +65,12 @@ The Appender is already the fastest way to bulk-load data, but a few properties 
 * **Avoid allocating a Java object per row.** Boxing values or constructing a new object for every row adds allocation and garbage-collection pressure. Prefer the primitive `append()` overloads and reuse buffers where you can.
 * **Keep strings short where possible.** DuckDB stores strings of up to 12 bytes inline; longer strings are stored out of line and add a small overhead per value.
 
+### Single-Value Appender (Legacy)
+
+An earlier appender, `org.duckdb.DuckDBSingleValueAppender`, created with `DuckDBConnection.createSingleValueAppender()`, writes one value at a time with typed `append()` overloads between `beginRow()` and `endRow()`. Both the class and the factory method are deprecated and retained only for backward compatibility.
+
+> Warning New code should use the `DuckDBAppender` described above, which is faster and appends nested and collection types. `DuckDBSingleValueAppender` is kept only for existing applications.
+
 ## Batch Writer
 
 The DuckDB JDBC driver offers batch write functionality.

--- a/docs/current/clients/java/data_import.md
+++ b/docs/current/clients/java/data_import.md
@@ -55,7 +55,7 @@ try (var appender = conn.createAppender("nested_tbl")) {
     appender.append(2);          // field y
     appender.endStruct();
     appender.beginUnion("str");  // select the UNION member named "str"
-    appender.append("hello");    // its VARCHAR value; the num member is left NULL
+    appender.append("hello");    // its VARCHAR value
     appender.endUnion();
     appender.endRow();
 }
@@ -68,6 +68,16 @@ try (var appender = conn.createAppender("list_tbl")) {
     appender.beginRow();
     appender.append(new int[] {1, 2, 3});               // a LIST value
     appender.append(new int[] {4, 5}, new boolean[] {false, true}); // second element is NULL
+    appender.endRow();
+}
+```
+
+For a `MAP` column, pass a Java `Map` as a single value; each entry is written as a key/value pair, and a `null` map is appended as SQL `NULL`. The following row targets a table declared as `CREATE TABLE map_tbl (m MAP(VARCHAR, INTEGER))`:
+
+```java
+try (var appender = conn.createAppender("map_tbl")) {
+    appender.beginRow();
+    appender.append(Map.of("a", 1, "b", 2));            // a MAP value
     appender.endRow();
 }
 ```

--- a/docs/current/clients/java/data_import.md
+++ b/docs/current/clients/java/data_import.md
@@ -45,7 +45,23 @@ try (var stmt = conn.createStatement()) {
 
 An appender can also be created with `createAppender(tableName)` for the default schema, or with `createAppender(catalogName, schemaName, tableName)` to target a specific catalog. Buffered rows are written to the table when the appender is closed, or earlier by calling `flush()`. Within a row, `appendNull()` writes a `NULL` and `appendDefault()` writes the column's `DEFAULT` value.
 
-Nested and collection types are appended within a row as well. For a `STRUCT` column, call `beginStruct()`, append each field value in declaration order, then `endStruct()`. For a `UNION` column, call `beginUnion(tag)` — where `tag` is the name of the target `UNION` member — append that member's value, then `endUnion()`. For a `LIST` or `ARRAY` column, pass a Java array as a single value, optionally with a boolean null mask where `true` marks the corresponding element as `NULL`:
+Nested and collection types are appended within a row as well. For a `STRUCT` column, call `beginStruct()`, append each field value in declaration order, then `endStruct()`. For a `UNION` column, call `beginUnion(tag)` — where `tag` is the name of the target `UNION` member — append that member's value, then `endUnion()`. The following row targets a table declared as `CREATE TABLE nested_tbl (point STRUCT(x INTEGER, y INTEGER), value UNION(num INTEGER, str VARCHAR))`:
+
+```java
+try (var appender = conn.createAppender("nested_tbl")) {
+    appender.beginRow();
+    appender.beginStruct();      // enter the STRUCT column
+    appender.append(1);          // field x
+    appender.append(2);          // field y
+    appender.endStruct();
+    appender.beginUnion("str");  // select the UNION member named "str"
+    appender.append("hello");    // its VARCHAR value; the num member is left NULL
+    appender.endUnion();
+    appender.endRow();
+}
+```
+
+For a `LIST` or `ARRAY` column, pass a Java array as a single value, optionally with a boolean null mask where `true` marks the corresponding element as `NULL`:
 
 ```java
 try (var appender = conn.createAppender("list_tbl")) {

--- a/docs/current/clients/java/functions.md
+++ b/docs/current/clients/java/functions.md
@@ -13,7 +13,7 @@ The JDBC driver can register user-defined functions (UDFs) written in Java, incl
 
 ## Scalar Functions
 
-Build a scalar function with the `DuckDBFunctions.scalarFunction()` builder and register it on a connection with `register()`. Once registered, the function can be called from SQL by the name passed to `withName()`.
+Build a scalar function with the `DuckDBFunctions.scalarFunction()` builder — which returns an `org.duckdb.DuckDBScalarFunctionBuilder` — and register it on a connection with `register()`. Once registered, the function can be called from SQL by the name passed to `withName()`. The builder is single-use: it is finalized once `register()` (or `close()`) is called.
 
 The simplest functions map directly to a Java functional interface. Pick the overload that matches the number of arguments and, for primitives, their type:
 
@@ -158,7 +158,7 @@ The `scalarFunction()` builder exposes the following methods:
 
 ## Table Functions
 
-Build a table function with the `DuckDBFunctions.tableFunction()` builder. The implementation is a `DuckDBTableFunction` with the following callbacks:
+Build a table function with the `DuckDBFunctions.tableFunction()` builder, which returns an `org.duckdb.DuckDBTableFunctionBuilder`. Like the scalar builder, it is single-use and finalized on `register()` (or `close()`). The implementation is a `DuckDBTableFunction` with the following callbacks:
 
 * `bind` runs when the statement is prepared. It registers the output columns with `addResultColumn()` and reads positional and named call parameters with `getParameter()` and `getNamedParameter()`. It may return bind data that is passed to the later callbacks.
 * `init` runs once before execution and returns the global state.
@@ -224,6 +224,59 @@ FROM java_table_basic(42, param1 = 'foobar');
 Rows are written through a `DuckDBDataChunkWriter`, the write-side counterpart to the [`DuckDBDataChunkReader`]({% link docs/current/clients/java/result_handling.md %}#chunked-results) used for reading results. Each output vector is addressed by column index, and values are set by row index with methods such as `setInt()`, `setString()`, and `setNull()`.
 
 All callback arguments, including the parameter and info objects, are valid only during callback execution and must not be retained. The Java table function interface mirrors DuckDB's [C API table functions]({% link docs/current/clients/c/api.md %}) as closely as possible.
+
+### Producing Rows in Chunks
+
+The example above writes every row in a single `apply` call, but a table function is not expected to. DuckDB calls `apply` repeatedly, each time passing a fresh output chunk that holds up to `output.capacity()` rows (2,048 by default). Fill up to that many rows, return how many you wrote, and DuckDB calls `apply` again for the next chunk until you return `0`. A cursor into the source therefore has to live in the init (or local-init) state so it survives across calls, rather than in a local variable.
+
+The `apply` below streams a bounded integer series in chunks. It also dispatches on each column's declared type with `DuckDBWritableVector.getType()`, which is convenient when the same routine populates columns of different types:
+
+```java
+// Held in the init state so the position survives across apply() calls.
+final class Series {
+    long next;
+    final long end;
+    Series(long end) { this.end = end; }
+}
+
+DuckDBFunctions.tableFunction()
+    .withName("java_series")
+    .withParameter(long.class)
+    .withFunction(new DuckDBTableFunction<Long, Series, Object>() {
+        @Override
+        public Long bind(DuckDBTableFunctionBindInfo info) throws Exception {
+            info.addResultColumn("n", Long.TYPE)
+                .addResultColumn("label", String.class);
+            return info.getParameter(0).getLong();
+        }
+
+        @Override
+        public Series init(DuckDBTableFunctionInitInfo info) throws Exception {
+            return new Series(info.getBindData());
+        }
+
+        @Override
+        public long apply(DuckDBTableFunctionCallInfo info, DuckDBDataChunkWriter output) throws Exception {
+            Series cursor = info.getInitData();
+            long row = 0;
+            // Fill at most one chunk; DuckDB calls apply() again for the rest.
+            for (; row < output.capacity() && cursor.next < cursor.end; row++, cursor.next++) {
+                for (long col = 0; col < output.columnCount(); col++) {
+                    DuckDBWritableVector vector = output.vector(col);
+                    switch (vector.getType()) {
+                        case BIGINT:  vector.setLong(row, cursor.next); break;
+                        case VARCHAR: vector.setString(row, "row-" + cursor.next); break;
+                        default:      vector.setNull(row);
+                    }
+                }
+            }
+            return row; // returning 0 tells DuckDB the scan is finished
+        }
+    })
+    .register(conn);
+```
+
+Calling `FROM java_series(5000)` drives `apply` three times — two full 2,048-row chunks and a final partial one — before the fourth call returns `0`.
 
 ### Cleaning up Resources
 

--- a/docs/current/clients/java/querying.md
+++ b/docs/current/clients/java/querying.md
@@ -121,9 +121,9 @@ try (ResultSet rs = stmt.executeQuery("SELECT '[1, 2, 3]'::JSON AS j")) {
 
 To bind a `LIST`/`ARRAY`, `STRUCT`, or `MAP` value as a prepared-statement parameter, build it from the `Connection` and pass it to `setObject()`. Each factory method attaches the SQL type name the driver needs to marshal the value.
 
-* `createArrayOf(typeName, elements)` — the standard JDBC method — returns an `org.duckdb.DuckDBUserArray` (a `java.sql.Array`) for a `LIST` or `ARRAY`, where `typeName` is the element type.
-* `createStruct(typeName, attributes)` — the standard JDBC method — returns an `org.duckdb.DuckDBUserStruct` (a `java.sql.Struct`), where `typeName` is the `STRUCT` type and `attributes` are the field values in declaration order.
-* `createMap(typeName, map)` — a DuckDB extension on `DuckDBConnection` — returns an `org.duckdb.DuckDBMap` (a `java.util.Map`) for a `MAP`, where `typeName` is the full map type such as `MAP(VARCHAR, INTEGER)`.
+* `createArrayOf(typeName, elements)` — the standard JDBC method — returns an `org.duckdb.user.DuckDBUserArray` (a `java.sql.Array`) for a `LIST` or `ARRAY`, where `typeName` is the element type.
+* `createStruct(typeName, attributes)` — the standard JDBC method — returns an `org.duckdb.user.DuckDBUserStruct` (a `java.sql.Struct`), where `typeName` is the `STRUCT` type and `attributes` are the field values in declaration order.
+* `createMap(typeName, map)` — a DuckDB extension on `DuckDBConnection` — returns an `org.duckdb.user.DuckDBMap` (a `java.util.Map`) for a `MAP`, where `typeName` is the full map type such as `MAP(VARCHAR, INTEGER)`.
 
 ```java
 import java.sql.Array;

--- a/docs/current/clients/java/querying.md
+++ b/docs/current/clients/java/querying.md
@@ -87,7 +87,138 @@ try (ResultSet rs = stmt.executeQuery("SELECT [1, 2, 3] AS l, {'a': 1, 'b': 2} A
 }
 ```
 
-The DuckDB result set also exposes typed accessors as extensions to the JDBC API, including `getArray(int)`, `getStruct(int)`, `getUuid(int)`, `getHugeint(int)`, and `getJsonObject(int)`. `DuckDBStruct.getMap()` returns the struct fields keyed by name, and `DuckDBArray.getResultSet()` exposes the list elements as an index and value result set.
+The DuckDB result set also exposes typed accessors as extensions to the JDBC API, including `getArray(int)`, `getStruct(int)`, `getUuid(int)`, `getHugeint(int)`, and `getJsonObject(int)`. `DuckDBStruct.getMap()` returns the struct fields keyed by name.
+
+`DuckDBArray.getResultSet()` exposes the list elements as an `org.duckdb.DuckDBArrayResultSet`, a read-only `ResultSet` with two columns: `INDEX`, the 1-based position of the element, and `VALUE`, the element itself. Iterate it like any other result set:
+
+```java
+try (ResultSet rs = stmt.executeQuery("SELECT [10, 20, 30] AS l")) {
+    rs.next();
+    DuckDBArray list = (DuckDBArray) rs.getObject(1);
+    try (ResultSet elements = list.getResultSet()) {
+        while (elements.next()) {
+            int index = elements.getInt("INDEX"); // 1-based position
+            int value = elements.getInt("VALUE"); // the element
+            System.out.println(index + " -> " + value);
+        }
+    }
+}
+```
+
+A `JSON` column is returned by `getObject(int)` (and `getJsonObject(int)`) as an `org.duckdb.JsonNode`, a lightweight wrapper over the raw JSON text. Query its shape with `isArray()`, `isObject()`, `isString()`, `isNumber()`, `isBoolean()`, and `isNull()`, and recover the JSON source with `toString()`:
+
+```java
+try (ResultSet rs = stmt.executeQuery("SELECT '[1, 2, 3]'::JSON AS j")) {
+    rs.next();
+    JsonNode json = (JsonNode) rs.getObject(1);
+    if (json.isArray()) {
+        System.out.println(json); // [1, 2, 3]
+    }
+}
+```
+
+## Binding Nested and Composite Parameters
+
+To bind a `LIST`/`ARRAY`, `STRUCT`, or `MAP` value as a prepared-statement parameter, build it from the `Connection` and pass it to `setObject()`. Each factory method attaches the SQL type name the driver needs to marshal the value.
+
+* `createArrayOf(typeName, elements)` — the standard JDBC method — returns an `org.duckdb.DuckDBUserArray` (a `java.sql.Array`) for a `LIST` or `ARRAY`, where `typeName` is the element type.
+* `createStruct(typeName, attributes)` — the standard JDBC method — returns an `org.duckdb.DuckDBUserStruct` (a `java.sql.Struct`), where `typeName` is the `STRUCT` type and `attributes` are the field values in declaration order.
+* `createMap(typeName, map)` — a DuckDB extension on `DuckDBConnection` — returns an `org.duckdb.DuckDBMap` (a `java.util.Map`) for a `MAP`, where `typeName` is the full map type such as `MAP(VARCHAR, INTEGER)`.
+
+```java
+import java.sql.Array;
+import java.sql.Struct;
+import java.util.Map;
+import org.duckdb.DuckDBConnection;
+
+DuckDBConnection conn = (DuckDBConnection) DriverManager.getConnection("jdbc:duckdb:");
+
+// LIST / ARRAY
+Array list = conn.createArrayOf("INTEGER", new Object[] {1, 2, 3});
+try (PreparedStatement stmt = conn.prepareStatement("SELECT ?::INTEGER[]")) {
+    stmt.setObject(1, list);
+    stmt.execute();
+}
+
+// STRUCT
+Struct point = conn.createStruct("STRUCT(x DOUBLE, y DOUBLE)", new Object[] {1.0, 2.0});
+
+// MAP
+Map<String, Integer> counts = conn.createMap("MAP(VARCHAR, INTEGER)", Map.of("a", 1, "b", 2));
+```
+
+## Binding Temporal Parameters
+
+Date and time parameters follow the same `setObject()` path. When you bind a `java.time` or `java.sql` temporal value, the driver wraps it in the matching internal holder — `java.sql.Date`/`LocalDate` become an `org.duckdb.DuckDBDate`, `Timestamp`/`LocalDateTime` become a `DuckDBTimestamp`, `OffsetDateTime` becomes a `DuckDBTimestampTZ`, and `Time`/`LocalTime` become a `DuckDBTime` — and marshals it to the corresponding DuckDB type:
+
+```java
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+try (PreparedStatement stmt = conn.prepareStatement("SELECT ?, ?")) {
+    stmt.setObject(1, LocalDate.of(2024, 1, 15));
+    stmt.setObject(2, LocalDateTime.of(2024, 1, 15, 12, 30));
+    stmt.execute();
+}
+```
+
+Each holder keeps its value relative to the Unix epoch (`1970-01-01`): `DuckDBDate` counts whole days through `getDaysSinceEpoch()`, while `DuckDBTimestamp`, `DuckDBTimestampTZ`, and `DuckDBTime` report microseconds through `getMicrosEpoch()` (for `DuckDBTime`, microseconds since midnight):
+
+```java
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.time.OffsetDateTime;
+import org.duckdb.DuckDBDate;
+import org.duckdb.DuckDBTime;
+import org.duckdb.DuckDBTimestamp;
+import org.duckdb.DuckDBTimestampTZ;
+
+long days = new DuckDBDate(Date.valueOf("2024-01-15")).getDaysSinceEpoch();                     // 19737
+long micros = new DuckDBTimestamp(Timestamp.valueOf("2024-01-15 12:30:00")).getMicrosEpoch();
+long zonedMicros = new DuckDBTimestampTZ(OffsetDateTime.parse("2024-01-15T12:30:00Z")).getMicrosEpoch();
+long timeMicros = new DuckDBTime(Time.valueOf("12:30:00")).getMicrosEpoch();
+```
+
+## Inspecting Metadata
+
+The driver implements the standard JDBC metadata interfaces, so an application can introspect the database, a result set, or a prepared statement's parameters without running catalog queries by hand.
+
+* `Connection.getMetaData()` returns an `org.duckdb.DuckDBDatabaseMetaData`, a `java.sql.DatabaseMetaData` that reports database-wide capabilities and exposes catalog objects such as `getTables()`, `getColumns()`, and `getSchemas()` as result sets built from DuckDB's system tables.
+* `ResultSet.getMetaData()` returns an `org.duckdb.DuckDBResultSetMetaData` describing the result columns — `getColumnCount()`, `getColumnName(int)`, `getColumnType(int)`, `getColumnTypeName(int)`, `getPrecision(int)`, and `getScale(int)`.
+* `PreparedStatement.getParameterMetaData()` returns an `org.duckdb.DuckDBParameterMetaData` describing the statement's parameters (1-based), including `getParameterCount()`, `getParameterType(int)`, and `getParameterTypeName(int)`.
+
+```java
+try (PreparedStatement stmt = conn.prepareStatement("SELECT * FROM items WHERE value > ?")) {
+    stmt.setDouble(1, 10.0);
+    ResultSetMetaData rsMeta = stmt.getMetaData();
+    for (int i = 1; i <= rsMeta.getColumnCount(); i++) {
+        System.out.println(rsMeta.getColumnName(i) + " : " + rsMeta.getColumnTypeName(i));
+    }
+    System.out.println("parameters: " + stmt.getParameterMetaData().getParameterCount());
+}
+```
+
+As a DuckDB extension, `DuckDBResultSetMetaData.getReturnType()` reports what a statement returns as an `org.duckdb.StatementReturnType` — `QUERY_RESULT`, `CHANGED_ROWS`, or `NOTHING`:
+
+```java
+import org.duckdb.DuckDBResultSetMetaData;
+import org.duckdb.StatementReturnType;
+
+DuckDBResultSetMetaData meta = (DuckDBResultSetMetaData) rs.getMetaData();
+StatementReturnType returnType = meta.getReturnType(); // QUERY_RESULT
+```
+
+For a `DECIMAL` column, `getPrecision(int)` and `getScale(int)` report the width and scale that DuckDB records for the type in a `DuckDBColumnTypeMetaData`. For the `value DECIMAL(10, 2)` column of the `items` table, they return `10` and `2`:
+
+```java
+try (ResultSet rs = stmt.executeQuery("SELECT value FROM items")) {
+    ResultSetMetaData rsMeta = rs.getMetaData();
+    int precision = rsMeta.getPrecision(1); // 10
+    int scale = rsMeta.getScale(1);         // 2
+    System.out.println("DECIMAL(" + precision + ", " + scale + ")");
+}
+```
 
 ## Further Reading
 

--- a/docs/current/clients/java/querying.md
+++ b/docs/current/clients/java/querying.md
@@ -105,7 +105,7 @@ try (ResultSet rs = stmt.executeQuery("SELECT [10, 20, 30] AS l")) {
 }
 ```
 
-A `JSON` column is returned by `getObject(int)` (and `getJsonObject(int)`) as an `org.duckdb.JsonNode`, a lightweight wrapper over the raw JSON text. Query its shape with `isArray()`, `isObject()`, `isString()`, `isNumber()`, `isBoolean()`, and `isNull()`, and recover the JSON source with `toString()`:
+A `JSON` column is returned by `getObject(int)` (and `getJsonObject(int)`) as an `org.duckdb.JsonNode`, a lightweight wrapper over the raw JSON text. Test its type with `isArray()`, `isObject()`, `isString()`, `isNumber()`, `isBoolean()`, and `isNull()`, and recover the JSON source with `toString()`:
 
 ```java
 try (ResultSet rs = stmt.executeQuery("SELECT '[1, 2, 3]'::JSON AS j")) {
@@ -149,7 +149,7 @@ Map<String, Integer> counts = conn.createMap("MAP(VARCHAR, INTEGER)", Map.of("a"
 
 ### Binding Spatial Values
 
-The [`spatial` extension]({% link docs/current/core_extensions/spatial/overview.md %}) builds its geometry types on the same `STRUCT` and `LIST` machinery, so they are bound with the same factory methods. A `POINT_2D` is a struct of two `DOUBLE` fields, and a `LINESTRING` is a list of such points. After loading the extension, build the value with `createStruct()` (or `createArrayOf()`) and cast the parameter to `GEOMETRY`; a `GEOMETRY` result comes back as Well-Known Binary through `getBlob()`:
+The [`spatial` extension]({% link docs/current/core_extensions/spatial/overview.md %}) builds its geometry types from `STRUCT` and `LIST` types, so they are bound with the same factory methods. A `POINT_2D` is a struct of two `DOUBLE` fields, and a `LINESTRING` is a list of such points. After loading the extension, build the value with `createStruct()` (or `createArrayOf()`) and cast the parameter to `GEOMETRY`; a `GEOMETRY` result comes back as Well-Known Binary through `getBlob()`:
 
 ```java
 try (Statement stmt = conn.createStatement()) {

--- a/docs/current/clients/java/querying.md
+++ b/docs/current/clients/java/querying.md
@@ -147,6 +147,32 @@ Struct point = conn.createStruct("STRUCT(x DOUBLE, y DOUBLE)", new Object[] {1.0
 Map<String, Integer> counts = conn.createMap("MAP(VARCHAR, INTEGER)", Map.of("a", 1, "b", 2));
 ```
 
+### Binding Spatial Values
+
+The [`spatial` extension]({% link docs/current/core_extensions/spatial/overview.md %}) builds its geometry types on the same `STRUCT` and `LIST` machinery, so they are bound with the same factory methods. A `POINT_2D` is a struct of two `DOUBLE` fields, and a `LINESTRING` is a list of such points. After loading the extension, build the value with `createStruct()` (or `createArrayOf()`) and cast the parameter to `GEOMETRY`; a `GEOMETRY` result comes back as Well-Known Binary through `getBlob()`:
+
+```java
+try (Statement stmt = conn.createStatement()) {
+    stmt.execute("INSTALL spatial");
+    stmt.execute("LOAD spatial");
+}
+
+// POINT_2D is a STRUCT(x DOUBLE, y DOUBLE)
+Struct point = conn.createStruct("POINT_2D", new Object[] {41.1, 42.2});
+try (PreparedStatement stmt = conn.prepareStatement("SELECT ?::POINT_2D::GEOMETRY")) {
+    stmt.setObject(1, point);
+    try (ResultSet rs = stmt.executeQuery()) {
+        rs.next();
+        Blob wkb = rs.getBlob(1); // the geometry as Well-Known Binary
+    }
+}
+
+// A LINESTRING is a LIST of POINT_2D structs
+Struct p1 = conn.createStruct("POINT_2D", new Object[] {0.0, 0.0});
+Struct p2 = conn.createStruct("POINT_2D", new Object[] {1.0, 1.0});
+Array line = conn.createArrayOf("POINT_2D", new Object[] {p1, p2});
+```
+
 ## Binding Temporal Parameters
 
 Date and time parameters follow the same `setObject()` path. When you bind a `java.time` or `java.sql` temporal value, the driver wraps it in the matching internal holder — `java.sql.Date`/`LocalDate` become an `org.duckdb.DuckDBDate`, `Timestamp`/`LocalDateTime` become a `DuckDBTimestamp`, `OffsetDateTime` becomes a `DuckDBTimestampTZ`, and `Time`/`LocalTime` become a `DuckDBTime` — and marshals it to the corresponding DuckDB type:


### PR DESCRIPTION
Fixes #7175 

This pull request expands and clarifies the Java client documentation for DuckDB, adding practical examples, deeper explanations, and improved guidance for advanced JDBC features. The most important changes are summarized below:

### Improved Documentation for Advanced JDBC Features

* Added comprehensive examples and explanations for working with nested and collection types in the Appender API, including detailed code samples for `STRUCT` and `UNION` columns.
* Introduced sections on binding nested/composite and temporal parameters in prepared statements, with code samples for `LIST`/`ARRAY`, `STRUCT`, `MAP`, and temporal types.
* Expanded the metadata section to cover JDBC metadata interfaces and DuckDB-specific extensions, including examples for inspecting result set and parameter metadata.

### API Guidance and Deprecations

* Documented the legacy `DuckDBSingleValueAppender` as deprecated, providing migration guidance to the newer, more capable `DuckDBAppender`.
* Clarified the usage of the scalar and table function builders, noting their single-use nature and the types they return, and improved the explanation of registering user-defined functions. [[1]](diffhunk://#diff-d1f6659f3e11d93e1cbaba0bbee8f32af386dc5682a93485846243bd4e3e83ceL16-R16) [[2]](diffhunk://#diff-d1f6659f3e11d93e1cbaba0bbee8f32af386dc5682a93485846243bd4e3e83ceL161-R161)

### Practical Usage Enhancements

* Added a new section and example for producing rows in chunks within table functions, illustrating how to efficiently stream large result sets and manage state across `apply()` calls.
* Provided expanded examples for accessing and iterating over arrays and JSON results, including use of `DuckDBArray.getResultSet()` and the `JsonNode` API.

### Minor Improvements and Clarifications

* Clarified that the explicit driver class to load is `DuckDBDriver` when automatic registration fails.

These changes make the Java client documentation more practical, complete, and helpful for both new and advanced users.