### PR TITLE
docs: integer division by zero now errors

### DIFF
--- a/docs/current/configuration/pragmas.md
+++ b/docs/current/configuration/pragmas.md
@@ -621,6 +621,8 @@ SET ieee_floating_point_ops = false;
 
 In this case, floating point division by zero (e.g., `1.0 / 0.0`, `0.0 / 0.0` and `-1.0 / 0.0`) will all return `NULL`.
 
+Integer division by zero (`1 // 0`, `1 % 0`, `INTERVAL '1' DAY / 0`) errors by default. `SET null_on_division_by_zero = true` restores the previous `NULL` result.
+
 ## Query Verification (for Development)
 
 The following `PRAGMA`s are mostly used for development and internal testing.

--- a/docs/current/sql/functions/numeric.md
+++ b/docs/current/sql/functions/numeric.md
@@ -41,6 +41,8 @@ There are two division operators: `/` and `//`.
 They are equivalent when at least one of the operands is a `FLOAT` or a `DOUBLE`.
 When both operands are integers, `/` performs floating points division (`5 / 2 = 2.5`) while `//` performs integer division (`5 // 2 = 2`).
 
+Integer division (`//`), modulo (`%`), and `INTERVAL / 0` throw an `Invalid Input Error` on division by zero instead of returning `NULL`. Wrap the expression in `TRY(...)` to return `NULL` for that expression, or `SET null_on_division_by_zero = true` to restore the old `NULL` result for all divisions by zero.
+
 ### Supported Types
 
 The modulo, bitwise, negation, and factorial operators work only on integral data types,


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb-web/issues/7182

After https://github.com/duckdb/duckdb/pull/25004, integer `//` / `%` and `INTERVAL / 0` throw instead of returning `NULL`. Noted on the numeric operators page, plus `TRY(...)` and `null_on_division_by_zero`. IEEE float `/ 0` is unchanged unless `ieee_floating_point_ops` is off.

I used an assistant on the edit. Maintainers can edit this branch.
