### PR TITLE
docs: regexp_extract options overload without a group

### DIFF
--- a/docs/current/sql/functions/regular_expressions.md
+++ b/docs/current/sql/functions/regular_expressions.md
@@ -183,6 +183,12 @@ SELECT regexp_extract('abc', '([a-z])(b)', 1); -- a
 SELECT regexp_extract('abc', '([a-z])(b)', 2); -- b
 ```
 
+There is also an overload that takes regex options as the third argument, with no group required:
+
+```sql
+SELECT regexp_extract('ABC', 'abc', 'i'); -- ABC
+```
+
 The `regexp_extract` function also supports a `name_list` argument, which is a `LIST` of strings. Using `name_list`, the `regexp_extract` will return the corresponding capture groups as fields of a `STRUCT`:
 
 ```sql


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb-web/issues/7154

After https://github.com/duckdb/duckdb/pull/24857 you can pass regex options as the third argument, with no group: `regexp_extract('ABC', 'abc', 'i')`. Added that example next to the existing group examples.

I used an assistant on the edit. Maintainers can edit this branch.
