### PR TITLE
docs: SHOW can print a configuration setting

### DIFF
--- a/docs/current/sql/statements/show.md
+++ b/docs/current/sql/statements/show.md
@@ -11,6 +11,19 @@ title: SHOW, SHOW DATABASES, and SHOW SCHEMAS Statements
 The `SHOW` statement is an alias for [`DESCRIBE`]({% link docs/current/sql/statements/describe.md %}).
 It shows the schema of a table, view or query.
 
+`SHOW` can also print a [configuration setting]({% link docs/current/configuration/overview.md %}) when the name is not a table (Postgres-style):
+
+```sql
+SET threads = 42;
+SHOW threads;
+```
+
+| threads |
+|---------|
+| 42      |
+
+If both a table and a setting share the name, `SHOW` describes the table (deprecated; use `DESCRIBE` for tables). `DESCRIBE` never resolves a setting.
+
 ## `SHOW DATABASES` Statement
 
 The `SHOW DATABASES` statement shows a list of all attached databases:


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb-web/issues/7142

After https://github.com/duckdb/duckdb/pull/23732, `SHOW threads` (and other settings) prints the current value. Documented on the SHOW page. If a table has the same name, SHOW still describes the table (deprecated; use DESCRIBE). DESCRIBE never resolves a setting.

I used an assistant on the edit. Maintainers can edit this branch.
