### PR TITLE
docs: parquet SCHEMA MAP can be keyed by name

### DIFF
--- a/docs/current/data/parquet/overview.md
+++ b/docs/current/data/parquet/overview.md
@@ -158,13 +158,15 @@ There are a number of options exposed that can be passed to the `read_parquet` f
 | `file_row_number` | Whether or not to include the `file_row_number` column. | `BOOL` | `false` |
 | `hive_partitioning` | Whether or not to interpret the path as a [Hive partitioned path]({% link docs/current/data/partitioning/hive_partitioning.md %}). | `BOOL` | (auto-detected) |
 | `union_by_name` | Whether the columns of multiple schemas should be [unified by name]({% link docs/current/data/multiple_files/combining_schemas.md %}), rather than by position. | `BOOL` | `false` |
-| `schema` | Allows you to read a Parquet file as if it has the supplied schema. Field IDs are required. | `MAP` | `NULL` |
+| `schema` | Allows you to read a Parquet file as if it has the supplied schema. The `MAP` can be keyed by field-id (`INTEGER`) or by column name (`VARCHAR`). | `MAP` | `NULL` |
 
 ## Using the `schema` Parameter
 
 The `schema` parameter allows you to read the Parquet file using a specific schema. This is useful for renaming, adding, deleting, reordering, or casting columns when reading Parquet files.
 
-To use the `schema` parameter, field IDs are required. To make them available when creating the Parquet using DuckDB, use:
+The `MAP` can be keyed by field-id or by column name.
+
+To map by field-id, field IDs are required. To make them available when creating the Parquet using DuckDB, use:
 
 ```sql
 COPY (SELECT 42::INTEGER AS i) TO 'integers.parquet' (FIELD_IDS {i: 0});
@@ -177,6 +179,27 @@ SELECT *
 FROM read_parquet('integers.parquet', schema = MAP {
                     0: {name: 'renamed_i', type: 'BIGINT', default_value: NULL},
                     1: {name: 'new_column', type: 'UTINYINT', default_value: 43}
+                  });
+```
+
+```text
+┌───────────┬────────────┐
+│ renamed_i │ new_column │
+│   int64   │   uint8    │
+├───────────┼────────────┤
+│        42 │         43 │
+└───────────┴────────────┘
+```
+
+You can also key the `MAP` by column name. Field IDs are not required:
+
+```sql
+COPY (SELECT 42::INTEGER AS i) TO 'integers.parquet';
+
+SELECT *
+FROM read_parquet('integers.parquet', schema = MAP {
+                    'i': {name: 'renamed_i', type: 'BIGINT', default_value: NULL},
+                    'j': {name: 'new_column', type: 'UTINYINT', default_value: 43}
                   });
 ```
 


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb-web/issues/7184

https://github.com/duckdb/duckdb/pull/15446 lets the `schema` MAP be keyed by column name as well as field-id. The page still said field IDs were required. Added a name-keyed example and updated the parameter table.

I used an assistant on the edit. Maintainers can edit this branch.
