### PR TITLE
Update quick install script from sh to bash

### DIFF
--- a/_includes/installation.html
+++ b/_includes/installation.html
@@ -93,7 +93,7 @@
     data-docs="{% link docs/current/clients/cli/overview.md %}">
 
     <figure class="highlight">
-        <pre><code class="language-bash" data-lang="bash"><span class="nb">curl </span><a href="https://install.duckdb.org">https://install.duckdb.org</a> | <span class="nb">sh</span></code></pre>
+        <pre><code class="language-bash" data-lang="bash"><span class="nb">curl </span><a href="https://install.duckdb.org">https://install.duckdb.org</a> | <span class="nb">bash</span></code></pre>
     </figure>
 
 <div class="alternative">
@@ -124,7 +124,7 @@ docker run --rm -it -v "$(pwd):/workspace" -w /workspace duckdb/duckdb
     data-docs="{% link docs/lts/clients/cli/overview.md %}">
 
 {%- highlight bash -%}
-curl https://install.duckdb.org | DUCKDB_VERSION={{ site.lts_duckdb_version }} sh
+curl https://install.duckdb.org | DUCKDB_VERSION={{ site.lts_duckdb_version }} bash
 {%- endhighlight -%}
 
 <div class="alternative">
@@ -143,7 +143,7 @@ curl https://install.duckdb.org | DUCKDB_VERSION={{ site.lts_duckdb_version }} s
     data-docs="{% link docs/current/clients/cli/overview.md %}">
 
 <figure class="highlight">
-    <pre><code class="language-bash" data-lang="bash"><span class="nb">curl </span><a href="https://install.duckdb.org">https://install.duckdb.org</a> | <span class="nb">sh</span></code></pre>
+    <pre><code class="language-bash" data-lang="bash"><span class="nb">curl </span><a href="https://install.duckdb.org">https://install.duckdb.org</a> | <span class="nb">bash</span></code></pre>
 </figure>
 
 <div class="alternative">
@@ -184,7 +184,7 @@ docker run --rm -it -v "$(pwd):/workspace" -w /workspace duckdb/duckdb
     data-docs="{% link docs/lts/clients/cli/overview.md %}">
 
 {%- highlight bash -%}
-curl https://install.duckdb.org | DUCKDB_VERSION={{ site.lts_duckdb_version }} sh
+curl https://install.duckdb.org | DUCKDB_VERSION={{ site.lts_duckdb_version }} bash
 {%- endhighlight -%}
 
 <div class="alternative">

--- a/_includes/quick_installation.html
+++ b/_includes/quick_installation.html
@@ -22,7 +22,7 @@
 
 				<div class="result content">
 {% highlight bash %}
-curl https://install.duckdb.org | sh
+curl https://install.duckdb.org | bash
 {% endhighlight %}
 				</div>
 
@@ -59,13 +59,13 @@ npm install @duckdb/node-api
 
 <div data-install="cli macos" data-version="{{ site.current_duckdb_version }}">
 {% highlight bash %}
-curl https://install.duckdb.org | sh
+curl https://install.duckdb.org | bash
 {% endhighlight %}
 </div>
 
 <div data-install="cli linux" data-version="{{ site.current_duckdb_version }}">
 {% highlight bash %}
-curl https://install.duckdb.org | sh
+curl https://install.duckdb.org | bash
 {% endhighlight %}
 </div>
 

--- a/_posts/2025-03-06-gems-of-duckdb-1-2.md
+++ b/_posts/2025-03-06-gems-of-duckdb-1-2.md
@@ -23,7 +23,7 @@ In line with DuckDB's “low friction” principle, we made sure that you can in
 DuckDB can now be installed on UNIX-like systems with an installation script:
 
 ```batch
-curl https://install.duckdb.org | sh
+curl https://install.duckdb.org | bash
 ```
 
 The script determines your operating system and architecture, fetches the tag of latest release, and if not present downloads the latest available DuckDB binary to `~/.duckdb/cli` (the `~/.duckdb` folder is already used to store extensions).

--- a/_posts/2025-09-08-duckdb-on-the-framework-laptop-13.md
+++ b/_posts/2025-09-08-duckdb-on-the-framework-laptop-13.md
@@ -24,7 +24,7 @@ To run this experiment, we purchased the 13" modular laptop by [Framework](https
 We installed [Omarchy 2.0](https://omarchy.org/), an Arch Linux-based distribution with a vibrant community and first-class support for Framework laptops. Assembling the laptop and installing Omarchy took less than an hour in total. Installing the DuckDB command line client only took seconds using the installer script:
 
 ```bash
-curl https://install.duckdb.org | sh
+curl https://install.duckdb.org | bash
 ```
 
 We changed the theme to _[Osaka Jade](https://github.com/Justikun/omarchy-osaka-jade-theme)_ for a more Matrix-like look and got to work:

--- a/docs/current/operations_manual/installing_duckdb/install_script.md
+++ b/docs/current/operations_manual/installing_duckdb/install_script.md
@@ -13,7 +13,7 @@ You can install the [DuckDB CLI client]({% link docs/current/clients/cli/overvie
 To use the [DuckDB install script](https://install.duckdb.org) on Linux and macOS, run:
 
 ```bash
-curl https://install.duckdb.org | sh
+curl https://install.duckdb.org | bash
 ```
 
 <!-- markdownlint-disable MD040 MD046 -->
@@ -66,7 +66,7 @@ export PATH="~/.duckdb/cli/latest":$PATH
 You can install [past DuckDB releases]({% link release_calendar.md %}#past-releases) (all the way back to v1.0.0) using the `DUCKDB_VERSION` variable. For example, to install v1.2.2, run:
 
 ```bash
-curl https://install.duckdb.org | DUCKDB_VERSION=1.2.2 sh
+curl https://install.duckdb.org | DUCKDB_VERSION=1.2.2 bash
 ```
 
 ## Windows

--- a/install/preview.md
+++ b/install/preview.md
@@ -56,7 +56,7 @@ To download the CLI or the C/C++ libraries as a package, use the following links
 To install the preview build on Linux and macOS, run:
 
 ```bash
-curl https://install.duckdb.org | DUCKDB_VERSION=alpha sh
+curl https://install.duckdb.org | DUCKDB_VERSION=alpha bash
 ```
 
 To download the CLI or the C/C++ libraries as a package, use the following links:

--- a/quack/index.html
+++ b/quack/index.html
@@ -260,7 +260,7 @@ CALL quack_serve();
 				<p class="pre-title step-label">Step 1</p>
 				<h3>Install DuckDB</h3>
 {% highlight bash %}
-curl https://install.duckdb.org | sh
+curl https://install.duckdb.org | bash
 {% endhighlight %}
 			</div>
 			<div class="step">


### PR DESCRIPTION
Just a copy replace job...

The installer script is explicitly bash (#!/bin/bash -e on line 1), so piping to sh breaks on dash-based systems like Ubuntu. macOS is fine (sh → bash).

The script uses [[ at install.duckdb.org line 128, a bash-only construct.