### PR TITLE
docs: document setval for sequences

### DIFF
--- a/docs/current/sql/statements/create_sequence.md
+++ b/docs/current/sql/statements/create_sequence.md
@@ -146,6 +146,30 @@ SELECT currval('serial') AS currval;
 |--------:|
 | 1       |
 
+### Setting the Sequence Value
+
+Use `setval` to set a sequence to a given value (Postgres-style). The optional third argument `is_called` defaults to `true`: the next `nextval` returns `value + increment`. If `is_called` is `false`, the next `nextval` returns `value`.
+
+```sql
+CREATE SEQUENCE serial START 1;
+SELECT setval('serial', 42);
+SELECT nextval('serial');
+```
+
+| nextval |
+|--------:|
+| 43      |
+
+```sql
+CREATE SEQUENCE serial START 1;
+SELECT setval('serial', 42, false);
+SELECT nextval('serial');
+```
+
+| nextval |
+|--------:|
+| 42      |
+
 ## Syntax
 
 <div id="rrdiagram"></div>


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb-web/issues/7050

After https://github.com/duckdb/duckdb/pull/24061, `setval` sets a sequence (Postgres-style). Documented next to `nextval` / `currval`. Third argument `is_called` defaults to true, so the next `nextval` is value + increment.

I used an assistant on the edit. Maintainers can edit this branch.
