### PR TITLE
docs: COPY TO can be used as a CTE body

### DIFF
--- a/docs/current/sql/statements/copy.md
+++ b/docs/current/sql/statements/copy.md
@@ -172,6 +172,15 @@ EXECUTE v1('lineitem.json');
 
 The `COPY ... TO` function can be called specifying either a table name, or a query. When a table name is specified, the contents of the entire table will be written into the resulting file. When a query is specified, the query is executed and the result of the query is written to the resulting file.
 
+`COPY ... TO` can also be used as a CTE body. The CTE returns the number of rows written. `COPY ... FROM` cannot be used as a CTE body.
+
+```sql
+WITH copied(rows_written) AS (
+    COPY lineitem TO 'lineitem.csv' (FORMAT CSV, HEADER)
+)
+SELECT rows_written FROM copied;
+```
+
 Copy the contents of the `lineitem` table to a CSV file with a header:
 
 ```sql


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb-web/issues/7062

After https://github.com/duckdb/duckdb/pull/24217, `COPY ... TO` can be a CTE body and returns the row count. `COPY ... FROM` cannot. Added a short example on the COPY page.

I used an assistant on the edit. Maintainers can edit this branch.
