### PR TITLE
Add Graal Native Image instructions

### DIFF
--- a/_data/menu_docs_current.json
+++ b/_data/menu_docs_current.json
@@ -328,6 +328,10 @@
                   "url": "profiling"
                 },
                 {
+                  "page": "Deploy as Native Image",
+                  "url": "deploy_native_image"
+                },
+                {
                   "page": "Troubleshoot",
                   "url": "troubleshoot"
                 }

--- a/docs/current/clients/java/connecting.md
+++ b/docs/current/clients/java/connecting.md
@@ -21,6 +21,8 @@ Class.forName("org.duckdb.DuckDBDriver");
 Connection conn = DriverManager.getConnection("jdbc:duckdb:");
 ```
 
+In [GraalVM Native Image]({% link docs/current/clients/java/deploy_native_image.md %}) executables, always use this explicit load: the service-provider discovery is not reliably visible to Native Image's static analysis.
+
 To create a DuckDB connection, call `DriverManager` with the `jdbc:duckdb:` JDBC URL prefix, like so:
 
 ```java

--- a/docs/current/clients/java/deploy_native_image.md
+++ b/docs/current/clients/java/deploy_native_image.md
@@ -1,0 +1,76 @@
+---
+layout: docu
+title: Deploy as Native Image
+---
+
+## Overview
+
+The JDBC driver runs inside [GraalVM Native Image](https://www.graalvm.org/latest/reference-manual/native-image/) executables. Graal Native Image compiles a Java application ahead of time into a standalone binary that starts in milliseconds and requires no JVM on the target machine, which suits command line tools, serverless functions, and small containers.
+
+Recent driver versions ship the JNI reachability metadata that `native-image` needs, and the build picks it up automatically from the class path. 
+
+Two things remain for the application to configure: native access and the location of DuckDB's shared library.
+
+> Driver versions up to and including 1.5.5 do not ship this metadata. For those versions, generate it by running the application once on the JVM with the [tracing agent](https://www.graalvm.org/latest/reference-manual/native-image/metadata/AutomaticMetadataCollection/):
+>
+> ```bash
+> java -agentlib:native-image-agent=config-output-dir=⟨config_dir⟩ -cp ⟨classpath⟩ ⟨MainClass⟩
+> ```
+>
+> Next, pass the directory to the build with `-H:ConfigurationFileDirectories=⟨config_dir⟩`.
+
+## Requirements
+
+GraalVM for JDK 22 or later is required. Older GraalVM releases initialize the driver's classes at image build time, which bakes a build machine path into the executable and fails at run time with `UnsatisfiedLinkError`.
+
+Pass `--enable-native-access=ALL-UNNAMED` to `native-image`, or add it as a build argument in the [Native Build Tools](https://graalvm.github.io/native-build-tools/latest/index.html) Maven or Gradle plugin.
+
+Load the driver explicitly before opening the first connection:
+
+```java
+Class.forName("org.duckdb.DuckDBDriver");
+```
+
+Driver auto-registration through `ServiceLoader` is not always visible to Graal Native Image's closed world analysis, and the explicit load makes registration deterministic.
+
+## Providing the Shared Library
+
+DuckDB's engine is a native library bundled inside the driver JAR, one file per platform. Choose one of two ways to make it available to the executable.
+
+### Option 1: Embed the Library in the Executable
+
+Add a resource entry naming your platform's library, either in a configuration directory passed via `-H:ConfigurationFileDirectories` or under `META-INF/native-image` in your own project:
+
+```json
+{ "resources": { "includes": [ { "pattern": "libduckdb_java\\.so_linux_amd64" } ] } }
+```
+
+The bundled library names are `libduckdb_java.so_linux_amd64`, `libduckdb_java.so_linux_arm64`, `libduckdb_java.so_osx_universal`, and `libduckdb_java.so_windows_amd64`. 
+
+Name the one for your target platform explicitly. A wildcard matching all of them adds roughly 260 MB to the executable.
+
+This option produces a single self contained file, around 120 MB. The driver extracts the library to a temporary directory when the first connection opens, which adds up to a second of startup time and requires a writable temporary directory.
+
+### Option 2: Ship the Library Next to the Executable
+
+Build without any resource entry and place the shared library in the same directory as the executable. The file works under its bundled name, for example `libduckdb_java.so_linux_amd64`, or under the platform convention: `libduckdb_java.so` on Linux, `libduckdb_java.dylib` on macOS, `duckdb_java.dll` on Windows. The lookup is anchored to the executable rather than the working directory, so the program runs correctly from anywhere.
+
+This option produces a small executable, under 20 MB for a simple application, with no extraction cost when connections open. The library can be extracted from the driver JAR, or taken from the `-nolib` distribution together with its separate library artifact.
+
+## Building
+
+A minimal build, with the driver JAR in the current directory:
+
+```bash
+javac -cp duckdb_jdbc-⟨version⟩.jar App.java
+native-image --no-fallback --enable-native-access=ALL-UNNAMED \
+    -cp duckdb_jdbc-⟨version⟩.jar:. -o app App
+```
+
+`--no-fallback` makes the build fail outright instead of producing an image that still requires a JVM. For Maven and Gradle projects, the [Native Build Tools](https://graalvm.github.io/native-build-tools/latest/index.html) plugins wrap the same build and run it during `mvn package` or `gradle nativeCompile`.
+
+## Further Reading
+
+* [Troubleshoot]({% link docs/current/clients/java/troubleshoot.md %}) — the Native Image errors that indicate missing metadata or a missing shared library.
+* [Define Connections]({% link docs/current/clients/java/connecting.md %}) — driver registration and connection configuration.
+* [Java (JDBC) Client]({% link docs/current/clients/java/overview.md %}) — installing the driver from Maven Central.

--- a/docs/current/clients/java/overview.md
+++ b/docs/current/clients/java/overview.md
@@ -18,7 +18,9 @@ title: Java (JDBC) Client
 >
 > The latest stable version of the DuckDB Java (JDBC) client is {% if site.current_duckdb_java_short_version != "" %}{{ site.current_duckdb_java_short_version }}{% else %}{{ site.lts_duckdb_java_short_version }}{% endif %}.
 
-The DuckDB Java (JDBC) client lets Java applications query DuckDB through the standard JDBC API, extended with DuckDB-specific features for bulk loading, [Apache Arrow](https://arrow.apache.org/) interchange, user-defined functions, and profiling. This page covers installation; the other pages in this section cover connecting and each feature in detail.
+The DuckDB Java (JDBC) client lets Java applications query DuckDB through the standard JDBC API, extended with DuckDB-specific features for bulk loading, [Apache Arrow](https://arrow.apache.org/) interchange, user-defined functions, and profiling. The driver also supports ahead-of-time compilation with [GraalVM Native Image]({% link docs/current/clients/java/deploy_native_image.md %}). 
+
+This page covers installation; the other pages in this section cover connecting and each feature in detail.
 
 ## Installation
 
@@ -65,4 +67,5 @@ try (Statement stmt = conn.createStatement();
 * [Run Queries]({% link docs/current/clients/java/querying.md %}) — sending queries with `Statement` and `PreparedStatement`, and reading DuckDB's nested types.
 * [Import Data]({% link docs/current/clients/java/data_import.md %}) — bulk-loading data with the Appender and the JDBC batch writer.
 * [Handle Results]({% link docs/current/clients/java/result_handling.md %}) — Apache Arrow interchange, result streaming, and chunked results.
+* [Deploy as Native Image]({% link docs/current/clients/java/deploy_native_image.md %}) — building standalone executables with GraalVM Native Image.
 * [Clients Overview]({% link docs/current/clients/overview.md %}) — the other client APIs DuckDB provides alongside JDBC.

--- a/docs/current/clients/java/troubleshoot.md
+++ b/docs/current/clients/java/troubleshoot.md
@@ -50,29 +50,55 @@ The same option can be passed to `read_parquet` directly, for example `read_parq
 
 This behavior is tracked in [duckdb-java issue #113](https://github.com/duckdb/duckdb-java/issues/113).
 
-## GraalVM Native Image Is Not Supported
+## Native Image: `NoSuchMethodError` When Opening a Connection
 
-The driver loads its JNI native library (`libduckdb_java`) from a static initializer in `org.duckdb.DuckDBNative`, which unpacks the bundled library to a temporary file and loads it at runtime. [GraalVM Native Image](https://www.graalvm.org/latest/reference-manual/native-image/) ahead-of-time (AOT) compilation does not reproduce this runtime loading step, so an AOT-compiled application fails when it opens a connection:
+In a [GraalVM Native Image]({% link docs/current/clients/java/deploy_native_image.md %}) executable, opening the first connection may fail with:
 
 ```console
-Exception in thread "main" java.lang.UnsatisfiedLinkError: Can't load library: ⟨path⟩/libduckdb_java.so_osx_universal
-    at com.oracle.svm.core.jdk.NativeLibrarySupport.loadLibraryAbsolute(NativeLibrarySupport.java:100)
-    at java.lang.ClassLoader.loadLibrary(ClassLoader.java:57)
-    at java.lang.System.load(System.java:1957)
-    at org.duckdb.DuckDBNative.<clinit>(DuckDBNative.java)
-    at org.duckdb.DuckDBConnection.newConnection(DuckDBConnection.java)
-    at org.duckdb.DuckDBDriver.connect(DuckDBDriver.java)
+Exception in thread "main" java.lang.ExceptionInInitializerError
+    ...
+Caused by: java.lang.NoSuchMethodError: ⟨class and method⟩
+    at com.oracle.svm.core.jni.functions.JNIFunctions$Support.getMethodID(JNIFunctions.java)
     ...
 ```
 
-The driver runs normally as an ordinary JAR; only AOT compilation is affected. It ships no Native Image reachability metadata, so an AOT build has nothing to configure the native library and reflection automatically.
+The driver resolves its entire JNI surface eagerly when its native library initializes, so a single class, method, or field missing from the reachability metadata fails the whole initialization. This indicates that the metadata compiled into the image is missing or older than the driver: upgrade to a driver version that ships its own metadata, or regenerate the metadata with the tracing agent against the exact driver version in use.
 
-The `-nolib` driver artifact loads the native library by name with `System.loadLibrary`, or from the directory alongside the JAR, instead of unpacking it from the JAR. This makes it possible to supply the library externally, but on its own it does not make an AOT build work.
+The error is sometimes wrapped in a misleading message:
 
-Native Image support is tracked in [duckdb-java issue #180](https://github.com/duckdb/duckdb-java/issues/180).
+```console
+java.lang.UnsatisfiedLinkError: Unsupported JNI version 0xffffffff, required by ⟨path⟩/libduckdb_java.⟨suffix⟩
+```
+
+This is what the library's `JNI_OnLoad` reports when an internal lookup failed, and the cause is the same missing metadata, not a JNI version problem.
+
+## Native Image: `UnsatisfiedLinkError: Can't load library`
+
+In a Native Image executable, the first connection may fail with:
+
+```console
+java.lang.UnsatisfiedLinkError: Can't load library: duckdb_java | java.library.path = [.]
+    ...
+Caused by: java.io.FileNotFoundException: DuckDB JNI library not found, path: '⟨path⟩/libduckdb_java.⟨suffix⟩'
+```
+
+The shared library was neither embedded in the executable nor found next to it. Either add a resource entry for your platform's library or place the library file beside the executable. Both options are described on the [Deploy as Native Image]({% link docs/current/clients/java/deploy_native_image.md %}) page.
+
+## Warning about a Restricted Method in `java.lang.System`
+
+On JDK 24 and later, loading the driver prints:
+
+```console
+WARNING: A restricted method in java.lang.System has been called
+WARNING: java.lang.System::load has been called by org.duckdb.DuckDBNative ...
+WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
+```
+
+This is the JDK's [native access integrity check](https://openjdk.org/jeps/472) and is harmless. Silence it by running the JVM with `--enable-native-access=ALL-UNNAMED`, or the module name of the driver if you place it on the module path. Future JDK releases will turn this warning into an error, so adding the flag is recommended.
 
 ## Further Reading
 
+* [Deploy as Native Image]({% link docs/current/clients/java/deploy_native_image.md %}) — building standalone executables with GraalVM, including both ways to provide the shared library.
 * [Java (JDBC) Client]({% link docs/current/clients/java/overview.md %}) — installing the driver from Maven Central, the fix for the driver-not-found errors above.
 * [Define Connections]({% link docs/current/clients/java/connecting.md %}) — driver registration, configuration options, and instance behavior behind many connection-time errors.
 * [Parquet Files]({% link docs/current/data/parquet/overview.md %}) — the `binary_as_string` setting and other options for reading Parquet string columns correctly.


### PR DESCRIPTION
This pull request adds documentation for deploying the DuckDB Java (JDBC) client as a GraalVM Native Image, and updates the Java client documentation to reflect this new support. It introduces a dedicated guide for Native Image deployment, updates menus and cross-links, and revises troubleshooting steps for common Native Image errors.

**New Feature: Native Image Deployment Documentation**
- Added a new page, `deploy_native_image.md`, detailing how to build and configure standalone executables with GraalVM Native Image, including requirements, library provisioning options, build instructions, and further reading.
- Updated the documentation menu (`_data/menu_docs_current.json`) to include "Deploy as Native Image" under the Java client section.

**Documentation Enhancements and Cross-linking**
- Updated the Java client overview (`overview.md`) to mention Native Image support and link to the new deployment guide. [[1]](diffhunk://#diff-73234e7e807f4fbbf784335836c1ee481ae44150309f2a4638c5ca5501f23e33L21-R23) [[2]](diffhunk://#diff-73234e7e807f4fbbf784335836c1ee481ae44150309f2a4638c5ca5501f23e33R70)
- Added a note to the connection guide (`connecting.md`) clarifying the need for explicit driver loading in Native Image executables.

**Troubleshooting Updates**
- Rewrote the troubleshooting guide (`troubleshoot.md`) to address Native Image-specific errors, including missing metadata, shared library issues, and new JDK warnings, with references to the new deployment guide for solutions.