### PR TITLE
Update 2026-09-02-try-duckdb-20-alpha.md

### DIFF
--- a/_posts/2026-09-02-try-duckdb-20-alpha.md
+++ b/_posts/2026-09-02-try-duckdb-20-alpha.md
@@ -37,7 +37,7 @@ curl https://install.duckdb.org | DUCKDB_VERSION=alpha bash
 │      version      │
 │      varchar      │
 ├───────────────────┤
-│ v2.0.0-alpha39764 │
+│ v2.0.0-alpha39998 │
 └───────────────────┘
 ```
 
@@ -56,7 +56,7 @@ python3 -c "import duckdb; print(duckdb.version())"
 This prints the versions of both the Python client (currently 1.6-dev) and the underlying DuckDB library (2.0.0-alpha):
 
 ```text
-1.6.0.dev365 (with duckdb 2.0.0-alpha38615)
+1.6.0.dev379 (with duckdb 2.0.0-alpha39998)
 ```
 
 ### More Clients


### PR DESCRIPTION
Both python and CLI latest binaries are published on `alpha39998`!