### PR TITLE
docs: add HTTP CSV Import guide (network_cloud_storage)

### DIFF
--- a/_data/menu_docs_current.json
+++ b/_data/menu_docs_current.json
@@ -1536,6 +1536,10 @@
                   "url": "http_import"
                 },
                 {
+                  "page": "HTTP CSV Import",
+                  "url": "http_csv_import"
+                },
+                {
                   "page": "S3 Parquet Import",
                   "url": "s3_import"
                 },

--- a/docs/current/guides/network_cloud_storage/http_csv_import.md
+++ b/docs/current/guides/network_cloud_storage/http_csv_import.md
@@ -1,0 +1,60 @@
+---
+layout: docu
+title: HTTP CSV Import
+---
+
+To load a CSV file directly over HTTP(S), the [`httpfs` extension]({% link docs/current/core_extensions/httpfs/overview.md %}) is required. This can be installed using the `INSTALL` SQL command. This only needs to be run once.
+
+```sql
+INSTALL httpfs;
+```
+
+To load the `httpfs` extension for usage, use the `LOAD` SQL command:
+
+```sql
+LOAD httpfs;
+```
+
+After the `httpfs` extension is set up, CSV files can be read over `http(s)` the same way as a local file, using [`read_csv`]({% link docs/current/guides/file_formats/csv_import.md %}) (or `read_csv_auto` for older DuckDB versions):
+
+```sql
+SELECT * FROM read_csv('https://⟨domain⟩/path/to/file.csv');
+```
+
+Moreover, the `read_csv` function itself can also be omitted thanks to DuckDB's [replacement scan mechanism]({% link docs/current/clients/c/replacement_scans.md %}):
+
+```sql
+SELECT * FROM 'https://⟨domain⟩/path/to/file.csv';
+```
+
+## Example
+
+The following query reads an openly licensed (CC BY 4.0) real-world CSV directly from GitHub's raw file host and aggregates it, with no local download step:
+
+```sql
+SELECT
+    area,
+    round(avg(sunbed_price), 0) AS avg_sunbed_price_eur,
+    count(*) AS clubs
+FROM read_csv('https://raw.githubusercontent.com/shiftdylson1/marbella-price-data/main/beach-clubs/beach-clubs.csv')
+WHERE sunbed_price IS NOT NULL
+GROUP BY area
+ORDER BY avg_sunbed_price_eur DESC;
+```
+
+```text
+┌────────────────────────────┬──────────────────────┬───────┐
+│            area            │ avg_sunbed_price_eur │ clubs │
+│          varchar           │        double        │ int64 │
+├────────────────────────────┼──────────────────────┼───────┤
+│ Marbella centre (El Cable) │                120.0 │     1 │
+│ Puerto Banús               │                103.0 │     4 │
+│ Golden Mile                │                 70.0 │     1 │
+│ El Rosario (Marbella East) │                 30.0 │     1 │
+│ Elviria (Marbella East)    │                 30.0 │     1 │
+│ Marbella centre            │                 20.0 │     1 │
+│ Casablanca (Golden Mile)   │                 15.0 │     1 │
+└────────────────────────────┴──────────────────────┴───────┘
+```
+
+Because `read_csv` streams the file rather than materializing it first, this works the same way for CSVs far larger than fit in memory, and pairs naturally with `read_csv`'s usual options (`columns`, `types`, `delim`, etc.) for files that need explicit schema hints.

--- a/docs/current/guides/overview.md
+++ b/docs/current/guides/overview.md
@@ -39,6 +39,7 @@ To find a list of these tools, check out the [Awesome DuckDB repository](https:/
 
 * [How to authenticate to S3 / AWS]({% link docs/current/core_extensions/aws.md %}#configuration-and-authentication)
 * [How to load a Parquet file directly from HTTP(S)]({% link docs/current/guides/network_cloud_storage/http_import.md %})
+* [How to load a CSV file directly from HTTP(S)]({% link docs/current/guides/network_cloud_storage/http_csv_import.md %})
 * [How to load a Parquet file directly from S3]({% link docs/current/guides/network_cloud_storage/s3_import.md %})
 * [How to export a Parquet file to S3]({% link docs/current/guides/network_cloud_storage/s3_export.md %})
 * [How to load a Parquet file from S3 Express One]({% link docs/current/guides/network_cloud_storage/s3_express_one.md %})


### PR DESCRIPTION
The Network and Cloud Storage guides cover loading a Parquet file directly over HTTP(S) (`http_import.md`), but there is no equivalent guide for CSV, even though `read_csv` supports the same `httpfs`-backed URL access and `csv_import.md` only covers local files.

This adds `http_csv_import.md` alongside it, covering `INSTALL`/`LOAD httpfs`, `read_csv('https://...')` and the replacement-scan shorthand (`FROM 'https://...csv'`), plus a short worked example (`GROUP BY` + `avg`) against a real, openly licensed (CC BY 4.0) CSV so the snippet is copy-paste runnable rather than a placeholder. Every snippet in the guide, including the example output, was run verbatim against a live URL before submitting.

Linked from `guides/overview.md` and added to the sidebar in `_data/menu_docs_current.json`, matching the existing `http_import` entries.

Happy to swap the example dataset for something else if you'd prefer a different source.