### PR TITLE
Update vcpkg to 2026.06.24

### DIFF
--- a/community_extensions/extensions/altertable.md
+++ b/community_extensions/extensions/altertable.md
@@ -15,7 +15,7 @@ extension:
   license: MIT
   maintainers:
     - redox
-  vcpkg_commit: 84bab45d415d22042bd0b9081aea57f362da3f35
+  vcpkg_commit: cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3 # Release 2026.06.24
   requires_toolchains: "vcpkg;parser_tools"
 repo:
   github: altertable-ai/duckdb-altertable

--- a/community_extensions/extensions/duck_lineage.md
+++ b/community_extensions/extensions/duck_lineage.md
@@ -13,7 +13,7 @@ extension:
   build: cmake
   license: MIT
   excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw"
-  vcpkg_commit: "84bab45d415d22042bd0b9081aea57f362da3f35"
+  vcpkg_commit: "cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3" # Release 2026.06.24
   maintainers:
     - ilum-cloud
     - thijs-s

--- a/community_extensions/extensions/erpl_tunnel.md
+++ b/community_extensions/extensions/erpl_tunnel.md
@@ -14,11 +14,7 @@ extension:
   license: BSL 1.1
   excluded_platforms: "windows_amd64_rtools;windows_amd64_mingw;wasm_mvp;wasm_eh;wasm_threads;"
   requires_toolchains: "go"
-  # vcpkg.json pins builtin-baseline 84bab45d to hold openssl at 3.5.0: the newer
-  # 3.6.0 requires Linux kernel headers the arm64 build container does not carry.
-  # Without this the non-v1.5.5 builds would use the older default pin, which
-  # predates that baseline.
-  vcpkg_commit: 84bab45d415d22042bd0b9081aea57f362da3f35
+  vcpkg_commit: cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3 # Release 2026.06.24
   maintainers:
     - jrosskopf
 

--- a/community_extensions/extensions/hive_metastore.md
+++ b/community_extensions/extensions/hive_metastore.md
@@ -13,7 +13,7 @@ extension:
   build: cmake
   license: MIT
   excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;windows_amd64;windows_arm64"
-  vcpkg_commit: "84bab45d415d22042bd0b9081aea57f362da3f35"
+  vcpkg_commit: "cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3" # Release 2026.06.24
   requires_toolchains: "parser_tools"
   maintainers:
     - ilum-cloud

--- a/community_extensions/extensions/loki.md
+++ b/community_extensions/extensions/loki.md
@@ -15,9 +15,7 @@ extension:
   # cpp-httplib + OpenSSL do live HTTP(S) at scan time, which the WebAssembly
   # targets cannot do — exclude them rather than ship a binary that can't connect.
   excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads"
-  # Pin the vcpkg baseline the extension is tested against (currently also the
-  # community pipeline default) so openssl/cpp-httplib/yyjson resolve reproducibly.
-  vcpkg_commit: "84bab45d415d22042bd0b9081aea57f362da3f35"
+  vcpkg_commit: "cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3" # Release 2026.06.24
   maintainers:
     - prochac
 

--- a/community_extensions/extensions/panduck.md
+++ b/community_extensions/extensions/panduck.md
@@ -15,9 +15,7 @@ extension:
   requires_toolchains: vcpkg
   maintainers:
     - teaguesterling
-  # The default pin from extension-ci-tools v1.5.5, which is what panduck's own
-  # distribution pipeline builds green against on every platform including wasm.
-  vcpkg_commit: 84bab45d415d22042bd0b9081aea57f362da3f35
+  vcpkg_commit: cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3 # Release 2026.06.24
 repo:
   github: teaguesterling/duckdb_panduck
   ref: a57402beff9805d69c1590733224fc9a71b5b08b

--- a/community_extensions/extensions/pcap_duckdb.md
+++ b/community_extensions/extensions/pcap_duckdb.md
@@ -19,7 +19,7 @@ extension:
   maintainers:
     - siara-in
   requires_toolchains: "vcpkg"
-  vcpkg_commit: 84bab45d415d22042bd0b9081aea57f362da3f35
+  vcpkg_commit: cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3 # Release 2026.06.24
 repo:
   github: siara-in/pcap_duckdb
   ref: 6e96e3de4d9edf1836211a065dbaef574f2f1e3e

--- a/community_extensions/extensions/pdf.md
+++ b/community_extensions/extensions/pdf.md
@@ -32,7 +32,7 @@ extension:
   excluded_platforms: wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;windows_amd64_rtools;windows_arm64
   requires_toolchains: vcpkg
   vcpkg_url: https://github.com/microsoft/vcpkg.git
-  vcpkg_commit: 84bab45d415d22042bd0b9081aea57f362da3f35
+  vcpkg_commit: cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3 # Release 2026.06.24
 
 repo:
   github: asubbarao/duckdb-pdf

--- a/community_extensions/extensions/waddle.md
+++ b/community_extensions/extensions/waddle.md
@@ -18,7 +18,7 @@ extension:
   # (Optional) param that specifies required extra toolchains
   requires_toolchains: "rust"
   # (Optional) param that specifies a precise vcpkg commit to use
-  vcpkg_commit: "84bab45d415d22042bd0b9081aea57f362da3f35"
+  vcpkg_commit: "cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3" # Release 2026.06.24
   # (Optional) this extension requires additional custom toolchain setup
   custom_toolchain_script: true
   # (Optional) ';' separated list of additional platforms

--- a/community_extensions/extensions/zim.md
+++ b/community_extensions/extensions/zim.md
@@ -16,7 +16,7 @@ extension:
   requires_toolchains: vcpkg
   maintainers:
     - teaguesterling
-  vcpkg_commit: 84bab45d415d22042bd0b9081aea57f362da3f35
+  vcpkg_commit: cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3 # Release 2026.06.24
 repo:
   github: teaguesterling/duckdb_zim
   ref: 2aca66d7c460c8470661bed02c9f5fe3a8db21d1


### PR DESCRIPTION
This pr updates the vcpkg version to 2026.06.24.

This is part of updating all of duckdb, therefore merging should be done in coordination with stakeholders.

References:
https://github.com/duckdb/duckdb/pull/25094
https://github.com/duckdblabs/duckdb-internal/issues/10429